### PR TITLE
Try ByteArray

### DIFF
--- a/Regex/NFA/VM/Basic.lean
+++ b/Regex/NFA/VM/Basic.lean
@@ -62,7 +62,7 @@ def NodeSet.empty {n : Nat} : NodeSet n :=
   ⟨⟨mkArray n 0⟩, by simp [ByteArray.size]⟩
 
 def NodeSet.get (ns : NodeSet n) (i : Fin n) : Bool :=
-  ns.val[i.cast ns.property.symm] ≠ 0
+  !(UInt8.decEq ns.val[i.cast ns.property.symm] 0).decide
 
 instance : GetElem (NodeSet n) Nat Bool (fun _ i => i < n) where
   getElem ns i h := ns.get ⟨i, h⟩


### PR DESCRIPTION
Try `ByteArray` instead of `Array Bool` for the node set. It turned out that `Array Bool` was 10% faster in a simple benchmark.

```
$ hyperfine --warmup 10 "./array-bool 'lean|rust' /usr/share/dict/american-english"  "./bytearray 'lean|rust' /usr/share/dict/american-english"
Benchmark 1: ./array-bool 'lean|rust' /usr/share/dict/american-english
  Time (mean ± σ):     270.7 ms ±  10.4 ms    [User: 262.2 ms, System: 8.2 ms]
  Range (min … max):   261.3 ms … 296.2 ms    11 runs
 
Benchmark 2: ./bytearray 'lean|rust' /usr/share/dict/american-english
  Time (mean ± σ):     298.1 ms ±   5.3 ms    [User: 290.1 ms, System: 7.9 ms]
  Range (min … max):   291.0 ms … 306.1 ms    10 runs
 
Summary
  ./array-bool 'lean|rust' /usr/share/dict/american-english ran
    1.10 ± 0.05 times faster than ./bytearray 'lean|rust' /usr/share/dict/american-english
```