### PR TITLE
Optimize match via short-circuiting

### DIFF
--- a/RegexCorrectness/NFA/Transition/AcceptOfMatch.lean
+++ b/RegexCorrectness/NFA/Transition/AcceptOfMatch.lean
@@ -230,6 +230,12 @@ theorem lt_of_mem_stepSet {nfa : NFA} (h : j ∈ nfa.stepSet S c) :
     exact lt_of_charStep step
   exact lt_of_εClosure_right this cls
 
+theorem foldl_stepSet_empty {nfa : NFA} :
+  List.foldl nfa.stepSet ∅ cs = ∅ := by
+  induction cs with
+  | nil => simp
+  | cons c cs ih => simp [ih]
+
 theorem foldl_stepSet_subset_of_le {nfa₁ nfa₂ : NFA} (le : nfa₁ ≤ nfa₂) (h : S₁ ⊆ S₂) :
   List.foldl nfa₁.stepSet S₁ cs ⊆ List.foldl nfa₂.stepSet S₂ cs := by
   induction cs generalizing S₁ S₂ with

--- a/RunRegex.lean
+++ b/RunRegex.lean
@@ -4,13 +4,12 @@ def main (args : List String) : IO Unit := do
   let regex := args.get! 0
   let regex := Regex.Parser.parse! regex
   let nfa := NFA.compile regex
-  let inBounds : nfa.inBounds := NFA.compile.inBounds rfl
 
   let file := args.get! 1
   let lines ← IO.FS.lines file
   let count ← lines.foldlM (fun acc line => do
     let line := line.trim
-    if nfa.match inBounds line then
+    if nfa.match line then
       return acc + 1
     else
       return acc


### PR DESCRIPTION
Once we got an empty node set, it's useless to traverse the rest of string, so we return immediately.

I got a 17% speedup:

```
$ hyperfine --warmup 10 "./array-bool 'lean|rust' /usr/share/dict/american-english"  "./array-bool-shortcircuit 'lean|rust' /usr/share/dict/american-english"
Benchmark 1: ./array-bool 'lean|rust' /usr/share/dict/american-english
  Time (mean ± σ):     265.5 ms ±   7.1 ms    [User: 260.0 ms, System: 5.5 ms]
  Range (min … max):   258.5 ms … 280.0 ms    11 runs
 
Benchmark 2: ./array-bool-shortcircuit 'lean|rust' /usr/share/dict/american-english
  Time (mean ± σ):     226.3 ms ±   5.9 ms    [User: 218.5 ms, System: 7.7 ms]
  Range (min … max):   220.7 ms … 240.0 ms    13 runs
 
Summary
  ./array-bool-shortcircuit 'lean|rust' /usr/share/dict/american-english ran
    1.17 ± 0.04 times faster than ./array-bool 'lean|rust' /usr/share/dict/american-english
```