### PR TITLE
Use List Char in Regex.matches

### DIFF
--- a/RegexCorrectness/NFA/Correctness.lean
+++ b/RegexCorrectness/NFA/Correctness.lean
@@ -3,14 +3,14 @@ import RegexCorrectness.NFA.Transition
 
 namespace NFA
 
-theorem evalFrom_of_compile_matches (eq : NFA.compile r = nfa) (m : r.matches ⟨cs⟩) :
+theorem evalFrom_of_compile_matches (eq : NFA.compile r = nfa) (m : r.matches cs) :
   0 ∈ nfa.evalFrom {nfa.start.val} cs := by
   unfold compile at eq
   have ev := evalFrom_of_matches (rfl : NFA.done.pushRegex ⟨0, by decide⟩ r = _) m _ le_refl
   exact eq ▸ ev
 
 theorem matches_of_compile_evalFrom (eq : NFA.compile r = nfa) (ev : 0 ∈ nfa.evalFrom {nfa.start.val} cs) :
-  r.matches ⟨cs⟩ := by
+  r.matches cs := by
   have path := pathIn_of_evalFrom ev
   have path := pathToNext_of_compile_of_pathIn eq path
   exact matches_of_pathToNext_compile eq path

--- a/RegexCorrectness/NFA/Transition.lean
+++ b/RegexCorrectness/NFA/Transition.lean
@@ -1,4 +1,3 @@
 import RegexCorrectness.NFA.Basic
 import RegexCorrectness.NFA.Compile
-import RegexCorrectness.NFA.Transition.MatchOfAccept
 import RegexCorrectness.NFA.Transition.Equivalance

--- a/RegexCorrectness/NFA/Transition/AcceptOfMatch.lean
+++ b/RegexCorrectness/NFA/Transition/AcceptOfMatch.lean
@@ -326,20 +326,20 @@ theorem mem_evalFrom_le {nfa₁ nfa₂ : NFA} (le : nfa₁ ≤ nfa₂) (h : next
 
 -- Proof of the main result
 
-theorem evalFrom_of_matches.group {s : String} (eq : pushRegex nfa next (.group i r) = nfa')
+theorem evalFrom_of_matches.group {cs : List Char} (eq : pushRegex nfa next (.group i r) = nfa')
   (ih : ∀ {nfa next} {nfa'}, pushRegex nfa next r = nfa' → ∀ (nfa'' : NFA), nfa' ≤ nfa'' →
-    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} s.data) :
-  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} s.data := by
+    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} cs) :
+  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} cs := by
   apply pushRegex.group eq
   intro nfa' nfa'' nfa''' property _ _ eq₁ eq₂ eq₃ eq
   rw [eq]
   simp
   have := ih eq₂.symm nfa'' le_refl
-  have : nfa'.val.start.val ∈ nfa'''.val.evalFrom {nfa''.val.start.val} s.data := by
+  have : nfa'.val.start.val ∈ nfa'''.val.evalFrom {nfa''.val.start.val} cs := by
     apply mem_evalFrom_le ?_ this
     rw [eq₃]
     apply le_pushNode
-  have : nfa'.val.start.val ∈ nfa'''.val.evalFrom {nfa'''.val.start.val} s.data := by
+  have : nfa'.val.start.val ∈ nfa'''.val.evalFrom {nfa'''.val.start.val} cs := by
     apply mem_of_mem_of_subset this
     unfold evalFrom
     apply foldl_stepSet_subset_of_le le_refl
@@ -369,10 +369,10 @@ theorem evalFrom_of_matches.group {s : String} (eq : pushRegex nfa next (.group 
   apply εClosure.step ?_ .base
   simp [εStep, Node.εStep, this, isLt''']
 
-theorem evalFrom_of_matches.alternateLeft {s : String} (eq : pushRegex nfa next (.alternate r₁ r₂) = nfa')
+theorem evalFrom_of_matches.alternateLeft {cs : List Char} (eq : pushRegex nfa next (.alternate r₁ r₂) = nfa')
   (ih : ∀ {nfa next} {nfa'}, pushRegex nfa next r₁ = nfa' → ∀ (nfa'' : NFA), nfa' ≤ nfa'' →
-    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} s.data) :
-  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} s.data := by
+    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} cs) :
+  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} cs := by
   apply pushRegex.alternate eq
   intro nfa₁ start₁ nfa₂ start₂ _ nfa' property eq₁ eq₂ eq₃ _ eq₅ eq
   rw [eq]
@@ -395,10 +395,10 @@ theorem evalFrom_of_matches.alternateLeft {s : String} (eq : pushRegex nfa next 
         simp [εStep, Node.εStep, eq₂]
       apply subset_εClosure_of_mem mem
 
-theorem evalFrom_of_matches.alternateRight {s : String} (eq : pushRegex nfa next (.alternate r₁ r₂) = nfa')
+theorem evalFrom_of_matches.alternateRight {cs : List Char} (eq : pushRegex nfa next (.alternate r₁ r₂) = nfa')
   (ih : ∀ {nfa next} {nfa'}, pushRegex nfa next r₂ = nfa' → ∀ (nfa'' : NFA), nfa' ≤ nfa'' →
-    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} s.data) :
-  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} s.data := by
+    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} cs) :
+  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} cs := by
   apply pushRegex.alternate eq
   intro nfa₁ start₁ nfa₂ start₂ _ nfa' property _ _ eq₃ eq₄ eq₅ eq
   rw [eq]
@@ -419,22 +419,20 @@ theorem evalFrom_of_matches.alternateRight {s : String} (eq : pushRegex nfa next
         simp [εStep, Node.εStep, eq₄]
       exact εClosure_trans mem h
 
-theorem evalFrom_of_matches.concat {s s₁ s₂ : String} (eq : pushRegex nfa next (.concat r₁ r₂) = nfa')
-  (eqs : s = s₁ ++ s₂)
+theorem evalFrom_of_matches.concat {cs₁ cs₂ : List Char} (eq : pushRegex nfa next (.concat r₁ r₂) = nfa')
   (ih₁ : ∀ {nfa next} {nfa'}, pushRegex nfa next r₁ = nfa' → ∀ (nfa'' : NFA), nfa' ≤ nfa'' →
-    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} s₁.data)
+    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} cs₁)
   (ih₂ : ∀ {nfa next} {nfa'}, pushRegex nfa next r₂ = nfa' → ∀ (nfa'' : NFA), nfa' ≤ nfa'' →
-    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} s₂.data) :
-  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} s.data := by
+    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} cs₂) :
+  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} (cs₁ ++ cs₂) := by
   apply pushRegex.concat eq
   intro nfa₂ nfa₁ property eq₂ eq₁ eq
   rw [eq]
-  simp
   unfold evalFrom
-  simp [eqs]
+  simp
   apply mem_of_mem_of_subset (ih₂ eq₂.symm nfa₂ le_refl)
-  calc nfa₂.val.evalFrom {nfa₂.val.start.val} s₂.data
-    _ ⊆ nfa₁.val.evalFrom {nfa₂.val.start.val} s₂.data :=
+  calc nfa₂.val.evalFrom {nfa₂.val.start.val} cs₂
+    _ ⊆ nfa₁.val.evalFrom {nfa₂.val.start.val} cs₂ :=
       evalFrom_subset (eq₁ ▸ le_pushRegex) Subset.rfl
     _ ⊆ _ := by
       unfold evalFrom
@@ -443,18 +441,17 @@ theorem evalFrom_of_matches.concat {s s₁ s₂ : String} (eq : pushRegex nfa ne
       simp
       exact ih₁ eq₁.symm nfa₁ le_refl
 
-theorem evalFrom_of_matches.starConcat {s s₁ s₂ : String} (eq : pushRegex nfa next (.star r) = nfa')
-  (eqs : s = s₁ ++ s₂)
+theorem evalFrom_of_matches.starConcat {cs₁ cs₂ : List Char} (eq : pushRegex nfa next (.star r) = nfa')
   (ih₁ : ∀ {nfa next} {nfa'}, pushRegex nfa next r = nfa' → ∀ (nfa'' : NFA), nfa' ≤ nfa'' →
-    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} s₁.data)
+    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} cs₁)
   (ih₂ : ∀ {nfa next} {nfa'}, pushRegex nfa next (.star r) = nfa' → ∀ (nfa'' : NFA), nfa' ≤ nfa'' →
-    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} s₂.data) :
-  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} s.data := by
+    next.val ∈ nfa''.evalFrom {nfa'.val.start.val} cs₂) :
+  next.val ∈ nfa'.val.evalFrom {nfa'.val.start.val} (cs₁ ++ cs₂) := by
   apply pushRegex.star eq
   intro placeholder compiled patched nfa' isLt inBounds property
     eq₁ eq₂ eq₃ eq₄ eq'
   rw [eq']
-  simp [eqs, evalFrom]
+  simp [evalFrom]
   have ih₂ := ih₂ eq nfa' (by simp [eq'])
   unfold evalFrom at ih₂
   apply mem_of_mem_of_subset ih₂
@@ -494,33 +491,33 @@ theorem evalFrom_of_matches.starConcat {s s₁ s₂ : String} (eq : pushRegex nf
   simp [Node.εStep]
 
 theorem evalFrom_of_matches (eq : pushRegex nfa next r = nfa')
-  (m : r.matches s) :
-  ∀ nfa'' : NFA, nfa' ≤ nfa'' → next.val ∈ nfa''.evalFrom {nfa'.val.start.val} s.data := by
+  (m : r.matches cs) :
+  ∀ nfa'' : NFA, nfa' ≤ nfa'' → next.val ∈ nfa''.evalFrom {nfa'.val.start.val} cs := by
   induction m generalizing next nfa with
-  | @sparse str int char p_in eqs =>
+  | sparse cls c hin =>
     intro nfa'' le
     apply mem_evalFrom_le le
-    simp [eqs, evalFrom, stepSet]
+    simp [evalFrom, stepSet]
     refine ⟨nfa'.val.start.val, by simp, ?_⟩
     simp [εClosureSet]
     refine ⟨next.val, ?_, .base⟩
     rw [←eq]
     simp [charStep]
-    simp [pushRegex, Node.charStep, p_in]
-  | @char s c eqs =>
+    simp [pushRegex, Node.charStep, hin]
+  | char c =>
     intro nfa'' le
     apply mem_evalFrom_le le
-    simp [eqs, evalFrom, stepSet]
+    simp [evalFrom, stepSet]
     refine ⟨nfa'.val.start.val, by simp, ?_⟩
     simp [εClosureSet]
     refine ⟨next.val, ?_, .base⟩
     rw [←eq]
     simp [charStep]
     simp [pushRegex, Node.charStep]
-  | @epsilon s eqs =>
+  | epsilon =>
     intro nfa'' le
     apply mem_evalFrom_le le
-    simp [eqs, evalFrom, εClosureSet]
+    simp [evalFrom, εClosureSet]
     refine .step ?_ .base
     rw [←eq]
     simp [εStep, pushRegex, Node.εStep]
@@ -536,17 +533,17 @@ theorem evalFrom_of_matches (eq : pushRegex nfa next r = nfa')
     intro nfa'' le
     apply mem_evalFrom_le le
     exact evalFrom_of_matches.alternateRight eq ih
-  | concat s s₁ s₂ r₁ r₂ eqs _ _ ih₁ ih₂ =>
+  | concat cs₁ cs₂ r₁ r₂ _ _ ih₁ ih₂ =>
     intro nfa'' le
     apply mem_evalFrom_le le
-    exact evalFrom_of_matches.concat eq eqs ih₁ ih₂
-  | starEpsilon eqs =>
+    exact evalFrom_of_matches.concat eq ih₁ ih₂
+  | starEpsilon =>
     intro nfa'' le
     apply mem_evalFrom_le le
     apply pushRegex.star eq
     intro placeholder compiled patched nfa' isLt inBounds property
       _ _ eq₃ eq₄ eq
-    rw [eq, eqs]
+    rw [eq]
     simp [evalFrom, εClosureSet]
     apply εClosure.step ?_ .base
     rw [eq₄]
@@ -554,16 +551,16 @@ theorem evalFrom_of_matches (eq : pushRegex nfa next r = nfa')
     simp [eq₃]
     rw [Array.get_set_eq]
     simp [Node.εStep]
-  | starConcat s s₁ s₂ r eqs _ _ ih₁ ih₂ =>
+  | starConcat cs₁ cs₂ r _ _ ih₁ ih₂ =>
     intro nfa'' le
     apply mem_evalFrom_le le
-    exact evalFrom_of_matches.starConcat eq eqs ih₁ ih₂
+    exact evalFrom_of_matches.starConcat eq ih₁ ih₂
 
-theorem pathToNext_of_matches.group {s : String}
+theorem pathToNext_of_matches.group {cs : List Char}
   (eq : pushRegex nfa next (.group i r) = nfa')
   (ih : ∀ {nfa next nfa'}, pushRegex nfa next r = nfa' →
-    pathToNext nfa' next nfa.nodes.size nfa'.val.start s.data) :
-  pathToNext nfa' next nfa.nodes.size nfa'.val.start s.data := by
+    pathToNext nfa' next nfa.nodes.size nfa'.val.start cs) :
+  pathToNext nfa' next nfa.nodes.size nfa'.val.start cs := by
   apply pushRegex.group eq
   intro nfa' nfa'' nfa''' property _ _ eq₁ eq₂ eq₃ eq
   rw [eq]
@@ -581,14 +578,14 @@ theorem pathToNext_of_matches.group {s : String}
     intro i _ h₂
     exists Nat.lt_trans h₂ nfa''.property
     rw [pushRegex_get_lt eq₂.symm _ h₂]
-  have path₂ : pathToNext nfa'' nfa'.val.start nfa'.val.nodes.size nfa''.val.start s.data :=
+  have path₂ : pathToNext nfa'' nfa'.val.start nfa'.val.nodes.size nfa''.val.start cs :=
     ih eq₂.symm
-  have path₂ : pathToNext nfa'' nfa'.val.start nfa.nodes.size nfa''.val.start s.data :=
+  have path₂ : pathToNext nfa'' nfa'.val.start nfa.nodes.size nfa''.val.start cs :=
     path₂.castStart (Nat.le_of_lt nfa'.property)
-  have path₂₃ : pathToNext nfa'' next nfa.nodes.size nfa''.val.start (s.data ++ []) :=
+  have path₂₃ : pathToNext nfa'' next nfa.nodes.size nfa''.val.start (cs ++ []) :=
     pathToNext.trans path₂ path₃
   simp at path₂₃
-  have path₂₃ : pathToNext nfa''' next nfa.nodes.size nfa''.val.start s.data := by
+  have path₂₃ : pathToNext nfa''' next nfa.nodes.size nfa''.val.start cs := by
     apply path₂₃.cast
     intro i _ h₂
     exists Nat.lt_trans h₂ nfa'''.property
@@ -606,17 +603,17 @@ theorem pathToNext_of_matches.group {s : String}
     exact Nat.lt_trans nfa'.property nfa''.property
   exact pathToNext.trans path₁ path₂₃
 
-theorem pathToNext_of_matches.alternateLeft {s : String}
+theorem pathToNext_of_matches.alternateLeft {cs : List Char}
   (eq : pushRegex nfa next (.alternate r₁ r₂) = nfa')
   (ih : ∀ {nfa next nfa'}, pushRegex nfa next r₁ = nfa' →
-    pathToNext nfa' next nfa.nodes.size nfa'.val.start s.data) :
-  pathToNext nfa' next nfa.nodes.size nfa'.val.start s.data := by
+    pathToNext nfa' next nfa.nodes.size nfa'.val.start cs) :
+  pathToNext nfa' next nfa.nodes.size nfa'.val.start cs := by
   apply pushRegex.alternate eq
   intro nfa₁ start₁ nfa₂ start₂ _ nfa' property eq₁ eq₂ eq₃ _ eq₅ eq
   rw [eq]
   simp
-  have : pathToNext nfa₁ next nfa.nodes.size nfa₁.val.start s.data := ih eq₁.symm
-  have : pathToNext nfa' next nfa.nodes.size nfa₁.val.start s.data := by
+  have : pathToNext nfa₁ next nfa.nodes.size nfa₁.val.start cs := ih eq₁.symm
+  have : pathToNext nfa' next nfa.nodes.size nfa₁.val.start cs := by
     apply this.cast
     intro i _ h₂
     have lt₂ : i < nfa₂.val.nodes.size := Nat.lt_trans h₂ nfa₂.property
@@ -632,18 +629,18 @@ theorem pathToNext_of_matches.alternateLeft {s : String}
   . rw [eq₅]
     simp [Node.εStep, eq₂]
 
-theorem pathToNext_of_matches.alternateRight {s : String}
+theorem pathToNext_of_matches.alternateRight {cs : List Char}
   (eq : pushRegex nfa next (.alternate r₁ r₂) = nfa')
   (ih : ∀ {nfa next nfa'}, pushRegex nfa next r₂ = nfa' →
-    pathToNext nfa' next nfa.nodes.size nfa'.val.start s.data) :
-  pathToNext nfa' next nfa.nodes.size nfa'.val.start s.data := by
+    pathToNext nfa' next nfa.nodes.size nfa'.val.start cs) :
+  pathToNext nfa' next nfa.nodes.size nfa'.val.start cs := by
   apply pushRegex.alternate eq
   intro nfa₁ start₁ nfa₂ start₂ _ nfa' property _ _ eq₃ eq₄ eq₅ eq
   rw [eq]
   simp
-  have : pathToNext nfa₂ next nfa.nodes.size nfa₂.val.start s.data :=
+  have : pathToNext nfa₂ next nfa.nodes.size nfa₂.val.start cs :=
     (ih eq₃.symm).castStart (Nat.le_of_lt nfa₁.property)
-  have : pathToNext nfa' next nfa.nodes.size nfa₂.val.start s.data := by
+  have : pathToNext nfa' next nfa.nodes.size nfa₂.val.start cs := by
     apply this.cast
     intro i _ h₂
     have : i < nfa'.val.nodes.size := Nat.lt_trans h₂ nfa'.property
@@ -657,39 +654,35 @@ theorem pathToNext_of_matches.alternateRight {s : String}
   . rw [eq₅]
     simp [Node.εStep, eq₄]
 
-theorem pathToNext_of_matches.concat {s s₁ s₂ : String}
+theorem pathToNext_of_matches.concat {cs₁ cs₂ : List Char}
   (eq : pushRegex nfa next (.concat r₁ r₂) = nfa')
-  (eqs : s = s₁ ++ s₂)
   (ih₁ : ∀ {nfa next nfa'}, pushRegex nfa next r₁ = nfa' →
-    pathToNext nfa' next nfa.nodes.size nfa'.val.start s₁.data)
+    pathToNext nfa' next nfa.nodes.size nfa'.val.start cs₁)
   (ih₂ : ∀ {nfa next nfa'}, pushRegex nfa next r₂ = nfa' →
-    pathToNext nfa' next nfa.nodes.size nfa'.val.start s₂.data) :
-  pathToNext nfa' next nfa.nodes.size nfa'.val.start s.data := by
-  simp [eqs]
+    pathToNext nfa' next nfa.nodes.size nfa'.val.start cs₂) :
+  pathToNext nfa' next nfa.nodes.size nfa'.val.start (cs₁ ++ cs₂) := by
   apply pushRegex.concat eq
   intro nfa₂ nfa₁ property eq₂ eq₁ eq
   rw [eq]
   simp
-  have ih₁ : pathToNext nfa₁ nfa₂.val.start nfa.nodes.size nfa₁.val.start s₁.data :=
+  have ih₁ : pathToNext nfa₁ nfa₂.val.start nfa.nodes.size nfa₁.val.start cs₁ :=
     (ih₁ eq₁.symm).castStart (Nat.le_of_lt nfa₂.property)
-  have ih₂ : pathToNext nfa₂ next nfa.nodes.size nfa₂.val.start s₂.data := ih₂ eq₂.symm
-  have ih₂ : pathToNext nfa₁ next nfa.nodes.size nfa₂.val.start s₂.data := by
+  have ih₂ : pathToNext nfa₂ next nfa.nodes.size nfa₂.val.start cs₂ := ih₂ eq₂.symm
+  have ih₂ : pathToNext nfa₁ next nfa.nodes.size nfa₂.val.start cs₂ := by
     apply ih₂.cast
     intro i _ h₂
     exists Nat.lt_trans h₂ nfa₁.property
     rw [pushRegex_get_lt eq₁.symm _ h₂]
   exact ih₁.trans ih₂
 
-theorem pathToNext_of_matches.starConcat {s s₁ s₂ : String}
+theorem pathToNext_of_matches.starConcat {cs₁ cs₂ : List Char}
   (eq : pushRegex nfa next (.star r) = nfa')
-  (eqs : s = s₁ ++ s₂)
   (ih₁ : ∀ {nfa next nfa'}, pushRegex nfa next r = nfa' →
-    pathToNext nfa' next nfa.nodes.size nfa'.val.start s₁.data)
+    pathToNext nfa' next nfa.nodes.size nfa'.val.start cs₁)
   (ih₂ : ∀ {nfa next nfa'}, pushRegex nfa next (.star r) = nfa' →
-    pathToNext nfa' next nfa.nodes.size nfa'.val.start s₂.data) :
-  pathToNext nfa' next nfa.nodes.size nfa'.val.start s.data := by
-  have ih₂ : pathToNext nfa' next nfa.nodes.size nfa'.val.start s₂.data := ih₂ eq
-  simp [eqs]
+    pathToNext nfa' next nfa.nodes.size nfa'.val.start cs₂) :
+  pathToNext nfa' next nfa.nodes.size nfa'.val.start (cs₁ ++ cs₂) := by
+  have ih₂ : pathToNext nfa' next nfa.nodes.size nfa'.val.start cs₂ := ih₂ eq
   apply pushRegex.star eq
   intro placeholder compiled patched nfa' isLt inBounds property
     eq₁ eq₂ eq₃ eq₄ eq
@@ -699,9 +692,9 @@ theorem pathToNext_of_matches.starConcat {s s₁ s₂ : String}
   simp at ih₂
   have eqStart : nfa'.start = nfa.nodes.size := by
     rw [eq₄]
-  have ih₁ : pathToNext compiled nfa.nodes.size placeholder.val.nodes.size compiled.val.start s₁.data :=
+  have ih₁ : pathToNext compiled nfa.nodes.size placeholder.val.nodes.size compiled.val.start cs₁ :=
     ih₁ eq₂.symm
-  have ih₁ : pathToNext nfa' nfa.nodes.size placeholder.val.nodes.size compiled.val.start s₁.data := by
+  have ih₁ : pathToNext nfa' nfa.nodes.size placeholder.val.nodes.size compiled.val.start cs₁ := by
     apply ih₁.cast
     intro i h₁ h₂
     rw [eq₄]
@@ -711,9 +704,9 @@ theorem pathToNext_of_matches.starConcat {s s₁ s₂ : String}
     rw [Array.get_set_ne (hj := h₂)]
     simp
     apply Nat.ne_of_lt (Nat.lt_of_lt_of_le placeholder.property h₁)
-  have ih₁ : pathToNext nfa' nfa.nodes.size nfa.nodes.size compiled.val.start s₁.data :=
+  have ih₁ : pathToNext nfa' nfa.nodes.size nfa.nodes.size compiled.val.start cs₁ :=
     ih₁.castStart (Nat.le_of_lt placeholder.property)
-  have ih₂ : pathToNext nfa' next nfa.nodes.size nfa.nodes.size s₂.data := by
+  have ih₂ : pathToNext nfa' next nfa.nodes.size nfa.nodes.size cs₂ := by
     rw [eqStart] at ih₂
     exact ih₂
   have := ih₁.trans ih₂
@@ -724,11 +717,10 @@ theorem pathToNext_of_matches.starConcat {s s₁ s₂ : String}
   simp [Node.εStep]
 
 theorem pathToNext_of_matches (eq : pushRegex nfa next r = nfa')
-  (m : r.matches s) :
-  pathToNext nfa' next nfa.nodes.size nfa'.val.start s.data := by
+  (m : r.matches cs) :
+  pathToNext nfa' next nfa.nodes.size nfa'.val.start cs := by
   induction m generalizing nfa next with
-  | @sparse int s c mem eqs =>
-    simp [eqs]
+  | sparse cls c hmem =>
     have : nfa.nodes.size ≤ nfa'.val.start.val := ge_pushRegex_start eq
     refine ⟨
       nfa'.val.start,
@@ -739,9 +731,8 @@ theorem pathToNext_of_matches (eq : pushRegex nfa next r = nfa')
       .charStep this nfa'.val.start.isLt ?_
     ⟩
     rw [←eq]
-    simp [pushRegex, Node.charStep, mem]
-  | @char p c eqs =>
-    simp [eqs]
+    simp [pushRegex, Node.charStep, hmem]
+  | char c =>
     have : nfa.nodes.size ≤ nfa'.val.start.val := ge_pushRegex_start eq
     refine ⟨
       nfa'.val.start,
@@ -753,8 +744,7 @@ theorem pathToNext_of_matches (eq : pushRegex nfa next r = nfa')
     ⟩
     rw [←eq]
     simp [pushRegex, Node.charStep]
-  | @epsilon s eqs =>
-    simp [eqs]
+  | epsilon =>
     have : nfa.nodes.size ≤ nfa'.val.start.val := ge_pushRegex_start eq
     refine ⟨nfa'.val.start, [], [], rfl, .base this, .εStep this nfa'.val.start.isLt ?_⟩
     rw [←eq]
@@ -762,10 +752,8 @@ theorem pathToNext_of_matches (eq : pushRegex nfa next r = nfa')
   | group _ ih => exact pathToNext_of_matches.group eq ih
   | alternateLeft _ ih => exact pathToNext_of_matches.alternateLeft eq ih
   | alternateRight _ ih => exact pathToNext_of_matches.alternateRight eq ih
-  | concat s s₁ s₂ r₁ r₂ eqs _ _ ih₁ ih₂ =>
-    exact pathToNext_of_matches.concat eq eqs ih₁ ih₂
-  | starEpsilon eqs =>
-    simp [eqs]
+  | concat cs₁ cs₂ r₁ r₂ _ _ ih₁ ih₂ => exact pathToNext_of_matches.concat eq ih₁ ih₂
+  | starEpsilon =>
     have : nfa.nodes.size ≤ nfa'.val.start.val := ge_pushRegex_start eq
     refine ⟨nfa'.val.start, [], [], rfl, .base this, .εStep this nfa'.val.start.isLt ?_⟩
 
@@ -779,12 +767,11 @@ theorem pathToNext_of_matches (eq : pushRegex nfa next r = nfa')
     simp [this, eq₄, get_eq_nodes_get, eq₃]
     rw [Array.get_set_eq]
     simp [Node.εStep]
-  | starConcat p s₁ s₂ r eqs _ _ ih₁ ih₂ =>
-    exact pathToNext_of_matches.starConcat eq eqs ih₁ ih₂
+  | starConcat cs₁ cs₂ r _ _ ih₁ ih₂ => exact pathToNext_of_matches.starConcat eq ih₁ ih₂
 
 theorem pathToNext_of_compile_matches (eq : NFA.compile r = nfa)
-  (m : r.matches s) :
-  pathToNext nfa 0 1 nfa.start s.data := by
+  (m : r.matches cs) :
+  pathToNext nfa 0 1 nfa.start cs := by
   unfold NFA.compile at eq
   set result := NFA.done.pushRegex ⟨0, by decide⟩ r with h
   have := pathToNext_of_matches h.symm m

--- a/RegexCorrectness/NFA/Transition/Equivalance.lean
+++ b/RegexCorrectness/NFA/Transition/Equivalance.lean
@@ -177,8 +177,8 @@ theorem pathToNext_of_compile_of_pathIn (eq : NFA.compile r = nfa)
     exact ge_pushRegex_start (rfl : NFA.done.pushRegex _ r = _)
   exact pathToNext_of_compile_of_pathIn' eq this rfl path
 
-theorem matches_iff_pathToNext {s : String} (eq : NFA.compile r = nfa) :
-  r.matches s ↔ nfa.pathToNext 0 1 nfa.start.val s.data :=
+theorem matches_iff_pathToNext {cs : List Char} (eq : NFA.compile r = nfa) :
+  r.matches cs ↔ nfa.pathToNext 0 1 nfa.start.val cs :=
   ⟨pathToNext_of_compile_matches eq, matches_of_pathToNext_compile eq⟩
 
 end NFA

--- a/RegexCorrectness/NFA/Transition/MatchOfAccept.lean
+++ b/RegexCorrectness/NFA/Transition/MatchOfAccept.lean
@@ -132,26 +132,26 @@ theorem matches_of_starLoop (eq : pushRegex nfa next (.star r) = result)
   (mr : ∀ {cs} rStart,
     rStart ∈ (result.val[nfa.nodes.size]'result.property).εStep →
     pathToNext result (Array.size nfa.nodes) (Array.size nfa.nodes + 1) rStart cs →
-    r.matches ⟨cs⟩)
+    r.matches cs)
   (loop : starLoop eq cs) :
-  (Regex.star r).matches ⟨cs⟩ := by
+  (Regex.star r).matches cs := by
   induction loop with
-  | complete => exact .starEpsilon rfl
+  | complete => exact .starEpsilon
   | loop mem path _ m₂ =>
     let m₁ := mr _ mem path
-    exact .starConcat _ _ _ _ rfl m₁ m₂
+    exact .starConcat _ _ _ m₁ m₂
 
 theorem matches_of_path.group (eq : pushRegex nfa next (.group i r) = result)
-  (path : pathToNext result next nfa.nodes.size result.val.start.val s)
-  (ih : ∀ {nfa next result s},
+  (path : pathToNext result next nfa.nodes.size result.val.start.val cs)
+  (ih : ∀ {nfa next result cs},
     pushRegex nfa next r = result →
-    pathToNext result next nfa.nodes.size result.val.start.val s →
-    r.matches ⟨s⟩) :
-  (Regex.group i r).matches ⟨s⟩ := by
+    pathToNext result next nfa.nodes.size result.val.start.val cs →
+    r.matches cs) :
+  (Regex.group i r).matches cs := by
   apply pushRegex.group eq
   intro nfa' nfa'' nfa''' property _ _ eq₁ eq₂ eq₃ eq
 
-  suffices pathToNext nfa'' nfa'.val.start nfa'.val.nodes.size nfa''.val.start s from
+  suffices pathToNext nfa'' nfa'.val.start nfa'.val.nodes.size nfa''.val.start cs from
     .group (ih eq₂.symm this)
 
   rw [eq] at path
@@ -242,16 +242,16 @@ theorem matches_of_path.group (eq : pushRegex nfa next (.group i r) = result)
         exact (Nat.lt_irrefl _ (Nat.lt_of_le_of_lt this next.isLt)).elim
 
 theorem matches_of_path.alternate (eq : pushRegex nfa next (.alternate r₁ r₂) = result)
-  (path : pathToNext result next nfa.nodes.size result.val.start.val s)
-  (ih₁ : ∀ {nfa next result s},
+  (path : pathToNext result next nfa.nodes.size result.val.start.val cs)
+  (ih₁ : ∀ {nfa next result cs},
     pushRegex nfa next r₁ = result →
-    pathToNext result next nfa.nodes.size result.val.start.val s →
-    r₁.matches ⟨s⟩)
-  (ih₂ : ∀ {nfa next result s},
+    pathToNext result next nfa.nodes.size result.val.start.val cs →
+    r₁.matches cs)
+  (ih₂ : ∀ {nfa next result cs},
     pushRegex nfa next r₂ = result →
-    pathToNext result next nfa.nodes.size result.val.start.val s →
-    r₂.matches ⟨s⟩) :
-  (Regex.alternate r₁ r₂).matches ⟨s⟩ := by
+    pathToNext result next nfa.nodes.size result.val.start.val cs →
+    r₂.matches cs) :
+  (Regex.alternate r₁ r₂).matches cs := by
   apply pushRegex.alternate eq
   intro nfa₁ start₁ nfa₂ start₂ inBounds final property eq₁ eq₂ eq₃ eq₄ eq₅ eq'
 
@@ -297,20 +297,20 @@ theorem matches_of_path.alternate (eq : pushRegex nfa next (.alternate r₁ r₂
       cases step with
       | inl eqs₁ =>
         rw [eqs₁] at rest
-        have : pathToNext final next nfa.nodes.size nfa₁.val.start.val s :=
+        have : pathToNext final next nfa.nodes.size nfa₁.val.start.val cs :=
           ⟨i, cs₄, cs₂, eqs, eq₂ ▸ rest, step⟩
-        have : pathToNext nfa₁ next nfa.nodes.size nfa₁.val.start.val s := by
+        have : pathToNext nfa₁ next nfa.nodes.size nfa₁.val.start.val cs := by
           apply this.cast' nfa₁.val.start.isLt
             (Nat.le_of_lt (Nat.lt_trans nfa₂.property final.property))
             get₁
         exact .alternateLeft (ih₁ eq₁.symm this)
       | inr eqs₂ =>
         rw [eqs₂] at rest
-        have : pathToNext final next nfa.nodes.size nfa₂.val.start.val s :=
+        have : pathToNext final next nfa.nodes.size nfa₂.val.start.val cs :=
           ⟨i, cs₄, cs₂, eqs, eq₄ ▸ rest, step⟩
-        have : pathToNext nfa₂ next nfa.nodes.size nfa₂.val.start.val s := by
+        have : pathToNext nfa₂ next nfa.nodes.size nfa₂.val.start.val cs := by
           apply this.cast' nfa₂.val.start.isLt (Nat.le_of_lt final.property) get₂
-        have : pathToNext nfa₂ next nfa₁.val.nodes.size nfa₂.val.start.val s := by
+        have : pathToNext nfa₂ next nfa₁.val.nodes.size nfa₂.val.start.val cs := by
           apply this.castLE (ge_pushRegex_start eq₃.symm)
 
           intro i j h₁ h₂ step hj
@@ -325,16 +325,16 @@ theorem matches_of_path.alternate (eq : pushRegex nfa next (.alternate r₁ r₂
         exact .alternateRight (ih₂ eq₃.symm this)
 
 theorem matches_of_path.concat (eq : pushRegex nfa next (.concat r₁ r₂) = result)
-  (path : pathToNext result next nfa.nodes.size result.val.start.val s)
-  (ih₁ : ∀ {nfa next result s},
+  (path : pathToNext result next nfa.nodes.size result.val.start.val cs)
+  (ih₁ : ∀ {nfa next result cs},
     pushRegex nfa next r₁ = result →
-    pathToNext result next nfa.nodes.size result.val.start.val s →
-    r₁.matches ⟨s⟩)
-  (ih₂ : ∀ {nfa next result s},
+    pathToNext result next nfa.nodes.size result.val.start.val cs →
+    r₁.matches cs)
+  (ih₂ : ∀ {nfa next result cs},
     pushRegex nfa next r₂ = result →
-    pathToNext result next nfa.nodes.size result.val.start.val s →
-    r₂.matches ⟨s⟩) :
-  (Regex.concat r₁ r₂).matches ⟨s⟩ := by
+    pathToNext result next nfa.nodes.size result.val.start.val cs →
+    r₂.matches cs) :
+  (Regex.concat r₁ r₂).matches cs := by
   apply pushRegex.concat eq
   intro nfa₂ nfa₁ property eq₂ eq₁ eq'
 
@@ -373,15 +373,16 @@ theorem matches_of_path.concat (eq : pushRegex nfa next (.concat r₁ r₂) = re
     apply path₂.cast' nfa₂.val.start.isLt (Nat.le_of_lt nfa₁.property) get
   have m₂ := ih₂ eq₂.symm path₂
 
-  exact .concat _ _ _ _ _ (by simp [eqs, eqs', String.ext_iff]) m₁ m₂
+  simp [eqs, eqs']
+  exact .concat _ _ _ _ m₁ m₂
 
 theorem matches_of_path.star (eq : pushRegex nfa next (.star r) = result)
-  (path : pathToNext result next nfa.nodes.size result.val.start.val s)
-  (ih : ∀ {nfa next result s},
+  (path : pathToNext result next nfa.nodes.size result.val.start.val cs)
+  (ih : ∀ {nfa next result cs},
     pushRegex nfa next r = result →
-    pathToNext result next nfa.nodes.size result.val.start.val s →
-    Regex.matches ⟨s⟩ r) :
-  (Regex.star r).matches ⟨s⟩ := by
+    pathToNext result next nfa.nodes.size result.val.start.val cs →
+    Regex.matches cs r) :
+  (Regex.star r).matches cs := by
   apply pushRegex.star eq
   intro placeholder compiled patched nfa' isLt inBounds property
     eq₁ eq₂ eq₃ eq₄ eq'
@@ -465,10 +466,10 @@ theorem List.concat_eq_append {α} {c : α} (l₂ : List α) : [c] ++ l₂ = c :
 
 theorem matches_of_pathToNext_pushRegex
   (eq : pushRegex nfa next r = result)
-  (path : pathToNext result next nfa.nodes.size result.val.start.val s) :
-  r.matches ⟨s⟩ := by
-  induction r generalizing nfa next s with
-  | classes cs =>
+  (path : pathToNext result next nfa.nodes.size result.val.start.val cs) :
+  r.matches cs := by
+  induction r generalizing nfa next cs with
+  | classes cls =>
     apply pushRegex.sparse eq
     intro eq
     rw [eq] at path
@@ -482,7 +483,9 @@ theorem matches_of_pathToNext_pushRegex
     | stepIn.charStep (c := c) _ _ step =>
       simp [this, NFA.Node.charStep, NFA.Node.εStep] at *
       cases path with
-      | base _ => exact .sparse cs c step (by simp [eqs])
+      | base _ =>
+        simp [eqs]
+        exact .sparse cls c step
       | step step rest =>
         cases step with
         | charStep _ _ step =>
@@ -515,7 +518,7 @@ theorem matches_of_pathToNext_pushRegex
     have : i = nfa.nodes.size := Nat.eq_of_ge_of_lt (le_of_pathIn_right path) this
     cases step <;> simp [this, NFA.Node.charStep, NFA.Node.εStep] at *
     cases path with
-    | base _ => exact .epsilon (by simp [eqs])
+    | base _ => exact eqs ▸ .epsilon
     | step step rest =>
       cases step with
       | charStep _ _ step => simp [NFA.Node.charStep] at step
@@ -535,7 +538,9 @@ theorem matches_of_pathToNext_pushRegex
     have : i = nfa.nodes.size := Nat.eq_of_ge_of_lt (le_of_pathIn_right path) this
     cases step <;> simp [this, NFA.Node.charStep, NFA.Node.εStep] at *
     cases path with
-    | base _ => exact .char c (by simp [*])
+    | base _ =>
+      simp [*]
+      exact .char c
     | step step rest =>
       cases step with
       | charStep _ _ step =>
@@ -549,8 +554,8 @@ theorem matches_of_pathToNext_pushRegex
   | star r ih => exact matches_of_path.star eq path ih
 
 theorem matches_of_pathToNext_compile (eq : NFA.compile r = nfa)
-  (path : pathToNext nfa 0 1 nfa.start.val s) :
-  r.matches ⟨s⟩ := by
+  (path : pathToNext nfa 0 1 nfa.start.val cs) :
+  r.matches cs := by
   set result := NFA.done.pushRegex ⟨0, by decide⟩ r
   have : nfa = result.val := by
     rw [←eq]

--- a/RegexCorrectness/NFA/VM/Correctness.lean
+++ b/RegexCorrectness/NFA/VM/Correctness.lean
@@ -491,7 +491,7 @@ theorem evalFrom_iff_match {nfa : NFA} {s : String} :
     exact ⟨lt_of_εClosure_right nfa.start.isLt mem, mem⟩
 
 theorem match_iff_regex_matches (eq : NFA.compile r = nfa) :
-  nfa.match s ↔ r.matches s := by
+  nfa.match s ↔ r.matches s.data := by
   rw [evalFrom_iff_match]
   exact ⟨matches_of_compile_evalFrom eq, evalFrom_of_compile_matches eq⟩
 

--- a/RegexCorrectness/NFA/VM/Correctness2.lean
+++ b/RegexCorrectness/NFA/VM/Correctness2.lean
@@ -84,17 +84,17 @@ theorem reaches_iff_pathIn {nfa : NFA} {i : Fin nfa.nodes.size} {m : List Char} 
   nfa.reaches i m ↔ nfa.pathIn 0 nfa.start i m := ⟨pathIn_of_reaches, reaches_of_pathIn⟩
 
 theorem matches_of_reaches (eq : compile r = nfa)
-  (h₁ : nfa.reaches i cs.data) (h₂ : nfa[i] = .done) :
+  (h₁ : nfa.reaches i cs) (h₂ : nfa[i] = .done) :
   r.matches cs := by
   have hi : i.val = 0 := (done_iff_zero_compile eq i).mp h₂
-  have : nfa.pathIn 0 nfa.start i cs.data := pathIn_of_reaches h₁
+  have : nfa.pathIn 0 nfa.start i cs := pathIn_of_reaches h₁
   simp at this
   have := pathToNext_of_compile_of_pathIn eq (hi ▸ this)
   exact (matches_iff_pathToNext eq).mpr this
 
 theorem reaches_of_matches (eq : compile r = nfa)
   (m : r.matches cs) :
-  ∃ i, nfa.reaches i cs.data ∧ nfa[i] = .done := by
+  ∃ i, nfa.reaches i cs ∧ nfa[i] = .done := by
   have := (matches_iff_pathToNext eq).mp m
   have := pathIn_of_pathToNext this
   simp at this
@@ -104,7 +104,7 @@ theorem reaches_of_matches (eq : compile r = nfa)
   exact ⟨i', this, hdone⟩
 
 theorem matches_iff_reaches (eq : compile r = nfa) :
-  r.matches cs ↔ ∃ i, nfa.reaches i cs.data ∧ nfa[i] = .done :=
+  r.matches cs ↔ ∃ i, nfa.reaches i cs ∧ nfa[i] = .done :=
   ⟨reaches_of_matches eq, fun ⟨_, h₁, h₂⟩ => matches_of_reaches eq h₁ h₂⟩
 
 theorem matches_of_captureNext
@@ -113,7 +113,7 @@ theorem matches_of_captureNext
   (v : it.Valid)
   (hsome : matched.isSome) :
   ∃ (s : Substring) (l m r : List Char),
-    s.ValidFor l m r ∧ it.toString = ⟨l ++ m ++ r⟩ ∧ re.matches ⟨m⟩ := by
+    s.ValidFor l m r ∧ it.toString = ⟨l ++ m ++ r⟩ ∧ re.matches m := by
   have ⟨s, l, m, r, sv, eqs, i, hr, hdone⟩ := captureNext_spec h v hsome
   have ma := matches_of_reaches eq hr hdone
   exact ⟨s, l, m, r, sv, eqs, ma⟩


### PR DESCRIPTION
When I defined the `Regex.matches` predicate, I was assuming we would need to reason about the fine details of `String` like utf8-ness so I used `String` in the definition. It turned out that we have predicates like [ValidFor](https://github.com/leanprover-community/batteries/blob/60d622c124cebcecc000853cdae93f4251f4beb5/Batteries/Data/String/Lemmas.lean#L823) that allows us to extract `List Char` from `String`, so the `String` in the definition just cluttered the proof. The MR refactors `Regex.matches` to use `List Char` instead. The MR also moves some equation hypothesis to patterns as I learned how to work around the dependent elimination failures (e.g., do not apply simp too eagerly and generalize as necessary).