### PR TITLE
Add find/replace functions

### DIFF
--- a/Regex/Regex/Basic.lean
+++ b/Regex/Regex/Basic.lean
@@ -32,14 +32,86 @@ def _root_.Regex.matches (regex : Regex) (s : String) : Matches :=
 
 @[export lean_regex_regex_matches_next]
 def Matches.next? (self : Matches) : Option ((Pos × Pos) × Matches) := do
-  let pos ← VM.searchNext self.regex.nfa ⟨self.haystack, self.currentPos⟩
-  if self.currentPos < pos.2 then
-    let next := { self with currentPos := pos.2 }
-    pure (pos, next)
+  if self.currentPos < self.haystack.endPos then
+    let pos ← VM.searchNext self.regex.nfa ⟨self.haystack, self.currentPos⟩
+    if self.currentPos < pos.2 then
+      let next := { self with currentPos := pos.2 }
+      pure (pos, next)
+    else
+      let next := { self with currentPos := self.haystack.next self.currentPos }
+      pure (pos, next)
   else
-    let next := { self with currentPos := self.haystack.next self.currentPos }
-    pure (pos, next)
+    throw ()
+
+def Matches.remaining (self : Matches) : Pos :=
+  self.haystack.endPos - self.currentPos
+
+theorem Matches.lt_next?_some {m : Matches} (h : m.next? = some (pos, m')) :
+  m.currentPos < m'.currentPos := by
+  unfold next? at h
+  split at h <;> simp at h
+  have ⟨_, _, h⟩ := h
+  split at h <;> simp at h
+  next h' => simp [←h, h']
+  next =>
+    simp [←h, String.next]
+    have : String.csize (m.haystack.get m.currentPos) > 0 := String.csize_pos _
+    omega
+
+theorem Matches.next?_decreasing {m : Matches} (h : m.next? = some (pos, m')) :
+  m'.remaining < m.remaining := by
+  unfold remaining
+  have : m'.haystack = m.haystack := by
+    unfold next? at h
+    split at h <;> simp at h
+    have ⟨_, _, h⟩ := h
+    split at h <;> simp at h <;> simp [←h]
+  rw [this]
+  have h₁ : m.currentPos < m'.currentPos := lt_next?_some h
+  have h₂ : m.currentPos < m.haystack.endPos := by
+    by_contra nlt
+    simp [next?, nlt] at h
+  exact Nat.sub_lt_sub_left h₂ h₁
+
+theorem _root_.String.Pos.sizeOf_eq {p : Pos} : sizeOf p = 1 + p.byteIdx := rfl
+theorem _root_.String.Pos.sizeOf_lt_iff {p p' : Pos} :
+  sizeOf p < sizeOf p' ↔ p < p' := by
+  simp [String.Pos.sizeOf_eq]
+  omega
+
+macro_rules | `(tactic| decreasing_trivial) => `(tactic|
+  rw [String.Pos.sizeOf_lt_iff];
+  exact Matches.next?_decreasing (by assumption))
 
 instance : Stream Matches (Pos × Pos) := ⟨Matches.next?⟩
+
+def find (regex : Regex) (haystack : String) : Option (Pos × Pos) :=
+  regex.matches haystack |>.next? |>.map Prod.fst
+
+def findAll (regex : Regex) (haystack : String) : Array (Pos × Pos) :=
+  go (regex.matches haystack) #[]
+where
+  go (m : Matches) (accum : Array (Pos × Pos)) : Array (Pos × Pos) :=
+    match _h : m.next? with
+    | some (pos, m') => go m' (accum.push pos)
+    | none => accum
+  termination_by m.remaining
+
+def replace (regex : Regex) (haystack : String) (replacement : String) : String :=
+  match regex.find haystack with
+  | some (startPos, endPos) =>
+    haystack.extract 0 startPos ++ replacement ++ haystack.extract endPos haystack.endPos
+  | none => haystack
+
+def replaceAll (regex : Regex) (haystack : String) (replacement : String) : String :=
+  go (regex.matches haystack) "" 0
+where
+  go (m : Matches) (accum : String) (endPos : Pos) : String :=
+    match _h : m.next? with
+    | some ((startPos', endPos'), m') =>
+      go m' (accum ++ haystack.extract endPos startPos' ++ replacement) endPos'
+    | none =>
+      accum ++ haystack.extract endPos haystack.endPos
+  termination_by m.remaining
 
 end Regex

--- a/Regex/Regex/Basic.lean
+++ b/Regex/Regex/Basic.lean
@@ -22,22 +22,22 @@ def parse! (s : String) : Regex :=
 
 structure Matches where
   regex : Regex
-  heystack : String
+  haystack : String
   currentPos : Pos
 deriving Repr
 
 @[export lean_regex_regex_matches]
 def _root_.Regex.matches (regex : Regex) (s : String) : Matches :=
-  { regex := regex, heystack := s, currentPos := 0 }
+  { regex := regex, haystack := s, currentPos := 0 }
 
 @[export lean_regex_regex_matches_next]
 def Matches.next? (self : Matches) : Option ((Pos × Pos) × Matches) := do
-  let pos ← VM.searchNext self.regex.nfa ⟨self.heystack, self.currentPos⟩
+  let pos ← VM.searchNext self.regex.nfa ⟨self.haystack, self.currentPos⟩
   if self.currentPos < pos.2 then
     let next := { self with currentPos := pos.2 }
     pure (pos, next)
   else
-    let next := { self with currentPos := self.heystack.next self.currentPos }
+    let next := { self with currentPos := self.haystack.next self.currentPos }
     pure (pos, next)
 
 instance : Stream Matches (Pos × Pos) := ⟨Matches.next?⟩

--- a/Test.lean
+++ b/Test.lean
@@ -1,0 +1,19 @@
+import Regex
+
+def main : IO Unit := do
+  -- まだ+を実装してないです…
+  let digits := Regex.parse! "[0-9][0-9]*"
+  let haystack := "こんにちは0120-333-906🤗Lotus123"
+
+  -- prints:
+  -- (15, 19) -> 0120
+  -- (20, 23) -> 333
+  -- (24, 27) -> 906
+  -- (36, 39) -> 123
+  let results := digits.findAll haystack
+  for result in results do
+    IO.println s!"{result} -> {Substring.mk haystack result.1 result.2}"
+
+  -- prints: こんにちは[redacted]-[redacted]-[redacted]🤗Lotus[redacted]
+  let replaced := digits.replaceAll haystack "[redacted]"
+  IO.println replaced

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -10,11 +10,15 @@ lean_lib Regex where
 lean_lib RegexCorrectness where
   -- add library configuration options here
 
+-- TODO: make a proper test_driver
+lean_exe Test where
+
 require mathlib from git
   "https://github.com/leanprover-community/mathlib4" @ "v4.8.0"
 
 require Parser from git
   "https://github.com/fgdorais/lean4-parser" @ "3d98183d1446d27c831e911be1f428f2b0466eb6"
 
+-- TODO: stop using meta if
 meta if get_config? doc = some "on" then -- do not download and build doc-gen4 by default
 require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "c7f4ac84b973b6efd8f24ba2b006cad1b32c9c53"


### PR DESCRIPTION
The PR adds the following functions to `Regex`.

- `Regex.find` finds the leftmost occurrence of the matches
- `Regex.findAll` finds all non-overlapping occurrences of the matches
- `Regex.replace` replaces the leftmost occurrence with the given replacement string
- `Regex.replaceAll` replaces all non-overlapping occurrences

The PR also fixes a bug in `Regex.Matches` that causes an infinite loop when searching repeatedly.