### PR TITLE
Compile-time regex compilation

### DIFF
--- a/Regex/Regex.lean
+++ b/Regex/Regex.lean
@@ -2,3 +2,4 @@ import Regex.Regex.Basic
 import Regex.Regex.Matches
 import Regex.Regex.Captures
 import Regex.Regex.Utilities
+import Regex.Regex.Elab

--- a/Regex/Regex/Elab.lean
+++ b/Regex/Regex/Elab.lean
@@ -1,0 +1,79 @@
+import Regex.Regex.Basic
+import Lean
+
+open Regex.Data (PerlClassKind PerlClass Class Classes)
+open Regex NFA Node
+open Lean Syntax Elab Term
+
+set_option autoImplicit false
+
+namespace Regex.Elab
+
+-- A term representing a proof of `prop` given by letting kernel decide `prop`
+-- using an `Decidable` instance `inst`.
+private def mkDecidableProof (prop : Expr) (inst : Expr) : Expr :=
+  let refl := mkApp2 (mkConst ``Eq.refl [1]) (mkConst ``Bool) (mkConst ``true)
+  mkApp3 (mkConst ``of_decide_eq_true) prop inst refl
+
+instance : ToExpr PerlClassKind where
+  toTypeExpr := mkConst ``PerlClassKind
+  toExpr
+    | .digit => mkConst ``PerlClassKind.digit
+    | .space => mkConst ``PerlClassKind.space
+    | .word => mkConst ``PerlClassKind.word
+
+instance : ToExpr PerlClass where
+  toTypeExpr := mkConst ``PerlClass
+  toExpr pc := mkApp2 (mkConst ``PerlClass.mk) (toExpr pc.negated) (toExpr pc.kind)
+
+instance : ToExpr Class where
+  toTypeExpr := mkConst ``Class
+  toExpr
+    | .single c => .app (mkConst ``Class.single) (toExpr c)
+    | .range s e _ =>
+      let s := toExpr s
+      let e := toExpr e
+      -- Construct a term representing `s ≤ e` using a decidable instance.
+      let leType := mkApp4 (mkConst ``LE.le [0]) (mkConst ``Char) (mkConst ``Char.instLE) s e
+      let leInstance := mkApp2 (mkConst ``Char.instDecidableLe) s e
+      let le := mkDecidableProof leType leInstance
+
+      mkApp3 (mkConst ``Class.range) s e le
+    | .perl pc => toExpr pc
+
+instance : ToExpr Classes where
+  toTypeExpr := mkConst ``Classes
+  toExpr cs := mkApp2 (mkConst ``Classes.mk) (toExpr cs.negated) (toExpr cs.classes)
+
+instance : ToExpr Node where
+  toTypeExpr := mkConst ``Node
+  toExpr
+    | .done => mkConst ``Node.done
+    | .fail => mkConst ``Node.fail
+    | .epsilon next => .app (mkConst ``Node.epsilon) (toExpr next)
+    | .char c next => mkApp2 (mkConst ``Node.char) (toExpr c) (toExpr next)
+    | .sparse cs next => mkApp2 (mkConst ``Node.sparse) (toExpr cs) (toExpr next)
+    | .split next₁ next₂ => mkApp2 (mkConst ``Node.split) (toExpr next₁) (toExpr next₂)
+    | .save tag next => mkApp2 (mkConst ``Node.save) (toExpr tag) (toExpr next)
+
+instance : ToExpr NFA where
+  toTypeExpr := mkConst ``NFA
+  toExpr nfa := mkApp2 (mkConst ``NFA.mk) (toExpr nfa.nodes) (toExpr nfa.start)
+
+instance : ToExpr Regex where
+  toTypeExpr := mkConst ``Regex
+  toExpr re :=
+    let nfa := toExpr re.nfa
+    -- Construct a term representing `nfa.WellFormed` using a decidable instance.
+    let wfType := Expr.app (mkConst ``NFA.WellFormed) nfa
+    let wfInstance := Expr.app (mkConst ``NFA.decWellFormed) nfa
+    let wf := mkDecidableProof wfType wfInstance
+    let maxTag := toExpr re.maxTag
+    mkApp3 (mkConst ``Regex.mk) nfa wf maxTag
+
+elab "re!" lit:str : term => do
+  match Regex.parse lit.getString with
+  | Except.ok re => return toExpr re
+  | Except.error e => throwError s!"failed to parse regex: {e}"
+
+end Regex.Elab

--- a/Regex/Regex/Elab.lean
+++ b/Regex/Regex/Elab.lean
@@ -39,7 +39,7 @@ instance : ToExpr Class where
       let le := mkDecidableProof leType leInstance
 
       mkApp3 (mkConst ``Class.range) s e le
-    | .perl pc => toExpr pc
+    | .perl pc => .app (mkConst ``Class.perl) (toExpr pc)
 
 instance : ToExpr Classes where
   toTypeExpr := mkConst ``Classes

--- a/Test.lean
+++ b/Test.lean
@@ -14,7 +14,8 @@ def main : IO Unit := do
   IO.println replaced
 
   -- Search/replace all non-overlapping matches
-  let regex := Regex.parse! "もも"
+  -- The re! literal checks for regex errors at compile time and creates a compiled `Regex` object
+  let regex := re!"もも"
   let haystack := "すもももももももものうち"
 
   -- prints: #[(3, 9), (9, 15), (15, 21), (21, 27)]


### PR DESCRIPTION
This PR introduces the `re!` syntax  that elaborates the given string literal to a `Regex` expression during the compile time. The elaboration performs syntax checking and reports an error if the given regular expression is invalid.

Examples:

```
def r₁ := re!"a*b"
def r₂ := re! r"\d+"
-- or
def r₂' := re!"\\d+"

def rError := re!")" -- failed to parse regex: unexpected token at { byteIdx := 0 }
```