### PR TITLE
No dependent types in pushRegex

### DIFF
--- a/correctness/RegexCorrectness/NFA/Semantics/Equivalence/CapturesOfPath.lean
+++ b/correctness/RegexCorrectness/NFA/Semantics/Equivalence/CapturesOfPath.lean
@@ -12,11 +12,11 @@ variable {nfa : NFA} {next e result span span' update}
 
 theorem captures_of_path.group {tag} (eq : nfa.pushRegex next (.group tag e) = result)
   (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size)
-  (path : result.val.Path nfa.nodes.size result.val.start span next span' update)
+  (path : result.Path nfa.nodes.size result.start span next span' update)
   (ih : ∀ {nfa : NFA} {next result span span' update}, nfa.pushRegex next e = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    result.val.Path nfa.nodes.size result.val.start span next span' update →
+    result.Path nfa.nodes.size result.start span next span' update →
     ∃ groups, EquivUpdate groups update ∧ e.Captures span span' groups) :
   ∃ groups, EquivUpdate groups update ∧ (Expr.group tag e).Captures span span' groups := by
   open Compile.ProofData Group in
@@ -26,7 +26,7 @@ theorem captures_of_path.group {tag} (eq : nfa.pushRegex next (.group tag e) = r
   cases path with
   | last step =>
     have ⟨eqnext, _, _⟩ := step_start_iff.mp step
-    have ge := ge_pushRegex_start (result := ⟨nfaExpr, _⟩) rfl
+    have ge := ge_pushRegex_start (result := nfaExpr) rfl
     simp [←eqnext, nfaClose] at ge
     have : next < pd.nfa.nodes.size := next_lt
     omega
@@ -44,11 +44,10 @@ theorem captures_of_path.group {tag} (eq : nfa.pushRegex next (.group tag e) = r
       simp [nfaClose]
       exact Nat.ne_of_lt next_lt
     have ⟨spanm, updateExpr, updateClose, equ, pathExpr, pathClose⟩ :=
-      rest.path_next_of_ne (result := ⟨nfaExpr, _⟩) rfl next_lt_close ge_expr_start ne_next
-    simp at pathExpr pathClose
+      rest.path_next_of_ne (result := nfaExpr) rfl next_lt_close ge_expr_start ne_next
 
     have wf_close := wf_close wf next_lt
-    have ⟨groupExpr, eqv, c⟩ := ih (result := ⟨nfaExpr, _⟩) rfl wf_close wf_close.start_lt pathExpr
+    have ⟨groupExpr, eqv, c⟩ := ih (result := nfaExpr) rfl wf_close wf_close.start_lt pathExpr
 
     have : nfaExpr[nfaClose.start]'size_lt_nfa_expr = nfa'[nfaClose.start]'size_lt := by
       simp [nfaClose, get_close_expr, get_close]
@@ -65,16 +64,16 @@ theorem captures_of_path.group {tag} (eq : nfa.pushRegex next (.group tag e) = r
 
 theorem captures_of_path.alternate {e₁ e₂} (eq : nfa.pushRegex next (.alternate e₁ e₂) = result)
   (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size)
-  (path : result.val.Path nfa.nodes.size result.val.start span next span' update)
+  (path : result.Path nfa.nodes.size result.start span next span' update)
   (ih₁ : ∀ {nfa : NFA} {next result span span' update}, nfa.pushRegex next e₁ = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    result.val.Path nfa.nodes.size result.val.start span next span' update →
+    result.Path nfa.nodes.size result.start span next span' update →
     ∃ groups, EquivUpdate groups update ∧ e₁.Captures span span' groups)
   (ih₂ : ∀ {nfa : NFA} {next result span span' update}, nfa.pushRegex next e₂ = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    result.val.Path nfa.nodes.size result.val.start span next span' update →
+    result.Path nfa.nodes.size result.start span next span' update →
     ∃ groups, EquivUpdate groups update ∧ e₂.Captures span span' groups) :
   ∃ groups, EquivUpdate groups update ∧ (Expr.alternate e₁ e₂).Captures span span' groups := by
   open Compile.ProofData Alternate in
@@ -115,16 +114,16 @@ theorem captures_of_path.alternate {e₁ e₂} (eq : nfa.pushRegex next (.altern
 
 theorem captures_of_path.concat {e₁ e₂} (eq : nfa.pushRegex next (.concat e₁ e₂) = result)
   (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size)
-  (path : result.val.Path nfa.nodes.size result.val.start span next span' update)
+  (path : result.Path nfa.nodes.size result.start span next span' update)
   (ih₁ : ∀ {nfa : NFA} {next result span span' update}, nfa.pushRegex next e₁ = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    result.val.Path nfa.nodes.size result.val.start span next span' update →
+    result.Path nfa.nodes.size result.start span next span' update →
     ∃ groups, EquivUpdate groups update ∧ e₁.Captures span span' groups)
   (ih₂ : ∀ {nfa : NFA} {next result span span' update}, nfa.pushRegex next e₂ = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    result.val.Path nfa.nodes.size result.val.start span next span' update →
+    result.Path nfa.nodes.size result.start span next span' update →
     ∃ groups, EquivUpdate groups update ∧ e₂.Captures span span' groups) :
   ∃ groups, EquivUpdate groups update ∧ (Expr.concat e₁ e₂).Captures span span' groups := by
   open Compile.ProofData Concat in
@@ -155,11 +154,11 @@ theorem captures_of_path.star_of_loop [Star] (loop : Loop span span' update)
 
 theorem captures_of_path.star {e} (eq : nfa.pushRegex next (.star e) = result)
   (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size)
-  (path : result.val.Path nfa.nodes.size result.val.start span next span' update)
+  (path : result.Path nfa.nodes.size result.start span next span' update)
   (ih : ∀ {nfa : NFA} {next result span span' update}, nfa.pushRegex next e = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    result.val.Path nfa.nodes.size result.val.start span next span' update →
+    result.Path nfa.nodes.size result.start span next span' update →
     ∃ groups, EquivUpdate groups update ∧ e.Captures span span' groups) :
   ∃ groups, EquivUpdate groups update ∧ (Expr.star e).Captures span span' groups := by
   open Compile.ProofData Star in
@@ -175,10 +174,10 @@ theorem captures_of_path.star {e} (eq : nfa.pushRegex next (.star e) = result)
 
 theorem captures_of_path (eq : nfa.pushRegex next e = result)
   (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size)
-  (path : result.val.Path nfa.nodes.size result.val.start span next span' update) :
+  (path : result.Path nfa.nodes.size result.start span next span' update) :
   ∃ groups, EquivUpdate groups update ∧ e.Captures span span' groups := by
   open Compile.ProofData in
-  induction e generalizing nfa next span span' update with
+  induction e generalizing nfa next result span span' update with
   | empty =>
     let pd := Empty.intro eq
     simp [pd.eq_result eq] at path

--- a/correctness/RegexCorrectness/NFA/Semantics/Equivalence/PathOfCaptures.lean
+++ b/correctness/RegexCorrectness/NFA/Semantics/Equivalence/PathOfCaptures.lean
@@ -15,14 +15,14 @@ theorem path_of_captures.group {tag} (eq : nfa.pushRegex next (.group tag e) = r
   (ih : ∀ {nfa : NFA} {next result}, nfa.pushRegex next e = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    ∃ update, EquivUpdate groups update ∧ result.val.Path nfa.nodes.size result.val.start span next span' update) :
-  ∃ update, EquivUpdate (.group tag span.curr span'.curr groups) update ∧ result.val.Path nfa.nodes.size result.val.start span next span' update := by
+    ∃ update, EquivUpdate groups update ∧ result.Path nfa.nodes.size result.start span next span' update) :
+  ∃ update, EquivUpdate (.group tag span.curr span'.curr groups) update ∧ result.Path nfa.nodes.size result.start span next span' update := by
   open Compile.ProofData Group in
   let pd := Group.intro eq
   simp [eq_result eq]
 
   have wf_close := wf_close wf next_lt
-  have ⟨update, eqv, path⟩ := ih (result := ⟨nfaExpr, _⟩) rfl wf_close wf_close.start_lt
+  have ⟨update, eqv, path⟩ := ih (result := nfaExpr) rfl wf_close wf_close.start_lt
   exists (2 * tag, span.curr) :: update ++ [(2 * tag + 1, span'.curr)], .group eqv
 
   have stepOpen : nfa'.Step nfa.nodes.size nfa'.start span nfaExpr.start span (.some (2 * tag, span.curr)) := by
@@ -43,13 +43,13 @@ theorem path_of_captures.alternateLeft {e₁ e₂} (eq : nfa.pushRegex next (.al
   (ih : ∀ {nfa : NFA} {next result}, nfa.pushRegex next e₁ = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    ∃ update, EquivUpdate groups update ∧ result.val.Path nfa.nodes.size result.val.start span next span' update) :
-  ∃ update, EquivUpdate groups update ∧ result.val.Path nfa.nodes.size result.val.start span next span' update := by
+    ∃ update, EquivUpdate groups update ∧ result.Path nfa.nodes.size result.start span next span' update) :
+  ∃ update, EquivUpdate groups update ∧ result.Path nfa.nodes.size result.start span next span' update := by
   open Compile.ProofData Alternate in
   let pd := Alternate.intro eq
   simp [eq_result eq]
 
-  have ⟨update, eqv, path⟩ := ih (result := ⟨nfa₁, _⟩) rfl wf next_lt
+  have ⟨update, eqv, path⟩ := ih (result := nfa₁) rfl wf next_lt
   exists update, eqv
 
   have step : nfa'.Step nfa.nodes.size nfa'.start span nfa₁.start span .none := by
@@ -63,14 +63,14 @@ theorem path_of_captures.alternateRight {e₁ e₂} (eq : nfa.pushRegex next (.a
   (ih : ∀ {nfa : NFA} {next result}, nfa.pushRegex next e₂ = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    ∃ update, EquivUpdate groups update ∧ result.val.Path nfa.nodes.size result.val.start span next span' update) :
-  ∃ update, EquivUpdate groups update ∧ result.val.Path nfa.nodes.size result.val.start span next span' update := by
+    ∃ update, EquivUpdate groups update ∧ result.Path nfa.nodes.size result.start span next span' update) :
+  ∃ update, EquivUpdate groups update ∧ result.Path nfa.nodes.size result.start span next span' update := by
   open Compile.ProofData Alternate in
   let pd := Alternate.intro eq
   simp [eq_result eq]
 
   have wf₁ := wf₁ wf next_lt
-  have ⟨update, eqv, path⟩ := ih (result := ⟨nfa₂, _⟩) rfl wf₁ (Nat.lt_trans next_lt nfa₁_property)
+  have ⟨update, eqv, path⟩ := ih (result := nfa₂) rfl wf₁ (Nat.lt_trans next_lt nfa₁_property)
   exists update, eqv
 
   have step : nfa'.Step nfa.nodes.size nfa'.start span nfa₂.start span .none := by
@@ -84,20 +84,19 @@ theorem path_of_captures.concat {e₁ e₂ span span' span'' groups₁ groups₂
   (ih₁ : ∀ {nfa : NFA} {next result}, nfa.pushRegex next e₁ = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    ∃ update, EquivUpdate groups₁ update ∧ result.val.Path nfa.nodes.size result.val.start span next span' update)
+    ∃ update, EquivUpdate groups₁ update ∧ result.Path nfa.nodes.size result.start span next span' update)
   (ih₂ : ∀ {nfa : NFA} {next result}, nfa.pushRegex next e₂ = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    ∃ update, EquivUpdate groups₂ update ∧ result.val.Path nfa.nodes.size result.val.start span' next span'' update) :
-  ∃ update, EquivUpdate (.concat groups₁ groups₂) update ∧ result.val.Path nfa.nodes.size result.val.start span next span'' update := by
+    ∃ update, EquivUpdate groups₂ update ∧ result.Path nfa.nodes.size result.start span' next span'' update) :
+  ∃ update, EquivUpdate (.concat groups₁ groups₂) update ∧ result.Path nfa.nodes.size result.start span next span'' update := by
   open Compile.ProofData Concat in
   let pd := Concat.intro eq
   simp [pd.eq_result eq]
 
   have wf₂ := wf₂ wf next_lt
-  have ⟨update₁, eqv₁, path₁⟩ := ih₁ (result := ⟨nfa', size₂_lt⟩) (Subtype.eq eq_push.symm) wf₂ wf₂.start_lt
-  have ⟨update₂, eqv₂, path₂⟩ := ih₂ (result := ⟨nfa₂, _⟩) rfl wf next_lt
-  simp at path₁ path₂
+  have ⟨update₁, eqv₁, path₁⟩ := ih₁ eq_push.symm wf₂ wf₂.start_lt
+  have ⟨update₂, eqv₂, path₂⟩ := ih₂ (result := nfa₂) rfl wf next_lt
   exists update₁ ++ update₂, .concat eqv₁ eqv₂
 
   have path₂ := castFrom₂ path₂
@@ -108,20 +107,19 @@ theorem path_of_captures.starConcat {e span span' span'' groups₁ groups₂} (e
   (ih₁ : ∀ {nfa : NFA} {next result}, nfa.pushRegex next e = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    ∃ update, EquivUpdate groups₁ update ∧ result.val.Path nfa.nodes.size result.val.start span next span' update)
+    ∃ update, EquivUpdate groups₁ update ∧ result.Path nfa.nodes.size result.start span next span' update)
   (ih₂ : ∀ {nfa : NFA} {next result}, nfa.pushRegex next (.star e) = result →
     nfa.WellFormed →
     next < nfa.nodes.size →
-    ∃ update, EquivUpdate groups₂ update ∧ result.val.Path nfa.nodes.size result.val.start span' next span'' update) :
-  ∃ update, EquivUpdate (.concat groups₁ groups₂) update ∧ result.val.Path nfa.nodes.size result.val.start span next span'' update := by
+    ∃ update, EquivUpdate groups₂ update ∧ result.Path nfa.nodes.size result.start span' next span'' update) :
+  ∃ update, EquivUpdate (.concat groups₁ groups₂) update ∧ result.Path nfa.nodes.size result.start span next span'' update := by
   open Compile.ProofData Star in
   let pd := Star.intro eq
   simp [pd.eq_result eq]
 
   have wf_placeholder := wf_placeholder wf
-  have ⟨update₁, eqv₁, path₁⟩ := ih₁ (result := ⟨nfaExpr, _⟩) rfl wf_placeholder wf_placeholder.start_lt
-  have ⟨update₂, eqv₂, path₂⟩ := ih₂ (result := ⟨nfa', _⟩) rfl wf next_lt
-  simp at path₁ path₂
+  have ⟨update₁, eqv₁, path₁⟩ := ih₁ (result := nfaExpr) rfl wf_placeholder wf_placeholder.start_lt
+  have ⟨update₂, eqv₂, path₂⟩ := ih₂ (result := nfa') rfl wf next_lt
   exists update₁ ++ update₂, .concat eqv₁ eqv₂
 
   have start_eq_placeholder : nfaPlaceholder.start = nfa'.start := by
@@ -136,9 +134,9 @@ theorem path_of_captures.starConcat {e span span' span'' groups₁ groups₂} (e
 theorem path_of_captures (eq : nfa.pushRegex next e = result)
   (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size)
   (c : e.Captures span span' groups) :
-  ∃ update, EquivUpdate groups update ∧ result.val.Path nfa.nodes.size result.val.start span next span' update := by
+  ∃ update, EquivUpdate groups update ∧ result.Path nfa.nodes.size result.start span next span' update := by
   open Compile.ProofData in
-  induction c generalizing nfa next with
+  induction c generalizing nfa next result with
   | @char l m r c =>
     let pd := Char.intro eq
     exists [], .empty

--- a/correctness/RegexCorrectness/NFA/Semantics/ProofData/Compile.lean
+++ b/correctness/RegexCorrectness/NFA/Semantics/ProofData/Compile.lean
@@ -6,7 +6,7 @@ namespace Regex.NFA
 
 open Compile.ProofData in
 theorem Step.eq_or_ge_of_pushRegex {nfa : NFA} {next e i span j span' update}
-  (step : (nfa.pushRegex next e).val.Step nfa.nodes.size i span j span' update) :
+  (step : (nfa.pushRegex next e).Step nfa.nodes.size i span j span' update) :
   j = next ∨ nfa.nodes.size ≤ j := by
   induction e generalizing nfa next with
   | empty =>
@@ -83,7 +83,7 @@ theorem Step.eq_or_ge_of_pushRegex {nfa : NFA} {next e i span j span' update}
       cases step.2.1 with
       | inl eq₁ => exact .inr (eq₁ ▸ (ge_pushRegex_start rfl))
       | inr eq₂ =>
-        have := ge_pushRegex_start (result := ⟨Alternate.nfa₂, _⟩) rfl
+        have := ge_pushRegex_start (result := pd.nfa₂) rfl
         exact .inr (Nat.le_trans (Nat.le_of_lt pd.nfa₁_property) (eq₂ ▸ this))
   | concat e₁ e₂ ih₁ ih₂ =>
     let pd := Concat.intro' nfa next e₁ e₂
@@ -123,12 +123,12 @@ theorem Step.eq_or_ge_of_pushRegex {nfa : NFA} {next e i span j span' update}
 
 theorem Path.eq_or_path_next {nfa : NFA} {next e result lb i span j span' update} (eq : nfa.pushRegex next e = result)
   (jlt : j < nfa.nodes.size) (ige : i ≥ nfa.nodes.size)
-  (path : result.val.Path lb i span j span' update) :
+  (path : result.Path lb i span j span' update) :
   j = next ∨
   ∃ spanm update₁ update₂,
     update = update₁ ++ update₂ ∧
-    result.val.Path nfa.nodes.size i span next spanm update₁ ∧
-    result.val.Path lb next spanm j span' update₂ := by
+    result.Path nfa.nodes.size i span next spanm update₁ ∧
+    result.Path lb next spanm j span' update₂ := by
   induction path with
   | @last i span j span' update step =>
     have step := eq ▸ step.liftBound' ige
@@ -148,11 +148,11 @@ theorem Path.eq_or_path_next {nfa : NFA} {next e result lb i span j span' update
 
 theorem Path.path_next_of_ne {nfa : NFA} {next e result lb i span j span' update} (eq : nfa.pushRegex next e = result)
   (jlt : j < nfa.nodes.size) (ige : i ≥ nfa.nodes.size) (ne : j ≠ next)
-  (path : result.val.Path lb i span j span' update) :
+  (path : result.Path lb i span j span' update) :
   ∃ spanm update₁ update₂,
     update = update₁ ++ update₂ ∧
-    result.val.Path nfa.nodes.size i span next spanm update₁ ∧
-    result.val.Path lb next spanm j span' update₂ := by
+    result.Path nfa.nodes.size i span next spanm update₁ ∧
+    result.Path lb next spanm j span' update₂ := by
   have := path.eq_or_path_next eq jlt ige
   cases this with
   | inl eq => contradiction

--- a/regex/Regex/NFA/Compile.lean
+++ b/regex/Regex/NFA/Compile.lean
@@ -1,3 +1,3 @@
 import Regex.NFA.Compile.Basic
-import Regex.NFA.Compile.ProofData
 import Regex.NFA.Compile.Lemmas
+import Regex.NFA.Compile.ProofData

--- a/regex/Regex/NFA/Compile/Basic.lean
+++ b/regex/Regex/NFA/Compile/Basic.lean
@@ -5,45 +5,42 @@ open Regex.Data (Expr)
 
 namespace Regex.NFA
 
-def pushNode (nfa : NFA) (node : Node) :
-  { nfa' : NFA // nfa.nodes.size < nfa'.nodes.size } :=
+def pushNode (nfa : NFA) (node : Node) : NFA :=
   let start := nfa.nodes.size
   let nodes := nfa.nodes.push node
-  let nfa' : NFA := ⟨nodes, start⟩
-
-  ⟨nfa', by simp [nodes, nfa']⟩
+  ⟨nodes, start⟩
 
 @[simp]
 theorem pushNode_size {nfa : NFA} {node : Node} :
-  (nfa.pushNode node).val.nodes.size = nfa.nodes.size + 1 := by
+  (nfa.pushNode node).nodes.size = nfa.nodes.size + 1 := by
   simp [pushNode]
 
 theorem pushNode_get_lt {nfa : NFA} {node : Node}
   (i : Nat) (h : i < nfa.nodes.size) :
-  (nfa.pushNode node).val[i]'(Nat.lt_trans h (nfa.pushNode node).property) = nfa[i] := by
+  (nfa.pushNode node)[i]'(Nat.lt_trans h (by simp only [pushNode_size, Nat.lt_add_one])) = nfa[i] := by
   simp [pushNode, get_eq_nodes_get]
   rw [Array.getElem_push_lt]
 
 @[simp]
 theorem pushNode_get_eq {nfa : NFA} {node : Node} :
-  (nfa.pushNode node).val[nfa.nodes.size] = node := by
+  (nfa.pushNode node)[nfa.nodes.size] = node := by
   simp [pushNode, get_eq_nodes_get]
 
 theorem pushNode_get {nfa : NFA} {node : Node}
-  (i : Nat) (h : i < (nfa.pushNode node).val.nodes.size) :
-  (nfa.pushNode node).val[i]'h = if h' : i < nfa.nodes.size then nfa[i]'h' else node := by
+  (i : Nat) (h : i < (nfa.pushNode node).nodes.size) :
+  (nfa.pushNode node)[i]'h = if h' : i < nfa.nodes.size then nfa[i]'h' else node := by
   simp at h
   cases Nat.lt_or_eq_of_le (Nat.le_of_succ_le_succ h) with
   | inl lt => simp [lt, pushNode_get_lt _ lt]
   | inr eq => simp [eq]
 
 @[simp]
-theorem pushNode_start_eq {nfa : NFA} {node : Node} : (nfa.pushNode node).val.start = nfa.nodes.size := rfl
+theorem pushNode_start_eq {nfa : NFA} {node : Node} : (nfa.pushNode node).start = nfa.nodes.size := rfl
 
 /--
   Compile a Regex and append the resulting nodes to the NFA. The nodes will transition to `next` on match.
 -/
-def pushRegex (nfa : NFA) (next : Nat) : Expr → { nfa' : NFA // nfa.nodes.size < nfa'.nodes.size }
+def pushRegex (nfa : NFA) (next : Nat) : Expr → NFA
   | .empty => nfa.pushNode .fail
   | .epsilon => nfa.pushNode (.epsilon next)
   | .char c => nfa.pushNode (.char c next)
@@ -51,63 +48,37 @@ def pushRegex (nfa : NFA) (next : Nat) : Expr → { nfa' : NFA // nfa.nodes.size
   | .group index r =>
     -- push the closing save node first
     let nfa' := nfa.pushNode (.save (2 * index + 1) next)
-    let nfa'' := nfa'.val.pushRegex nfa'.val.start r
-    let nfa''' := nfa''.val.pushNode (.save (2 * index) nfa''.val.start)
-
-    have property : nfa.nodes.size < nfa'''.val.nodes.size :=
-      calc
-        _ < _ := nfa'.property
-        _ < _ := nfa''.property
-        _ < _ := nfa'''.property
-
-    ⟨nfa''', property⟩
+    let nfa'' := nfa'.pushRegex nfa'.start r
+    nfa''.pushNode (.save (2 * index) nfa''.start)
   | .alternate r₁ r₂ =>
     -- TODO: it feels better to compile r₂ first to align with concat
     let nfa₁ := nfa.pushRegex next r₁
-    let start₁ := nfa₁.val.start
-    let nfa₂ := nfa₁.val.pushRegex next r₂
-    let start₂ := nfa₂.val.start
+    let start₁ := nfa₁.start
+    let nfa₂ := nfa₁.pushRegex next r₂
+    let start₂ := nfa₂.start
 
     let split := Node.split start₁ start₂
 
-    let nfa' := nfa₂.val.pushNode split
-    have property : nfa.nodes.size < nfa'.val.nodes.size :=
-      calc
-        _ < _ := nfa₁.property
-        _ < _ := nfa₂.property
-        _ < _ := nfa'.property
-
-    ⟨nfa', property⟩
+    nfa₂.pushNode split
   | .concat r₁ r₂ =>
     let nfa₂ := nfa.pushRegex next r₂
-    let nfa₁ := nfa₂.val.pushRegex nfa₂.val.start r₁
-
-    ⟨nfa₁, Nat.lt_trans nfa₂.property nfa₁.property⟩
+    nfa₂.pushRegex nfa₂.start r₁
   | .star r =>
+    let start := nfa.nodes.size
     -- We need to generate a placeholder node first. We use `fail` for it because
     -- 1. We want to make sure `done` does not appear except at the first node.
     -- 2. variants without data are represented as a boxed integer so there is one less allocation.
     let placeholder := nfa.pushNode .fail
-    -- FIXME: generated code used to keep `placeholder` alive, copying the array. Investigate again
-    let compiled := placeholder.val.pushRegex nfa.nodes.size r
+    let compiled := placeholder.pushRegex start r
 
-    -- Patch the placeholder node
-    have isLt : nfa.nodes.size < compiled.val.nodes.size :=
-      calc
-        _ < _ := placeholder.property
-        _ < _ := compiled.property
+    let split := Node.split compiled.start next
+    -- While we know that `pushRegex` increase the size and hence this `setIfInBounds` is always
+    -- in bounds, we don't use that information to eliminate the bounds check. This is because
+    -- it requires changing the return type to `{ nfa' : NFA // nfa.nodes.size < nfa'.nodes.size }`
+    -- which is much more inconvenient to work with.
+    let patched := compiled.nodes.setIfInBounds start split
 
-    let split := Node.split compiled.val.start next
-    let patched := compiled.val.nodes.set nfa.nodes.size split
-
-    let nfa' := ⟨patched, nfa.nodes.size⟩
-    have property :=
-      calc
-        _ < _ := placeholder.property
-        _ < _ := compiled.property
-        _ = nfa'.nodes.size := by simp [patched, nfa']
-
-    ⟨nfa', property⟩
+    ⟨patched, start⟩
 
 def compile (r : Expr) : NFA := done.pushRegex 0 r
 

--- a/regex/Regex/NFA/Compile/Lemmas.lean
+++ b/regex/Regex/NFA/Compile/Lemmas.lean
@@ -1,191 +1,35 @@
 import Regex.NFA.Compile.Basic
-import Regex.NFA.Compile.ProofData
-
-open Regex.Data (Expr)
-
-set_option autoImplicit false
 
 namespace Regex.NFA
 
-theorem pushNode_wf {nfa : NFA} {node}
-  (wf : nfa.WellFormed) (inBounds : node.inBounds (nfa.nodes.size + 1)) :
-  (nfa.pushNode node).val.WellFormed := by
-  simp [pushNode, WellFormed.iff, NFA.get_eq_nodes_get]
-  intro i
-  cases Nat.lt_or_ge i.val nfa.nodes.size with
-  | inl lt =>
-    have : (nfa.nodes.push node)[i.val] = nfa.nodes[i.val] := nfa.nodes.getElem_push_lt _ _ lt
-    simp [this]
-    apply Node.inBounds_of_inBounds_of_le (wf.inBounds ⟨i.val, lt⟩) (by omega)
-  | inr ge =>
-    have isLt := i.isLt
-    simp at isLt
-    have : i.val = nfa.nodes.size := by omega
-    simp [this, inBounds]
-
-open Compile.ProofData in
-theorem pushRegex_wf {nfa : NFA} {next e result} (eq : nfa.pushRegex next e = result)
-  (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) :
-  result.val.WellFormed := by
+theorem pushRegex_size_lt {nfa : NFA} {next e} :
+  nfa.nodes.size < (nfa.pushRegex next e).nodes.size := by
   induction e generalizing nfa next with
-  | empty =>
-    let pd := Empty.intro eq
-    simp [pd.eq_result eq]
-    apply pushNode_wf wf
-    simp
-  | epsilon =>
-    let pd := Epsilon.intro eq
-    simp [pd.eq_result eq]
-    apply pushNode_wf wf
-    simp [Node.inBounds]
-    exact Nat.lt_trans next_lt (by omega)
-  | char c =>
-    let pd := Char.intro eq
-    simp [pd.eq_result eq]
-    apply pushNode_wf wf
-    simp [Node.inBounds]
-    exact Nat.lt_trans next_lt (by omega)
-  | classes cs =>
-    let pd := Classes.intro eq
-    simp [pd.eq_result eq]
-    apply pushNode_wf wf
-    simp [Node.inBounds]
-    exact Nat.lt_trans next_lt (by omega)
+  | empty => simp [pushRegex]
+  | epsilon => simp [pushRegex]
+  | char => simp [pushRegex]
+  | classes => simp [pushRegex]
   | group tag e ih =>
-    let pd := Group.intro eq
-    simp [pd.eq_result eq]
-
-    have wf_close : Group.nfaClose.WellFormed := by
-      apply pushNode_wf wf
-      simp [Node.inBounds]
-      exact Nat.lt_trans next_lt (by omega)
-
-    have wf_expr : Group.nfaExpr.WellFormed := ih rfl wf_close wf_close.start_lt
-
-    apply pushNode_wf wf_expr
-    simp [Node.inBounds]
-    exact Nat.lt_trans wf_expr.start_lt (by omega)
+    simp [pushRegex]
+    calc nfa.nodes.size
+      _ < (nfa.pushNode (.save (2 * tag + 1) next)).nodes.size := by simp
+      _ < ((nfa.pushNode (.save (2 * tag + 1) next)).pushRegex nfa.nodes.size e).nodes.size := ih
+      _ < _ := by omega
   | alternate e₁ e₂ ih₁ ih₂ =>
-    let pd := Alternate.intro eq
-    simp [pd.eq_result eq]
-
-    have wf₁ : Alternate.nfa₁.WellFormed := ih₁ rfl wf next_lt
-    have wf₂ : Alternate.nfa₂.WellFormed := ih₂ rfl wf₁ (Nat.lt_trans next_lt pd.nfa₁_property)
-
-    apply pushNode_wf wf₂
-    simp [Node.inBounds]
-    exact ⟨
-      Nat.lt_trans wf₁.start_lt (Nat.lt_trans pd.nfa₂_property (by omega)),
-      Nat.lt_trans wf₂.start_lt (by omega)
-    ⟩
+    simp [pushRegex]
+    calc nfa.nodes.size
+      _ < (nfa.pushRegex next e₁).nodes.size := ih₁
+      _ < ((nfa.pushRegex next e₁).pushRegex next e₂).nodes.size := ih₂
+      _ < _ := by omega
   | concat e₁ e₂ ih₁ ih₂ =>
-    let pd := Concat.intro eq
-    simp [pd.eq_result eq]
-
-    have wf₂ : Concat.nfa₂.WellFormed := ih₂ rfl wf next_lt
-    apply ih₁ rfl wf₂ wf₂.start_lt
+    simp [pushRegex]
+    calc nfa.nodes.size
+      _ < (nfa.pushRegex next e₂).nodes.size := ih₂
+      _ < _ := ih₁
   | star e ih =>
-    let pd := Star.intro eq
-    simp [pd.eq_result eq]
-
-    have wf_placeholder : Star.nfaPlaceholder.WellFormed := by
-      apply pushNode_wf wf
-      simp
-    have wf_expr : Star.nfaExpr.WellFormed :=
-      ih rfl wf_placeholder pd.nfaPlaceholder_property
-
-    simp [WellFormed.iff]
-    refine ⟨pd.size_lt, ?_⟩
-    intro i
-    cases Nat.decEq i nfa.nodes.size with
-    | isTrue eq =>
-      simp [eq]
-      show (nfa'[pd.nfa.nodes.size]'size_lt).inBounds nfa'.nodes.size
-      simp [pd.get_start, Node.inBounds]
-      exact ⟨pd.size_eq_expr' ▸ wf_expr.start_lt, Nat.lt_trans next_lt size_lt⟩
-    | isFalse ne =>
-      simp [pd.get_ne_start i i.isLt ne, pd.size_eq_expr']
-      exact wf_expr.inBounds ⟨i, pd.size_eq_expr' ▸ i.isLt⟩
-
-theorem compile_wf {e} : (compile e).WellFormed := by
-  simp [compile]
-  apply pushRegex_wf rfl done_WellFormed (by simp [done])
-
--- Well-formedness of the NFAs
-namespace Compile.ProofData
-
-theorem Empty.wf' [Empty] (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-theorem Epsilon.wf' [Epsilon] (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-theorem Char.wf' [Char] (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-theorem Classes.wf' [Classes] (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-namespace Group
-
-variable [Group]
-
-theorem wf_close (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfaClose.WellFormed := by
-  apply pushNode_wf wf
-  simp [Node.inBounds]
-  omega
-
-theorem wf_expr (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfaExpr.WellFormed :=
-  pushRegex_wf rfl (wf_close wf next_lt) (wf_close wf next_lt).start_lt
-
-theorem wf' (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-end Group
-
-namespace Alternate
-
-variable [Alternate]
-
-theorem wf₁ (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa₁.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-theorem wf₂ (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa₂.WellFormed :=
-  pushRegex_wf rfl (wf₁ wf next_lt) (Nat.lt_trans next_lt nfa₁_property)
-
-theorem wf' (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-end Alternate
-
-namespace Concat
-
-variable [Concat]
-
-theorem wf₂ (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa₂.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-theorem wf' (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-end Concat
-
-namespace Star
-
-variable [Star]
-
-theorem wf_placeholder (wf : nfa.WellFormed) : nfaPlaceholder.WellFormed := by
-  apply pushNode_wf wf
-  simp
-
-theorem wf_expr (wf : nfa.WellFormed) : nfaExpr.WellFormed :=
-  pushRegex_wf rfl (wf_placeholder wf) (wf_placeholder wf).start_lt
-
-theorem wf' (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
-  pushRegex_wf rfl wf next_lt
-
-end Star
-
-end Compile.ProofData
+    simp [pushRegex]
+    calc nfa.nodes.size
+      _ < (nfa.pushNode .fail).nodes.size := by simp
+      _ < ((nfa.pushNode .fail).pushRegex nfa.nodes.size e).nodes.size := ih
 
 end Regex.NFA

--- a/regex/Regex/NFA/Compile/ProofData.lean
+++ b/regex/Regex/NFA/Compile/ProofData.lean
@@ -1,1 +1,2 @@
 import Regex.NFA.Compile.ProofData.Basic
+import Regex.NFA.Compile.ProofData.Lemmas

--- a/regex/Regex/NFA/Compile/ProofData/Basic.lean
+++ b/regex/Regex/NFA/Compile/ProofData/Basic.lean
@@ -1,4 +1,5 @@
 import Regex.NFA.Compile.Basic
+import Regex.NFA.Compile.Lemmas
 
 open Regex.Data (Classes Expr)
 
@@ -17,13 +18,13 @@ variable [ProofData]
 
 def nfa' : NFA := nfa.pushRegex next e
 
-theorem size_lt : nfa.nodes.size < nfa'.nodes.size := (nfa.pushRegex next e).property
+theorem size_lt : nfa.nodes.size < nfa'.nodes.size := pushRegex_size_lt
 
-theorem eq_result {result} (eq : NFA.pushRegex nfa next e = result) : result = ⟨nfa', size_lt⟩ := by
+theorem eq_result {result} (eq : NFA.pushRegex nfa next e = result) : result = nfa' := by
   simp [←eq]
   rfl
 
-theorem eq : (nfa.pushRegex next e).val = nfa' := rfl
+theorem eq : nfa.pushRegex next e = nfa' := rfl
 
 end ProofData
 
@@ -42,7 +43,7 @@ def intro' (nfa : NFA) (next : Nat) : Empty :=
 
 variable [Empty]
 
-theorem eq' : nfa' = (nfa.pushRegex next .empty).val := by
+theorem eq' : nfa' = nfa.pushRegex next .empty := by
   simp [nfa', expr_eq]
 
 theorem start_eq : nfa'.start = nfa.nodes.size := by
@@ -83,7 +84,7 @@ def intro' (nfa : NFA) (next : Nat) : Epsilon :=
 
 variable [Epsilon]
 
-theorem eq' : nfa' = (nfa.pushRegex next .epsilon).val := by
+theorem eq' : nfa' = nfa.pushRegex next .epsilon := by
   simp [nfa', expr_eq]
 
 theorem start_eq : nfa'.start = nfa.nodes.size := by
@@ -125,7 +126,7 @@ def intro' (nfa : NFA) (next : Nat) (c : _root_.Char) : Char :=
 
 variable [Char]
 
-theorem eq' : nfa' = (nfa.pushRegex next (.char c)).val := by
+theorem eq' : nfa' = nfa.pushRegex next (.char c) := by
   simp [nfa', expr_eq]
 
 theorem start_eq : nfa'.start = nfa.nodes.size := by
@@ -167,7 +168,7 @@ def intro' (nfa : NFA) (next : Nat) (cs : Data.Classes) : Classes :=
 
 variable [Classes]
 
-theorem eq' : nfa' = (nfa.pushRegex next (.classes cs)).val := by
+theorem eq' : nfa' = nfa.pushRegex next (.classes cs) := by
   simp [nfa', expr_eq]
 
 theorem start_eq : nfa'.start = nfa.nodes.size := by
@@ -213,13 +214,12 @@ variable [Group]
 def nfaClose : NFA := nfa.pushNode (.save (2 * tag + 1) next)
 def nfaExpr : NFA := nfaClose.pushRegex nfaClose.start e'
 
-theorem nfaClose_property : nfa.nodes.size < nfaClose.nodes.size :=
-  (nfa.pushNode (.save (2 * tag + 1) next)).property
+theorem nfaClose_property : nfa.nodes.size < nfaClose.nodes.size := by simp [nfaClose]
 
 theorem nfaExpr_property : nfaClose.nodes.size < nfaExpr.nodes.size :=
-  (nfaClose.pushRegex nfaClose.start e').property
+  pushRegex_size_lt
 
-theorem eq' : nfa' = (nfa.pushRegex next (.group tag e')).val := by
+theorem eq' : nfa' = nfa.pushRegex next (.group tag e') := by
   simp [nfa', expr_eq]
 
 theorem eq_push : nfa' = nfaExpr.pushNode (.save (2 * tag) nfaExpr.start) := eq'
@@ -268,12 +268,12 @@ def nfa₁ : NFA := nfa.pushRegex next e₁
 def nfa₂ : NFA := nfa₁.pushRegex next e₂
 
 theorem nfa₁_property : nfa.nodes.size < nfa₁.nodes.size :=
-  (nfa.pushRegex next e₁).property
+  pushRegex_size_lt
 
 theorem nfa₂_property : nfa₁.nodes.size < nfa₂.nodes.size :=
-  (nfa₁.pushRegex next e₂).property
+  pushRegex_size_lt
 
-theorem eq' : nfa' = (nfa.pushRegex next (.alternate e₁ e₂)).val := by
+theorem eq' : nfa' = nfa.pushRegex next (.alternate e₁ e₂) := by
   simp [nfa', expr_eq]
 
 theorem eq_push : nfa' = nfa₂.pushNode (.split nfa₁.start nfa₂.start) := eq'
@@ -313,9 +313,9 @@ variable [Concat]
 def nfa₂ : NFA := nfa.pushRegex next e₂
 
 theorem nfa₂_property : nfa.nodes.size < nfa₂.nodes.size :=
-  (nfa.pushRegex next e₂).property
+  pushRegex_size_lt
 
-theorem eq' : nfa' = (NFA.pushRegex nfa next (.concat e₁ e₂)).val := by
+theorem eq' : nfa' = nfa.pushRegex next (.concat e₁ e₂) := by
   simp [nfa', expr_eq]
 
 theorem eq_push : nfa' = nfa₂.pushRegex nfa₂.start e₁ := by
@@ -324,7 +324,7 @@ theorem eq_push : nfa' = nfa₂.pushRegex nfa₂.start e₁ := by
 
 theorem size₂_lt : nfa₂.nodes.size < nfa'.nodes.size := by
   simp [eq_push]
-  exact (nfa₂.pushRegex nfa₂.start e₁).property
+  exact pushRegex_size_lt
 
 end Concat
 
@@ -342,7 +342,7 @@ def intro' (nfa : NFA) (next : Nat) (e': Expr) : Star :=
 
 variable [Star]
 
-theorem eq' : nfa' = (NFA.pushRegex nfa next (.star e')).val := by
+theorem eq' : nfa' = nfa.pushRegex next (.star e') := by
   simp [nfa', expr_eq]
 
 def nfaPlaceholder : NFA := nfa.pushNode .fail
@@ -352,7 +352,7 @@ theorem nfaPlaceholder_property : nfa.nodes.size < nfaPlaceholder.nodes.size := 
   simp [nfaPlaceholder]
 
 theorem nfaExpr_property : nfaPlaceholder.nodes.size < nfaExpr.nodes.size :=
-  (nfaPlaceholder.pushRegex nfaPlaceholder.start e').property
+  pushRegex_size_lt
 
 theorem start_eq : nfa'.start = nfa.nodes.size := by
   rw [eq', pushRegex]
@@ -367,8 +367,7 @@ theorem get_start : nfa'[nfa.nodes.size]'size_lt = .split nfaExpr.start next := 
 
 theorem get_ne_start (i : Nat) (h : i < nfa'.nodes.size) (ne : i ≠ nfa.nodes.size) :
   nfa'[i] = nfaExpr[i]'(size_eq_expr' ▸ h) := by
-  simp [eq', pushRegex, NFA.get_eq_nodes_get]
-  rw [Array.get_set_ne (h := ne.symm)]
+  simp [eq', pushRegex, NFA.get_eq_nodes_get, ne.symm]
   rfl
 
 end Star

--- a/regex/Regex/NFA/Compile/ProofData/Lemmas.lean
+++ b/regex/Regex/NFA/Compile/ProofData/Lemmas.lean
@@ -1,0 +1,178 @@
+import Regex.NFA.Compile.Basic
+import Regex.NFA.Compile.ProofData.Basic
+
+open Regex.Data (Expr)
+
+set_option autoImplicit false
+
+namespace Regex.NFA
+
+theorem pushNode_wf {nfa : NFA} {node}
+  (wf : nfa.WellFormed) (inBounds : node.inBounds (nfa.nodes.size + 1)) :
+  (nfa.pushNode node).WellFormed := by
+  simp [pushNode, WellFormed.iff, NFA.get_eq_nodes_get]
+  intro i
+  cases Nat.lt_or_ge i.val nfa.nodes.size with
+  | inl lt =>
+    have : (nfa.nodes.push node)[i.val] = nfa.nodes[i.val] := nfa.nodes.getElem_push_lt _ _ lt
+    simp [this]
+    apply Node.inBounds_of_inBounds_of_le (wf.inBounds ⟨i.val, lt⟩) (by omega)
+  | inr ge =>
+    have isLt := i.isLt
+    simp at isLt
+    have : i.val = nfa.nodes.size := by omega
+    simp [this, inBounds]
+
+open Compile.ProofData in
+theorem pushRegex_wf {nfa : NFA} {next e}
+  (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) :
+  (nfa.pushRegex next e).WellFormed := by
+  induction e generalizing nfa next with
+  | empty =>
+    simp [pushRegex]
+    exact pushNode_wf wf (by simp)
+  | epsilon =>
+    simp [pushRegex]
+    apply pushNode_wf wf
+    exact Nat.lt_trans next_lt (by omega)
+  | char c =>
+    simp [pushRegex]
+    apply pushNode_wf wf
+    exact Nat.lt_trans next_lt (by omega)
+  | classes cs =>
+    simp [pushRegex]
+    apply pushNode_wf wf
+    exact Nat.lt_trans next_lt (by omega)
+  | group tag e ih =>
+    let pd := Group.intro' nfa next tag e
+
+    have wf_close : (pd.nfaClose).WellFormed := by
+      apply pushNode_wf wf
+      simp [Node.inBounds]
+      exact Nat.lt_trans next_lt (by omega)
+
+    have wf_expr : (pd.nfaExpr).WellFormed := ih wf_close wf_close.start_lt
+
+    apply pushNode_wf wf_expr
+    exact Nat.lt_trans wf_expr.start_lt (by omega)
+  | alternate e₁ e₂ ih₁ ih₂ =>
+    let pd := Alternate.intro' nfa next e₁ e₂
+
+    have wf₁ : (pd.nfa₁).WellFormed := ih₁ wf next_lt
+    have wf₂ : (pd.nfa₂).WellFormed := ih₂ wf₁ (Nat.lt_trans next_lt pd.nfa₁_property)
+
+    apply pushNode_wf wf₂
+    simp [Node.inBounds]
+    exact ⟨
+      Nat.lt_trans wf₁.start_lt (Nat.lt_trans pd.nfa₂_property (by omega)),
+      Nat.lt_trans wf₂.start_lt (by omega)
+    ⟩
+  | concat e₁ e₂ ih₁ ih₂ =>
+    let pd := Concat.intro' nfa next e₁ e₂
+
+    have wf₂ : (pd.nfa₂).WellFormed := ih₂ wf next_lt
+    apply ih₁ wf₂ wf₂.start_lt
+  | star e ih =>
+    let pd := Star.intro' nfa next e
+    show (pd.nfa').WellFormed
+
+    have wf_placeholder : (pd.nfaPlaceholder).WellFormed := by
+      apply pushNode_wf wf
+      simp
+    have wf_expr : (pd.nfaExpr).WellFormed :=
+      ih wf_placeholder pd.nfaPlaceholder_property
+
+    simp [WellFormed.iff]
+    refine ⟨pd.size_lt, ?_⟩
+    intro i
+    cases Nat.decEq i pd.nfa.nodes.size with
+    | isTrue eq =>
+      simp [eq]
+      simp [pd.get_start, Node.inBounds]
+      exact ⟨pd.size_eq_expr' ▸ wf_expr.start_lt, Nat.lt_trans next_lt size_lt⟩
+    | isFalse ne =>
+      simp [pd.get_ne_start i i.isLt ne, pd.size_eq_expr']
+      exact wf_expr.inBounds ⟨i, pd.size_eq_expr' ▸ i.isLt⟩
+
+theorem compile_wf {e} : (compile e).WellFormed := by
+  simp [compile]
+  apply pushRegex_wf done_WellFormed (by simp [done])
+
+-- Well-formedness of the NFAs
+namespace Compile.ProofData
+
+theorem Empty.wf' [Empty] (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
+  pushRegex_wf wf next_lt
+
+theorem Epsilon.wf' [Epsilon] (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
+  pushRegex_wf wf next_lt
+
+theorem Char.wf' [Char] (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
+  pushRegex_wf wf next_lt
+
+theorem Classes.wf' [Classes] (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
+  pushRegex_wf wf next_lt
+
+namespace Group
+
+variable [Group]
+
+theorem wf_close (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfaClose.WellFormed := by
+  apply pushNode_wf wf
+  simp [Node.inBounds]
+  omega
+
+theorem wf_expr (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfaExpr.WellFormed :=
+  pushRegex_wf (wf_close wf next_lt) (wf_close wf next_lt).start_lt
+
+theorem wf' (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
+  pushRegex_wf wf next_lt
+
+end Group
+
+namespace Alternate
+
+variable [Alternate]
+
+theorem wf₁ (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa₁.WellFormed :=
+  pushRegex_wf wf next_lt
+
+theorem wf₂ (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa₂.WellFormed :=
+  pushRegex_wf (wf₁ wf next_lt) (Nat.lt_trans next_lt nfa₁_property)
+
+theorem wf' (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
+  pushRegex_wf wf next_lt
+
+end Alternate
+
+namespace Concat
+
+variable [Concat]
+
+theorem wf₂ (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa₂.WellFormed :=
+  pushRegex_wf wf next_lt
+
+theorem wf' (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
+  pushRegex_wf wf next_lt
+
+end Concat
+
+namespace Star
+
+variable [Star]
+
+theorem wf_placeholder (wf : nfa.WellFormed) : nfaPlaceholder.WellFormed := by
+  apply pushNode_wf wf
+  simp
+
+theorem wf_expr (wf : nfa.WellFormed) : nfaExpr.WellFormed :=
+  pushRegex_wf (wf_placeholder wf) (wf_placeholder wf).start_lt
+
+theorem wf' (wf : nfa.WellFormed) (next_lt : next < nfa.nodes.size) : nfa'.WellFormed :=
+  pushRegex_wf wf next_lt
+
+end Star
+
+end Compile.ProofData
+
+end Regex.NFA


### PR DESCRIPTION
While the use of `Subtype` in `pushRegex` has eliminated the bounds checking when compiling `.star e`, it made reasoning about the result of `pushRegex` more cumbersome. Let's get rid of dependent types.