### PR TITLE
Fix unnecessary copying of large arrays

### DIFF
--- a/correctness/RegexCorrectness/VM/Correspondence/Refinement/Refinement.lean
+++ b/correctness/RegexCorrectness/VM/Correspondence/Refinement/Refinement.lean
@@ -301,11 +301,11 @@ theorem captureNext'.go.refines {current current' result result'}
     rw [captureNext'.go_ind_not_found atEnd isNone' h₁ h₂] at h'
     rw [captureNext.go_ind_not_found atEnd isNone hexpand hstep] at h
 
-    have := εClosure'.refines hexpand h₁ (by simp [refineUpdateOpt]) refCurrent (.cons rfl rfl .nil)
-    simp at this
-    have ⟨refMatched'', refNext''⟩ := eachStepChar'.refines hstep h₂ this.2 refNext
+    have refExpanded := εClosure'.refines hexpand h₁ (by simp [refineUpdateOpt]) refCurrent (.cons rfl rfl .nil)
+    simp at refExpanded
+    have ⟨refMatched'', refNext''⟩ := eachStepChar'.refines hstep h₂ refExpanded.2 refNext
     simp at refMatched'' refNext''
-    exact ih h h' refMatched'' refNext'' (by simp [refCurrent.1, SearchState'.refines, refCurrent.2])
+    exact ih h h' refMatched'' refNext'' (by simp [SearchState'.refines, refExpanded.2.1, refExpanded.2.2])
   | ind_found it matched' current' next' matched'' next'' atEnd isEmpty' isSome' h'' ih =>
     have isEmpty : ¬current.states.isEmpty := refCurrent.1 ▸ isEmpty'
     have isSome : matched.isSome := by

--- a/correctness/RegexCorrectness/VM/Correspondence/Refinement/Simp.lean
+++ b/correctness/RegexCorrectness/VM/Correspondence/Refinement/Simp.lean
@@ -19,7 +19,10 @@ theorem εClosure_base : εClosure nfa wf it matched next [] = (matched, next) :
 theorem εClosure_visited {update state stack'} (hmem : state ∈ next.states) :
   εClosure nfa wf it matched next ((update, state) :: stack') =
   εClosure nfa wf it matched next stack' := by
-  simp [εClosure, hmem]
+  conv =>
+    lhs
+    unfold εClosure
+    simp [hmem]
 
 @[simp]
 theorem εClosure_epsilon {update state stack' state'} (hmem : state ∉ next.states) (hn : nfa[state] = .epsilon state') :
@@ -169,7 +172,7 @@ theorem captureNext.go_ind_not_found {_matched matched'}
   (atEnd : ¬it.atEnd) (isNone : matched.isNone)
   (h₁ : εClosure nfa wf it .none current [(Buffer.empty, ⟨nfa.start, wf.start_lt⟩)] = (_matched, current'))
   (h₂ : eachStepChar nfa wf it current' next = (matched', next')) :
-  captureNext.go nfa wf bufferSize it matched current next = captureNext.go nfa wf bufferSize it.next matched' next' ⟨current.states.clear, current.updates⟩ := by
+  captureNext.go nfa wf bufferSize it matched current next = captureNext.go nfa wf bufferSize it.next matched' next' ⟨current'.states.clear, current'.updates⟩ := by
   have isSome : ¬matched.isSome := by
     cases matched <;> simp_all
   conv =>

--- a/correctness/RegexCorrectness/VM/Search/Basic.lean
+++ b/correctness/RegexCorrectness/VM/Search/Basic.lean
@@ -26,7 +26,7 @@ where
         if matched.isNone then
           let expanded := εClosure' nfa wf it .none current [([], ⟨nfa.start, wf.start_lt⟩)]
           let stepped := eachStepChar' nfa wf it expanded.2 next
-          go it.next stepped.1 stepped.2 ⟨current.states.clear, current.updates⟩
+          go it.next stepped.1 stepped.2 ⟨expanded.2.states.clear, expanded.2.updates⟩
         else
           let stepped := eachStepChar' nfa wf it current next
           go it.next (stepped.1 <|> matched) stepped.2 ⟨current.states.clear, current.updates⟩
@@ -43,7 +43,7 @@ theorem captureNext'.go.induct' (nfa : NFA) (wf : nfa.WellFormed)
     ¬it.atEnd → matched.isNone →
     εClosure' nfa wf it .none current [([], ⟨nfa.start, wf.start_lt⟩)] = (_matched, current') →
     eachStepChar' nfa wf it current' next = (matched', next') →
-    motive it.next matched' next' ⟨current.states.clear, current.updates⟩ →
+    motive it.next matched' next' ⟨current'.states.clear, current'.updates⟩ →
     motive it matched current next)
   (ind_found : ∀ it matched current next matched' next',
     ¬it.atEnd → ¬current.states.isEmpty → matched.isSome →
@@ -85,7 +85,7 @@ theorem captureNext'.go_ind_not_found {nfa wf it matched current next _matched c
   (atEnd : ¬it.atEnd) (isNone : matched.isNone)
   (h₁ : εClosure' nfa wf it .none current [([], ⟨nfa.start, wf.start_lt⟩)] = (_matched, current'))
   (h₂ : eachStepChar' nfa wf it current' next = (matched', next')) :
-  captureNext'.go nfa wf it matched current next = captureNext'.go nfa wf it.next matched' next' ⟨current.states.clear, current.updates⟩ := by
+  captureNext'.go nfa wf it matched current next = captureNext'.go nfa wf it.next matched' next' ⟨current'.states.clear, current'.updates⟩ := by
   have isSome : ¬matched.isSome := by
     cases matched <;> simp_all
   conv =>


### PR DESCRIPTION
This PR fixes unintentional cloning of arrays (found via `samply`). In my environment, I observed 2x speed-up.

- [ ] Set up a CI to monitor the speed differences
- [x] Fix proofs