### PR TITLE
Add anchor

### DIFF
--- a/correctness/RegexCorrectness/Data/Expr/Semantics/Separation.lean
+++ b/correctness/RegexCorrectness/Data/Expr/Semantics/Separation.lean
@@ -5,14 +5,14 @@ import RegexCorrectness.Data.Expr.Semantics.Captures
 namespace Regex.Data.Expr
 
 def tags : Expr → Finset Nat
-| .empty | .epsilon | .char _ | .classes _ => ∅
+| .empty | .epsilon | .anchor _ | .char _ | .classes _ => ∅
 | .group tag e => {tag} ∪ e.tags
 | .alternate e₁ e₂ => e₁.tags ∪ e₂.tags
 | .concat e₁ e₂ => e₁.tags ∪ e₂.tags
 | .star e => e.tags
 
 def Disjoint : Expr → Prop
-| .empty | .epsilon | .char _ | .classes _ => True
+| .empty | .epsilon | .anchor _ | .char _ | .classes _ => True
 | .group tag e => tag ∉ e.tags ∧ e.Disjoint
 | .alternate e₁ e₂ => e₁.tags ∩ e₂.tags = ∅ ∧ e₁.Disjoint ∧ e₂.Disjoint
 | .concat e₁ e₂ => e₁.tags ∩ e₂.tags = ∅ ∧ e₁.Disjoint ∧ e₂.Disjoint

--- a/correctness/RegexCorrectness/NFA/Compile.lean
+++ b/correctness/RegexCorrectness/NFA/Compile.lean
@@ -14,9 +14,10 @@ open Compile.ProofData in
 theorem pushRegex_get_lt {nfa next e nfa'} (eq : pushRegex nfa next e = nfa') (i : Nat) (h : i < nfa.nodes.size) :
   nfa'[i]'(Nat.lt_trans h (eq ▸ pushRegex_size_lt)) = nfa[i] := by
   induction e generalizing nfa next nfa' with
-  | empty | epsilon | char | classes =>
+  | empty | epsilon | anchor | char | classes =>
     try let pd := Empty.intro eq
     try let pd := Epsilon.intro eq
+    try let pd := Anchor.intro eq
     try let pd := Char.intro eq
     try let pd := Classes.intro eq
     simp [pd.eq_result eq, pd.get_lt h]
@@ -162,9 +163,10 @@ open Compile.ProofData in
 theorem ge_pushRegex_start {nfa next e result} (eq : pushRegex nfa next e = result) :
   nfa.nodes.size ≤ result.start := by
   induction e generalizing nfa next result with
-  | empty | epsilon | char c | classes cs =>
+  | empty | epsilon | anchor a | char c | classes cs =>
     try let pd := Empty.intro eq
     try let pd := Epsilon.intro eq
+    try let pd := Anchor.intro eq
     try let pd := Char.intro eq
     try let pd := Classes.intro eq
     simp [pd.eq_result eq, pd.start_eq]
@@ -200,8 +202,9 @@ theorem eq_or_ge_of_step_pushRegex {nfa next e result} {i j : Nat} (eq : pushReg
     simp [pd.eq_result eq, pd.size_eq] at step h₂
     have : i = pd.nfa.nodes.size := Nat.eq_of_le_of_lt_succ h₁ h₂
     simp [this, Node.charStep, Node.εStep, pd.get_eq] at step
-  | epsilon | char c | classes cs =>
+  | epsilon | anchor a | char c | classes cs =>
     try let pd := Epsilon.intro eq
+    try let pd := Anchor.intro eq
     try let pd := Char.intro eq
     try let pd := Classes.intro eq
     simp [pd.eq_result eq, pd.size_eq] at step h₂
@@ -299,7 +302,7 @@ theorem mem_save_of_mem_tags_pushRegex {nfa next e result tag} (eq : pushRegex n
   ∃ (i j : Fin result.nodes.size) (offset offset' : Nat),
     result[i] = .save (2 * tag) offset ∧ result[j] = .save (2 * tag + 1) offset' := by
   induction e generalizing nfa next result with
-  | empty | epsilon | char | classes => simp [tags] at h
+  | empty | epsilon | anchor | char | classes => simp [tags] at h
   | group tag' e ih =>
     let pd := Group.intro eq
     rw [pd.eq_result eq]
@@ -427,9 +430,10 @@ theorem done_iff_zero_pushRegex {nfa next e result} (eq : pushRegex nfa next e =
   (h₂ : ∀ (i : Nat) (isLt : i < nfa.nodes.size), nfa[i] = .done ↔ i = 0) :
   ∀ (i : Nat) (isLt : i < result.nodes.size), result[i] = .done ↔ i = 0 := by
   induction e generalizing nfa next result with
-  | empty | epsilon | char c | classes c =>
+  | empty | epsilon | anchor a | char c | classes c =>
     try let pd := Empty.intro eq
     try let pd := Epsilon.intro eq
+    try let pd := Anchor.intro eq
     try let pd := Char.intro eq
     try let pd := Classes.intro eq
     simp [pd.eq_result eq, pd.eq', pushRegex]

--- a/correctness/RegexCorrectness/NFA/Semantics/Path.lean
+++ b/correctness/RegexCorrectness/NFA/Semantics/Path.lean
@@ -16,6 +16,8 @@ open Regex.Data (Span)
 inductive Step (nfa : NFA) (lb : Nat) : Nat → Span → Nat → Span → Option (Nat × String.Pos) → Prop where
   | epsilon {i j span} (ge : lb ≤ i) (lt : i < nfa.nodes.size) (eq : nfa[i] = .epsilon j) :
     Step nfa lb i span j span .none
+  | anchor {i j span a} (ge : lb ≤ i) (lt : i < nfa.nodes.size) (eq : nfa[i] = .anchor a j) (h : a.test span.iterator) :
+    Step nfa lb i span j span .none
   | splitLeft {i j₁ j₂ span} (ge : lb ≤ i) (lt : i < nfa.nodes.size) (eq : nfa[i] = .split j₁ j₂) :
     Step nfa lb i span j₁ span .none
   | splitRight {i j₁ j₂ span} (ge : lb ≤ i) (lt : i < nfa.nodes.size) (eq : nfa[i] = .split j₁ j₂) :
@@ -56,6 +58,7 @@ theorem cast (step : nfa.Step lb i span j span' update)
   nfa'.Step lb i span j span' update := by
   cases step with
   | epsilon ge _ eq => exact .epsilon ge lt (h ▸ eq)
+  | anchor ge _ eq h' => exact .anchor ge lt (h ▸ eq) h'
   | splitLeft ge _ eq => exact .splitLeft ge lt (h ▸ eq)
   | splitRight ge _ eq => exact .splitRight ge lt (h ▸ eq)
   | save ge _ eq => exact .save ge lt (h ▸ eq)
@@ -66,6 +69,7 @@ theorem liftBound' (ge : lb' ≤ i) (step : nfa.Step lb i span j span' update) :
   nfa.Step lb' i span j span' update := by
   cases step with
   | epsilon _ lt eq => exact .epsilon ge lt eq
+  | anchor _ lt eq h => exact .anchor ge lt eq h
   | splitLeft _ lt eq => exact .splitLeft ge lt eq
   | splitRight _ lt eq => exact .splitRight ge lt eq
   | save _ lt eq => exact .save ge lt eq

--- a/correctness/RegexCorrectness/NFA/Semantics/ProofData/Basic.lean
+++ b/correctness/RegexCorrectness/NFA/Semantics/ProofData/Basic.lean
@@ -61,6 +61,44 @@ theorem path_start_iff (next_lt : next < nfa.nodes.size) :
 
 end Epsilon
 
+namespace Anchor
+
+variable [Anchor] {span j span' update}
+
+theorem step_start_iff :
+  nfa'.Step nfa.nodes.size nfa'.start span j span' update ↔
+  j = next ∧ span' = span ∧ update = .none ∧ anchor.test span.iterator := by
+  have lt : nfa'.start < nfa'.nodes.size := by
+    simp [size_eq, start_eq]
+  have : nfa'[nfa'.start] = .anchor anchor next := by
+    simp [start_eq, get_eq]
+  apply Iff.intro
+  . intro step
+    cases step <;> simp_all
+  . intro ⟨hj, hspan, hupdate, hcond⟩
+    simp_all
+    exact .anchor (by simp [start_eq]) lt this hcond
+
+theorem path_start_iff (next_lt : next < nfa.nodes.size) :
+  nfa'.Path nfa.nodes.size nfa'.start span j span' update ↔
+  j = next ∧ span' = span ∧ update = [] ∧ anchor.test span.iterator := by
+  apply Iff.intro
+  . intro path
+    cases path with
+    | last step =>
+      simp [step_start_iff] at step
+      simp [step]
+    | more step rest =>
+      simp [step_start_iff] at step
+      simp [step] at rest
+      have ge := rest.ge
+      omega
+  . intro ⟨hj, hspan, hupdate, hcond⟩
+    simp_all
+    exact .last (step_start_iff.mpr ⟨rfl, rfl, rfl, hcond⟩)
+
+end Anchor
+
 namespace Char
 
 variable [Char] {span j span' update}

--- a/correctness/RegexCorrectness/NFA/Semantics/ProofData/Compile.lean
+++ b/correctness/RegexCorrectness/NFA/Semantics/ProofData/Compile.lean
@@ -23,6 +23,14 @@ theorem Step.eq_or_ge_of_pushRegex {nfa : NFA} {next e i span j span' update}
     have := Epsilon.step_start_iff.mp (this ▸ step)
     simp [this]
     exact .inl rfl
+  | anchor a =>
+    let pd := Anchor.intro' nfa next a
+    have lt := step.lt
+    simp [pushRegex] at lt
+    have : i = nfa'.start := Nat.eq_of_le_of_lt_succ step.ge lt
+    have := Anchor.step_start_iff.mp (this ▸ step)
+    simp [this]
+    exact .inl rfl
   | char c =>
     let pd := Char.intro' nfa next c
     have lt := step.lt

--- a/correctness/RegexCorrectness/Syntax/Ast.lean
+++ b/correctness/RegexCorrectness/Syntax/Ast.lean
@@ -23,6 +23,9 @@ theorem toRegexAux_tags {index index' : Nat} {ast : Ast} {e : Expr}
   next =>
     simp [toRegexAux] at h
     simp [←h, Expr.tags]
+  next =>
+    simp [toRegexAux] at h
+    simp [←h, Expr.tags]
   next index ast index'' e' h' ih =>
     simp [toRegexAux, h'] at h
     have ⟨le, ih⟩ := ih h'
@@ -60,6 +63,7 @@ theorem toRegexAux_tags {index index' : Nat} {ast : Ast} {e : Expr}
 
 theorem toRegexAux_disjoint (index : Nat) (ast : Ast) : Expr.Disjoint (ast.toRegexAux index).2 := by
   induction index, ast using Ast.toRegexAux.induct
+  next => simp [toRegexAux, Expr.Disjoint]
   next => simp [toRegexAux, Expr.Disjoint]
   next => simp [toRegexAux, Expr.Disjoint]
   next => simp [toRegexAux, Expr.Disjoint]

--- a/correctness/RegexCorrectness/VM/EpsilonClosure/Basic.lean
+++ b/correctness/RegexCorrectness/VM/EpsilonClosure/Basic.lean
@@ -34,6 +34,12 @@ def εClosure' (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
       | .epsilon state' =>
         have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
         εClosure' nfa wf it matched ⟨states', next.updates⟩ ((update, ⟨state', isLt⟩) :: stack')
+      | .anchor anchor state' =>
+        have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
+        if anchor.test it then
+          εClosure' nfa wf it matched ⟨states', next.updates⟩ ((update, ⟨state', isLt⟩) :: stack')
+        else
+          εClosure' nfa wf it matched ⟨states', next.updates⟩ stack'
       | .split state₁ state₂ =>
         have isLt : state₁ < nfa.nodes.size ∧ state₂ < nfa.nodes.size := wf.inBounds' state hn
         εClosure' nfa wf it matched ⟨states', next.updates⟩ ((update, ⟨state₁, isLt.1⟩) :: (update, ⟨state₂, isLt.2⟩):: stack')
@@ -54,68 +60,189 @@ def εClosure' (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
       | .fail => εClosure' nfa wf it matched ⟨states', next.updates⟩ stack'
 termination_by (next.states.measure, stack)
 
+#check εClosure'.induct
+
+/-
+Regex.VM.εClosure'.induct (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
+  (motive : Option (List (ℕ × Pos)) → SearchState' nfa → εStack' nfa → Prop)
+  (case1 : ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa), motive matched next [])
+  (case2 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∈ next.states → motive matched next stack' → motive matched next ((update, state) :: stack'))
+  (case3 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∉ next.states →
+        let states' := next.states.insert state;
+        ∀ (state' : ℕ),
+          nfa[state] = NFA.Node.epsilon state' →
+            ∀ (isLt : state' < nfa.nodes.size),
+              motive matched { states := states', updates := next.updates } ((update, ⟨state', isLt⟩) :: stack') →
+                motive matched next ((update, state) :: stack'))
+  (case4 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∉ next.states →
+        let states' := next.states.insert state;
+        ∀ (anchor : Data.Anchor) (state' : ℕ),
+          nfa[state] = NFA.Node.anchor anchor state' →
+            ∀ (isLt : state' < nfa.nodes.size),
+              Data.Anchor.test it anchor = true →
+                motive matched { states := states', updates := next.updates } ((update, ⟨state', isLt⟩) :: stack') →
+                  motive matched next ((update, state) :: stack'))
+  (case5 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∉ next.states →
+        let states' := next.states.insert state;
+        ∀ (anchor : Data.Anchor) (state' : ℕ),
+          nfa[state] = NFA.Node.anchor anchor state' →
+            state' < nfa.nodes.size →
+              ¬Data.Anchor.test it anchor = true →
+                motive matched { states := states', updates := next.updates } stack' →
+                  motive matched next ((update, state) :: stack'))
+  (case6 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∉ next.states →
+        let states' := next.states.insert state;
+        ∀ (state₁ state₂ : ℕ),
+          nfa[state] = NFA.Node.split state₁ state₂ →
+            ∀ (isLt : state₁ < nfa.nodes.size ∧ state₂ < nfa.nodes.size),
+              motive matched { states := states', updates := next.updates }
+                  ((update, ⟨state₁, ⋯⟩) :: (update, ⟨state₂, ⋯⟩) :: stack') →
+                motive matched next ((update, state) :: stack'))
+  (case7 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∉ next.states →
+        let states' := next.states.insert state;
+        ∀ (offset state' : ℕ),
+          nfa[state] = NFA.Node.save offset state' →
+            ∀ (isLt : state' < nfa.nodes.size),
+              let update' := update ++ [(offset, it.pos)];
+              motive matched { states := states', updates := next.updates } ((update', ⟨state', isLt⟩) :: stack') →
+                motive matched next ((update, state) :: stack'))
+  (case8 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∉ next.states →
+        let states' := next.states.insert state;
+        nfa[state] = NFA.Node.done →
+          let matched' := matched <|> some update;
+          let updates' := next.updates.set (↑state) update ⋯;
+          motive matched' { states := states', updates := updates' } stack' →
+            motive matched next ((update, state) :: stack'))
+  (case9 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∉ next.states →
+        let states' := next.states.insert state;
+        ∀ (c : Char) (state' : ℕ),
+          nfa[state] = NFA.Node.char c state' →
+            let updates' := next.updates.set (↑state) update ⋯;
+            motive matched { states := states', updates := updates' } stack' →
+              motive matched next ((update, state) :: stack'))
+  (case10 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∉ next.states →
+        let states' := next.states.insert state;
+        ∀ (cs : Data.Classes) (state' : ℕ),
+          nfa[state] = NFA.Node.sparse cs state' →
+            let updates' := next.updates.set (↑state) update ⋯;
+            motive matched { states := states', updates := updates' } stack' →
+              motive matched next ((update, state) :: stack'))
+  (case11 :
+    ∀ (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (update : List (ℕ × Pos))
+      (state : Fin nfa.nodes.size) (stack' : List (List (ℕ × Pos) × Fin nfa.nodes.size)),
+      state ∉ next.states →
+        let states' := next.states.insert state;
+        nfa[state] = NFA.Node.fail →
+          motive matched { states := states', updates := next.updates } stack' →
+            motive matched next ((update, state) :: stack'))
+  (matched : Option (List (ℕ × Pos))) (next : SearchState' nfa) (stack : εStack' nfa) : motive matched next stack
+-/
+
 -- Cleaner version of the fuction induction principle
 -- Using tactics in the body crashes Lean due to too high memory usage
-theorem εClosure'.induct' (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
-  (motive : Option (List (Nat × Pos)) → SearchState' nfa → εStack' nfa → Prop)
-  (base : ∀ matched next, motive matched next [])
-  (visited :
-    ∀ matched next update state stack',
-    state ∈ next.states →
-    motive matched next stack' →
-    motive matched next ((update, state) :: stack'))
-  (epsilon : ∀ matched next update state stack' state',
-    state ∉ next.states → nfa[state] = .epsilon state' →
-    let next' := ⟨next.states.insert state, next.updates⟩;
-    motive matched next' ((update, state') :: stack') →
-    motive matched next ((update, state) :: stack'))
-  (split : ∀ matched next update state stack' state₁ state₂,
-    state ∉ next.states → nfa[state] = .split state₁ state₂ →
-    let next' := ⟨next.states.insert state, next.updates⟩;
-    motive matched next' ((update, state₁) :: (update, state₂) :: stack') →
-    motive matched next ((update, state) :: stack'))
-  (save : ∀ matched next update state stack' offset state',
-    state ∉ next.states → nfa[state] = .save offset state' →
-    let next' := ⟨next.states.insert state, next.updates⟩;
-    motive matched next' ((update ++ [(offset, it.pos)], state') :: stack') →
-    motive matched next ((update, state) :: stack'))
-  (done : ∀ matched next update state stack',
-    state ∉ next.states → nfa[state] = .done →
-    let next' := ⟨next.states.insert state, next.updates.set state update⟩;
-    motive (matched <|> .some update) next' stack' →
-    motive matched next ((update, state) :: stack'))
-  (char : ∀ matched next update state stack' c (state' : Fin nfa.nodes.size),
-    state ∉ next.states → nfa[state] = .char c state' →
-    let next' := ⟨next.states.insert state, next.updates.set state update⟩;
-    motive matched next' stack' →
-    motive matched next ((update, state) :: stack'))
-  (sparse : ∀ matched next update state stack' cs (state' : Fin nfa.nodes.size),
-    state ∉ next.states → nfa[state] = .sparse cs state' →
-    let next' := ⟨next.states.insert state, next.updates.set state update⟩;
-    motive matched next' stack' →
-    motive matched next ((update, state) :: stack'))
-  (fail : ∀ matched next update state stack',
-    state ∉ next.states → nfa[state] = .fail →
-    let next' := ⟨next.states.insert state, next.updates⟩;
-    motive matched next' stack' →
-    motive matched next ((update, state) :: stack')) :
-  ∀ matched next stack, motive matched next stack := fun matched next stack =>
-    εClosure'.induct nfa wf it motive base visited
-      (fun matched next update state stack' mem state' hn isLt ih =>
-        epsilon matched next update state stack' ⟨state', isLt⟩ mem hn ih)
-      (fun matched next update state stack' mem state₁ state₂ hn isLt ih =>
-        split matched next update state stack' ⟨state₁, isLt.1⟩ ⟨state₂, isLt.2⟩ mem hn ih)
-      (fun matched next update state stack' mem offset state' hn isLt ih =>
-        save matched next update state stack' offset ⟨state', isLt⟩ mem hn ih)
-      (fun matched next update state stack' mem hn ih =>
-        done matched next update state stack' mem hn ih)
-      (fun matched next update state stack' mem c state' hn ih =>
-        char matched next update state stack' c ⟨state', wf.inBounds' state hn⟩ mem hn ih)
-      (fun matched next update state stack' mem cs state' hn ih =>
-        sparse matched next update state stack' cs ⟨state', wf.inBounds' state hn⟩ mem hn ih)
-      (fun matched next update state stack' mem hn ih =>
-        fail matched next update state stack' mem hn ih)
-      matched next stack
+-- theorem εClosure'.induct' (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
+--   (motive : Option (List (Nat × Pos)) → SearchState' nfa → εStack' nfa → Prop)
+--   (base : ∀ matched next, motive matched next [])
+--   (visited :
+--     ∀ matched next update state stack',
+--     state ∈ next.states →
+--     motive matched next stack' →
+--     motive matched next ((update, state) :: stack'))
+--   (epsilon : ∀ matched next update state stack' state',
+--     state ∉ next.states → nfa[state] = .epsilon state' →
+--     let next' := ⟨next.states.insert state, next.updates⟩;
+--     motive matched next' ((update, state') :: stack') →
+--     motive matched next ((update, state) :: stack'))
+--   (anchor_pos : ∀ matched next update state stack' anchor state',
+--     state ∉ next.states → nfa[state] = .anchor anchor state' →
+--     let next' := ⟨next.states.insert state, next.updates⟩;
+--     anchor.test it →
+--     motive matched next' ((update, state') :: stack') →
+--     motive matched next ((update, state) :: stack'))
+--   (anchor_neg : ∀ matched next update state stack' anchor state',
+--     state ∉ next.states → nfa[state] = .anchor anchor state' →
+--     let next' := ⟨next.states.insert state, next.updates⟩;
+--     ¬anchor.test it →
+--     motive matched next' stack' →
+--     motive matched next ((update, state) :: stack'))
+--   (split : ∀ matched next update state stack' state₁ state₂,
+--     state ∉ next.states → nfa[state] = .split state₁ state₂ →
+--     let next' := ⟨next.states.insert state, next.updates⟩;
+--     motive matched next' ((update, state₁) :: (update, state₂) :: stack') →
+--     motive matched next ((update, state) :: stack'))
+--   (save : ∀ matched next update state stack' offset state',
+--     state ∉ next.states → nfa[state] = .save offset state' →
+--     let next' := ⟨next.states.insert state, next.updates⟩;
+--     motive matched next' ((update ++ [(offset, it.pos)], state') :: stack') →
+--     motive matched next ((update, state) :: stack'))
+--   (done : ∀ matched next update state stack',
+--     state ∉ next.states → nfa[state] = .done →
+--     let next' := ⟨next.states.insert state, next.updates.set state update⟩;
+--     motive (matched <|> .some update) next' stack' →
+--     motive matched next ((update, state) :: stack'))
+--   (char : ∀ matched next update state stack' c (state' : Fin nfa.nodes.size),
+--     state ∉ next.states → nfa[state] = .char c state' →
+--     let next' := ⟨next.states.insert state, next.updates.set state update⟩;
+--     motive matched next' stack' →
+--     motive matched next ((update, state) :: stack'))
+--   (sparse : ∀ matched next update state stack' cs (state' : Fin nfa.nodes.size),
+--     state ∉ next.states → nfa[state] = .sparse cs state' →
+--     let next' := ⟨next.states.insert state, next.updates.set state update⟩;
+--     motive matched next' stack' →
+--     motive matched next ((update, state) :: stack'))
+--   (fail : ∀ matched next update state stack',
+--     state ∉ next.states → nfa[state] = .fail →
+--     let next' := ⟨next.states.insert state, next.updates⟩;
+--     motive matched next' stack' →
+--     motive matched next ((update, state) :: stack')) :
+--   ∀ matched next stack, motive matched next stack := fun matched next stack =>
+--     εClosure'.induct nfa wf it motive base visited
+--       (fun matched next update state stack' mem state' hn isLt ih =>
+--         epsilon matched next update state stack' ⟨state', isLt⟩ mem hn ih)
+--       (fun matched next update state stack' mem a state' hn isLt h ih =>
+--         anchor_pos matched next update state stack' a ⟨state', isLt⟩ mem hn h ih)
+--       (fun matched next update state stack' mem a state' hn isLt h ih =>
+--         anchor_neg matched next update state stack' a ⟨state', isLt⟩ mem hn h ih)
+--       (fun matched next update state stack' mem state₁ state₂ hn isLt ih =>
+--         split matched next update state stack' ⟨state₁, isLt.1⟩ ⟨state₂, isLt.2⟩ mem hn ih)
+--       (fun matched next update state stack' mem offset state' hn isLt ih =>
+--         save matched next update state stack' offset ⟨state', isLt⟩ mem hn ih)
+--       (fun matched next update state stack' mem hn ih =>
+--         done matched next update state stack' mem hn ih)
+--       (fun matched next update state stack' mem c state' hn ih =>
+--         char matched next update state stack' c ⟨state', wf.inBounds' state hn⟩ mem hn ih)
+--       (fun matched next update state stack' mem cs state' hn ih =>
+--         sparse matched next update state stack' cs ⟨state', wf.inBounds' state hn⟩ mem hn ih)
+--       (fun matched next update state stack' mem hn ih =>
+--         fail matched next update state stack' mem hn ih)
+--       matched next stack
 
 /-
 Simplification lemmas for `εClosure'`.
@@ -143,6 +270,26 @@ theorem εClosure'_epsilon {update state stack' state'} (hmem : state ∉ next.s
     unfold εClosure'
     simp [hmem]
   split <;> simp_all
+
+@[simp]
+theorem εClosure'_anchor_pos {update state stack' anchor state'} (hmem : state ∉ next.states) (hn : nfa[state] = .anchor anchor state') (h : anchor.test it) :
+  εClosure' nfa wf it matched next ((update, state) :: stack') =
+  εClosure' nfa wf it matched ⟨next.states.insert state, next.updates⟩ ((update, state') :: stack') := by
+  conv =>
+    lhs
+    unfold εClosure'
+    simp [hmem]
+  sorry
+
+@[simp]
+theorem εClosure'_anchor_neg {update state stack' anchor state'} (hmem : state ∉ next.states) (hn : nfa[state] = .anchor anchor state') (h : ¬anchor.test it) :
+  εClosure' nfa wf it matched next ((update, state) :: stack') =
+  εClosure' nfa wf it matched ⟨next.states.insert state, next.updates⟩ stack' := by
+  conv =>
+    lhs
+    unfold εClosure'
+    simp [hmem]
+  sorry
 
 @[simp]
 theorem εClosure'_split {update state stack' state₁ state₂} (hmem : state ∉ next.states) (hn : nfa[state] = .split state₁ state₂) :

--- a/regex/Regex/Data/Anchor.lean
+++ b/regex/Regex/Data/Anchor.lean
@@ -1,0 +1,13 @@
+namespace Regex.Data
+
+inductive Anchor where
+  | start
+  | eos
+deriving DecidableEq, Repr, Inhabited
+
+def Anchor.test (it : String.Iterator) (anchor : Anchor) : Bool :=
+  match anchor with
+  | Anchor.start => it.pos = 0
+  | Anchor.eos => it.atEnd
+
+end Regex.Data

--- a/regex/Regex/Data/Expr.lean
+++ b/regex/Regex/Data/Expr.lean
@@ -1,3 +1,4 @@
+import Regex.Data.Anchor
 import Regex.Data.Classes
 
 namespace Regex.Data
@@ -8,6 +9,7 @@ An inductive type that represents a regular expression.
 inductive Expr : Type where
   | empty : Expr
   | epsilon : Expr
+  | anchor : Anchor → Expr
   | char : Char → Expr
   | group : Nat → Expr → Expr
   | alternate : Expr → Expr → Expr

--- a/regex/Regex/NFA/Compile/Basic.lean
+++ b/regex/Regex/NFA/Compile/Basic.lean
@@ -43,6 +43,7 @@ theorem pushNode_start_eq {nfa : NFA} {node : Node} : (nfa.pushNode node).start 
 def pushRegex (nfa : NFA) (next : Nat) : Expr → NFA
   | .empty => nfa.pushNode .fail
   | .epsilon => nfa.pushNode (.epsilon next)
+  | .anchor a => nfa.pushNode (.anchor a next)
   | .char c => nfa.pushNode (.char c next)
   | .classes cs => nfa.pushNode (.sparse cs next)
   | .group index r =>

--- a/regex/Regex/NFA/Compile/Lemmas.lean
+++ b/regex/Regex/NFA/Compile/Lemmas.lean
@@ -7,6 +7,7 @@ theorem pushRegex_size_lt {nfa : NFA} {next e} :
   induction e generalizing nfa next with
   | empty => simp [pushRegex]
   | epsilon => simp [pushRegex]
+  | anchor a => simp [pushRegex]
   | char => simp [pushRegex]
   | classes => simp [pushRegex]
   | group tag e ih =>

--- a/regex/Regex/NFA/Compile/ProofData/Basic.lean
+++ b/regex/Regex/NFA/Compile/ProofData/Basic.lean
@@ -113,20 +113,20 @@ theorem get (i : Nat) (h : i < nfa'.nodes.size) :
 end Epsilon
 
 class Anchor extends ProofData where
-  a : Data.Anchor
-  expr_eq : e = .anchor a
+  anchor : Data.Anchor
+  expr_eq : e = .anchor anchor
 
 namespace Anchor
 
-def intro {nfa next a result} (_ : NFA.pushRegex nfa next (.anchor a) = result) : Anchor :=
-  { nfa, next, e := .anchor a, a, expr_eq := rfl }
+def intro {nfa next anchor result} (_ : NFA.pushRegex nfa next (.anchor anchor) = result) : Anchor :=
+  { nfa, next, e := .anchor anchor, anchor, expr_eq := rfl }
 
-def intro' (nfa : NFA) (next : Nat) (a : Data.Anchor) : Anchor :=
-  { nfa, next, e := .anchor a, a, expr_eq := rfl }
+def intro' (nfa : NFA) (next : Nat) (anchor : Data.Anchor) : Anchor :=
+  { nfa, next, e := .anchor anchor, anchor, expr_eq := rfl }
 
 variable [Anchor]
 
-theorem eq' : nfa' = nfa.pushRegex next (.anchor a) := by
+theorem eq' : nfa' = nfa.pushRegex next (.anchor anchor) := by
   simp [nfa', expr_eq]
 
 theorem start_eq : nfa'.start = nfa.nodes.size := by
@@ -138,12 +138,12 @@ theorem size_eq : nfa'.nodes.size = nfa.nodes.size + 1 := by
 theorem get_lt {i : Nat} (h : i < nfa.nodes.size) : nfa'[i]'(Nat.lt_trans h size_lt) = nfa[i] := by
   simp [eq', pushRegex, pushNode_get_lt i h]
 
-theorem get_eq : nfa'[nfa.nodes.size]'size_lt = .anchor a next := by
+theorem get_eq : nfa'[nfa.nodes.size]'size_lt = .anchor anchor next := by
   simp [eq', pushRegex]
 
 theorem get (i : Nat) (h : i < nfa'.nodes.size) :
   if _ : i < nfa.nodes.size then nfa'[i] = nfa[i]
-  else nfa'[i] = .anchor a next := by
+  else nfa'[i] = .anchor anchor next := by
   split
   case isTrue => exact get_lt _
   case isFalse h' =>

--- a/regex/Regex/NFA/Compile/ProofData/Basic.lean
+++ b/regex/Regex/NFA/Compile/ProofData/Basic.lean
@@ -112,6 +112,48 @@ theorem get (i : Nat) (h : i < nfa'.nodes.size) :
 
 end Epsilon
 
+class Anchor extends ProofData where
+  a : Data.Anchor
+  expr_eq : e = .anchor a
+
+namespace Anchor
+
+def intro {nfa next a result} (_ : NFA.pushRegex nfa next (.anchor a) = result) : Anchor :=
+  { nfa, next, e := .anchor a, a, expr_eq := rfl }
+
+def intro' (nfa : NFA) (next : Nat) (a : Data.Anchor) : Anchor :=
+  { nfa, next, e := .anchor a, a, expr_eq := rfl }
+
+variable [Anchor]
+
+theorem eq' : nfa' = nfa.pushRegex next (.anchor a) := by
+  simp [nfa', expr_eq]
+
+theorem start_eq : nfa'.start = nfa.nodes.size := by
+  simp [eq', pushRegex]
+
+theorem size_eq : nfa'.nodes.size = nfa.nodes.size + 1 := by
+  simp [eq', pushRegex]
+
+theorem get_lt {i : Nat} (h : i < nfa.nodes.size) : nfa'[i]'(Nat.lt_trans h size_lt) = nfa[i] := by
+  simp [eq', pushRegex, pushNode_get_lt i h]
+
+theorem get_eq : nfa'[nfa.nodes.size]'size_lt = .anchor a next := by
+  simp [eq', pushRegex]
+
+theorem get (i : Nat) (h : i < nfa'.nodes.size) :
+  if _ : i < nfa.nodes.size then nfa'[i] = nfa[i]
+  else nfa'[i] = .anchor a next := by
+  split
+  case isTrue => exact get_lt _
+  case isFalse h' =>
+    have : i = nfa.nodes.size := by
+      simp [size_eq] at h
+      omega
+    simp [this, get_eq]
+
+end Anchor
+
 class Char extends ProofData where
   c : _root_.Char
   expr_eq : e = .char c

--- a/regex/Regex/NFA/Compile/ProofData/Lemmas.lean
+++ b/regex/Regex/NFA/Compile/ProofData/Lemmas.lean
@@ -35,6 +35,10 @@ theorem pushRegex_wf {nfa : NFA} {next e}
     simp [pushRegex]
     apply pushNode_wf wf
     exact Nat.lt_trans next_lt (by omega)
+  | anchor a =>
+    simp [pushRegex]
+    apply pushNode_wf wf
+    exact Nat.lt_trans next_lt (by omega)
   | char c =>
     simp [pushRegex]
     apply pushNode_wf wf

--- a/regex/Regex/Regex/Elab.lean
+++ b/regex/Regex/Regex/Elab.lean
@@ -1,7 +1,7 @@
 import Regex.Regex.Basic
 import Lean
 
-open Regex.Data (PerlClassKind PerlClass Class Classes)
+open Regex.Data (Anchor PerlClassKind PerlClass Class Classes)
 open Regex NFA Node
 open Lean Syntax Elab Term
 
@@ -14,6 +14,12 @@ namespace Regex.Elab
 private def mkDecidableProof (prop : Expr) (inst : Expr) : Expr :=
   let refl := mkApp2 (mkConst ``Eq.refl [1]) (mkConst ``Bool) (mkConst ``true)
   mkApp3 (mkConst ``of_decide_eq_true) prop inst refl
+
+instance : ToExpr Anchor where
+  toTypeExpr := mkConst ``Anchor
+  toExpr
+    | .start => mkConst ``Anchor.start
+    | .eos => mkConst ``Anchor.eos
 
 instance : ToExpr PerlClassKind where
   toTypeExpr := mkConst ``PerlClassKind
@@ -51,6 +57,7 @@ instance : ToExpr Node where
     | .done => mkConst ``Node.done
     | .fail => mkConst ``Node.fail
     | .epsilon next => .app (mkConst ``Node.epsilon) (toExpr next)
+    | .anchor a next => mkApp2 (mkConst ``Node.anchor) (toExpr a) (toExpr next)
     | .char c next => mkApp2 (mkConst ``Node.char) (toExpr c) (toExpr next)
     | .sparse cs next => mkApp2 (mkConst ``Node.sparse) (toExpr cs) (toExpr next)
     | .split next₁ next₂ => mkApp2 (mkConst ``Node.split) (toExpr next₁) (toExpr next₂)

--- a/regex/Regex/Syntax/Ast.lean
+++ b/regex/Regex/Syntax/Ast.lean
@@ -1,13 +1,17 @@
+import Regex.Data.Anchor
 import Regex.Data.Classes
 import Regex.Data.Expr
 
-open Regex.Data (Class Classes PerlClass Expr)
+set_option autoImplicit false
+
+open Regex.Data (Anchor Class Classes PerlClass Expr)
 
 namespace Regex.Syntax.Parser
 
 inductive Ast : Type where
   | empty : Ast
   | epsilon : Ast
+  | anchor : Anchor → Ast
   | char : Char → Ast
   | group : Ast → Ast
   | alternate : Ast → Ast → Ast
@@ -22,6 +26,7 @@ def Ast.toRegexAux (index : Nat) (ast : Ast) : Nat × Expr :=
   match ast with
   | .empty => (index, .empty)
   | .epsilon => (index, .epsilon)
+  | .anchor a => (index, .anchor a)
   | .char c => (index, .char c)
   | .group h =>
     let (index', r) := h.toRegexAux (index + 1)

--- a/regex/Regex/Syntax/Parser/Test.lean
+++ b/regex/Regex/Syntax/Parser/Test.lean
@@ -23,6 +23,10 @@ local instance : DecidableEq (Except Error Ast) := decEq
 #guard parseAst "(a)" = .ok (.group (.char 'a'))
 #guard parseAst "(?:a)" = .ok (.char 'a')
 
+#guard parseAst "^" = .ok (.anchor .start)
+#guard parseAst "$" = .ok (.anchor .eos)
+#guard parseAst "^abc$" = .ok (.concat (.concat (.concat (.concat (.anchor .start) (.char 'a')) (.char 'b')) (.char 'c')) (.anchor .eos))
+
 #guard parseAst "[abc]" = .ok (.classes ⟨false, #[.single 'a', .single 'b', .single 'c']⟩)
 #guard parseAst "[^abc]" = .ok (.classes ⟨true, #[.single 'a', .single 'b', .single 'c']⟩)
 #guard parseAst "[a-z]" = .ok (.classes ⟨false, #[.range 'a' 'z' (by decide)]⟩)

--- a/regex/Regex/VM/Basic.lean
+++ b/regex/Regex/VM/Basic.lean
@@ -48,6 +48,12 @@ def εClosure {bufferSize : Nat} (nfa : NFA) (wf : nfa.WellFormed) (it : Iterato
         | .epsilon state' =>
           have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
           εClosure nfa wf it matched ⟨states', updates⟩ ((update, ⟨state', isLt⟩) :: stack')
+        | .anchor a state' =>
+          have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
+          if a.test it then
+            εClosure nfa wf it matched ⟨states', updates⟩ ((update, ⟨state', isLt⟩) :: stack')
+          else
+            εClosure nfa wf it matched ⟨states', updates⟩ stack'
         | .split state₁ state₂ =>
           have isLt : state₁ < nfa.nodes.size ∧ state₂ < nfa.nodes.size := wf.inBounds' state hn
           εClosure nfa wf it matched ⟨states', updates⟩ ((update, ⟨state₁, isLt.1⟩) :: (update, ⟨state₂, isLt.2⟩):: stack')


### PR DESCRIPTION
Lean takes too much memory when type checking `εClosure'.induct'`. Blocked by https://github.com/leanprover/lean4/issues/6753.