### PR TITLE
Fix priority

### DIFF
--- a/correctness/RegexCorrectness/VM/CharStep/Basic.lean
+++ b/correctness/RegexCorrectness/VM/CharStep/Basic.lean
@@ -46,28 +46,33 @@ theorem stepChar_not_char_sparse {σ nfa wf it currentUpdates next state}
   unfold stepChar
   split <;> simp_all
 
+set_option linter.unusedVariables false in
 theorem eachStepChar.go.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator) (current : SearchState σ nfa)
   (motive : (i : Nat) → i ≤ current.states.count → SearchState σ nfa → Prop)
   (base : ∀ next, motive current.states.count (Nat.le_refl _) next)
-  (found : ∀ i hlt next matched next',
+  (done : ∀ i hlt next (hn : nfa[current.states[i]] = .done), motive i (Nat.le_of_lt hlt) next)
+  (found : ∀ i hlt next (hn : nfa[current.states[i]] ≠ .done) matched next',
     stepChar σ nfa wf it current.updates next current.states[i] = (matched, next') →
     matched.isSome → motive i (Nat.le_of_lt hlt) next)
-  (not_found : ∀ i hlt next matched next',
+  (not_found : ∀ i hlt next (hn : nfa[current.states[i]] ≠ .done) matched next',
     stepChar σ nfa wf it current.updates next current.states[i] = (matched, next') →
     ¬matched.isSome → motive (i + 1) (by omega) next' →
     motive i (Nat.le_of_lt hlt) next)
   (i : Nat) (hle : i ≤ current.states.count) (next : SearchState σ nfa) :
   motive i hle next := by
-  refine eachStepChar.go.induct σ nfa wf it current motive ?base ?found ?not_found i hle next
+  refine eachStepChar.go.induct σ nfa wf it current motive ?base ?done ?found ?not_found i hle next
   case base =>
     intro next _
     exact base next
+  case done =>
+    intro i _ next _ hlt state hn
+    exact done i hlt next hn
   case found =>
-    intro i _ next _ hlt result isSome
-    exact found i hlt next result.1 result.2 rfl isSome
+    intro i _ next _ hlt state hn result isSome
+    exact found i hlt next hn result.1 result.2 rfl isSome
   case not_found =>
-    intro i _ next _ hlt result notSome ih
-    exact not_found i hlt next result.1 result.2 rfl (by simp [notSome]) ih
+    intro i _ next _ hlt state hn result notSome ih
+    exact not_found i hlt next hn result.1 result.2 rfl (by simp [notSome]) ih
 
 @[simp]
 theorem eachStepChar.go_base {σ nfa wf it current next} :
@@ -75,21 +80,32 @@ theorem eachStepChar.go_base {σ nfa wf it current next} :
   simp [eachStepChar.go]
 
 @[simp]
+theorem eachStepChar.go_done {σ nfa wf it current i next}
+  (hlt : i < current.states.count)
+  (hn : nfa[current.states[i]] = .done) :
+  eachStepChar.go σ nfa wf it current i (Nat.le_of_lt hlt) next = (.none, next) := by
+  unfold eachStepChar.go
+  simp [Nat.ne_of_lt hlt, hn]
+
+@[simp]
 theorem eachStepChar.go_found {σ nfa wf it current i next next' matched}
   (hlt : i < current.states.count)
+  (hn : nfa[current.states[i]] ≠ .done)
   (h : stepChar σ nfa wf it current.updates next current.states[i] = (matched, next')) (found : matched.isSome) :
   eachStepChar.go σ nfa wf it current i (Nat.le_of_lt hlt) next = (matched, next') := by
   unfold eachStepChar.go
-  simp [Nat.ne_of_lt hlt, h, found]
+  simp_all [Nat.ne_of_lt hlt]
 
 @[simp]
 theorem eachStepChar.go_not_found {σ nfa wf it current i next next' matched}
   (hlt : i < current.states.count)
+  (hn : nfa[current.states[i]] ≠ .done)
   (h : stepChar σ nfa wf it current.updates next current.states[i] = (matched, next')) (not_found : ¬matched.isSome) :
   eachStepChar.go σ nfa wf it current i (Nat.le_of_lt hlt) next = eachStepChar.go σ nfa wf it current (i + 1) (by omega) next' := by
+  simp at hn
   conv =>
     lhs
     unfold eachStepChar.go
-    simp [Nat.ne_of_lt hlt, h, not_found]
+    simp [Nat.ne_of_lt hlt, hn, h, not_found]
 
 end Regex.VM

--- a/correctness/RegexCorrectness/VM/CharStep/Lemmas.lean
+++ b/correctness/RegexCorrectness/VM/CharStep/Lemmas.lean
@@ -153,12 +153,13 @@ theorem eachStepChar.go.lower_bound {idx hle} (h : eachStepChar.go HistoryStrate
   εClosure.LowerBound it.next next'.states := by
   induction idx, hle, next using eachStepChar.go.induct' HistoryStrategy nfa wf it current with
   | base next => simp_all
-  | found i hlt next matched next'' h' found =>
-    rw [eachStepChar.go_found hlt h' found] at h
+  | done i hlt next hn => simp_all
+  | found i hlt next hn matched next'' h' found =>
+    rw [eachStepChar.go_found hlt hn h' found] at h
     simp_all
     exact stepChar.lower_bound h' lb
-  | not_found i hlt next matched next'' h' not_found ih =>
-    rw [eachStepChar.go_not_found hlt h' not_found] at h
+  | not_found i hlt next hn matched next'' h' not_found ih =>
+    rw [eachStepChar.go_not_found hlt hn h' not_found] at h
     exact ih h (stepChar.lower_bound h' lb)
 
 theorem eachStepChar.go.done_of_matched_some {idx hle} (h : eachStepChar.go HistoryStrategy nfa wf it current idx hle next = (matched', next'))
@@ -168,13 +169,16 @@ theorem eachStepChar.go.done_of_matched_some {idx hle} (h : eachStepChar.go Hist
   | base next =>
     simp at h
     simp [←h.1] at isSome'
-  | found i hl next matched next'' h' found =>
-    rw [eachStepChar.go_found hl h' found] at h
+  | done i hlt next hn =>
+    simp [hlt, hn] at h
+    simp [←h.1] at isSome'
+  | found i hlt next hn matched next'' h' found =>
+    rw [eachStepChar.go_found hlt hn h' found] at h
     simp at h
     simp [h] at h'
     exact stepChar.done_of_matched_some h' isSome'
-  | not_found i hl next matched next'' h' not_found ih =>
-    rw [eachStepChar.go_not_found hl h' not_found] at h
+  | not_found i hlt next hn matched next'' h' not_found ih =>
+    rw [eachStepChar.go_not_found hlt hn h' not_found] at h
     exact ih h
 
 theorem eachStepChar.done_of_matched_some (h : eachStepChar HistoryStrategy nfa wf it current next = (matched', next'))
@@ -209,12 +213,13 @@ theorem eachStepChar.go.inv {idx hle} (h : eachStepChar.go HistoryStrategy nfa w
   next'.Inv nfa wf it.next := by
   induction idx, hle, next using eachStepChar.go.induct' HistoryStrategy nfa wf it current with
   | base next => simp_all
-  | found idx hlt next matched next'' h' found =>
-    rw [eachStepChar.go_found hlt h' found] at h
+  | done i hlt next hn => simp_all
+  | found idx hlt next hn matched next'' h' found =>
+    rw [eachStepChar.go_found hlt hn h' found] at h
     simp_all
     exact eachStepChar.inv_of_stepChar hlt h' (by simp [notEnd]) inv_curr inv_next
-  | not_found idx hlt next matched next'' h' not_found ih =>
-    rw [eachStepChar.go_not_found hlt h' not_found] at h
+  | not_found idx hlt next hn matched next'' h' not_found ih =>
+    rw [eachStepChar.go_not_found hlt hn h' not_found] at h
     have inv' : next''.Inv nfa wf it.next :=
       eachStepChar.inv_of_stepChar hlt h' (by simp [notEnd]) inv_curr inv_next
     apply ih h inv'

--- a/correctness/RegexCorrectness/VM/Correspondence/Refinement/Refinement.lean
+++ b/correctness/RegexCorrectness/VM/Correspondence/Refinement/Refinement.lean
@@ -257,7 +257,14 @@ theorem eachStepChar.go.refines {current current' i hle hle' result result'}
     simp at h'
     simp [refCurrent.1] at h
     simp [←h', ←h, refineUpdateOpt, refNext]
-  | found i hlt' next' matched' next'' hstep' isSome' =>
+  | done i hlt' next' hn =>
+    have hlt : i < current.states.count := refCurrent.1 ▸ hlt'
+    have eq : current.states[i] = current'.states[i] := by
+      simp [refCurrent.1]
+    simp [hlt', hn] at h'
+    simp [hlt, eq ▸ hn] at h
+    simp [←h', ←h, refineUpdateOpt, refNext]
+  | found i hlt' next' hn matched' next'' hstep' isSome' =>
     have hlt : i < current.states.count := refCurrent.1 ▸ hlt'
     have eq : current.states[i] = current'.states[i] := by
       simp [refCurrent.1]
@@ -267,10 +274,10 @@ theorem eachStepChar.go.refines {current current' i hle hle' result result'}
     have isSome : stepped.1.isSome := by
       simp [refineUpdateOpt.isSome_iff refStepChar.1] at isSome'
       exact isSome'
-    rw [eachStepChar.go_found hlt' hstep' isSome'] at h'
-    rw [eachStepChar.go_found hlt hstep isSome] at h
+    rw [eachStepChar.go_found hlt' hn hstep' isSome'] at h'
+    rw [eachStepChar.go_found hlt (eq ▸ hn) hstep isSome] at h
     simp [←h', ←h, refStepChar]
-  | not_found i hlt' next' matched' next'' hstep' isSome' ih =>
+  | not_found i hlt' next' hn matched' next'' hstep' isSome' ih =>
     have hlt : i < current.states.count := refCurrent.1 ▸ hlt'
     have eq : current.states[i] = current'.states[i] := by
       simp [refCurrent.1]
@@ -280,8 +287,8 @@ theorem eachStepChar.go.refines {current current' i hle hle' result result'}
     have isSome : ¬stepped.1.isSome := by
       rw [refineUpdateOpt.isSome_iff refStepChar.1] at isSome'
       exact isSome'
-    rw [eachStepChar.go_not_found hlt' hstep' isSome'] at h'
-    rw [eachStepChar.go_not_found hlt hstep isSome] at h
+    rw [eachStepChar.go_not_found hlt' hn hstep' isSome'] at h'
+    rw [eachStepChar.go_not_found hlt (eq ▸ hn) hstep isSome] at h
     exact ih h h' refCurrent refStepChar.2
 
 theorem eachStepChar.refines {current current' result result'}

--- a/regex/Regex/NFA/Basic.lean
+++ b/regex/Regex/NFA/Basic.lean
@@ -15,7 +15,7 @@ inductive Node where
   | save (offset : Nat) (next : Nat)
   -- TODO: use an efficient representation
   | sparse (cs : Regex.Data.Classes) (next : Nat)
-deriving Repr
+deriving Repr, DecidableEq
 
 def Node.inBounds (n : Node) (size : Nat) : Prop :=
   match n with
@@ -121,7 +121,7 @@ namespace Regex
 structure NFA where
   nodes : Array NFA.Node
   start : Nat
-deriving Repr
+deriving Repr, DecidableEq
 
 instance : ToString NFA where
   toString nfa := reprStr nfa

--- a/regex/tests/Test.lean
+++ b/regex/tests/Test.lean
@@ -16,8 +16,10 @@ namespace Priority
 def re := Regex.parse! r##"bool|boolean"##
 #guard re.find "boolean" = .some (⟨0⟩, ⟨4⟩)
 
--- BUG: we don't handle empty matches correctly.
--- def re' := Regex.parse! r##"|x"##
--- #guard re'.find "x" = .some (⟨0⟩, ⟨0⟩)
+def re' := Regex.parse! r##"|x"##
+#guard re'.find "x" = .some (⟨0⟩, ⟨0⟩)
+
+def re'' := Regex.parse! r##"x|"##
+#guard re''.find "x" = .some (⟨0⟩, ⟨1⟩)
 
 end Priority


### PR DESCRIPTION
The VM traversal didn't implement the greedy selection correctly. It was possible that states that appear after the `.done` node (in SparseSet) can override the matches found previously, which means that matches with a lower priority can overwrite a match with a higher priority.

The PR adds a missing early termination in `eachCharStep` so that it stops the iteration once it finds a `.done` node in SparseSet.