### PR TITLE
Bounded backtracker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
         - name: Run CorpusTest
           run: |
             cd regex
-            lake exe CorpusTest --verify
+            time lake exe CorpusTest --verify
+            time lake exe CorpusTest --verify --backtracker
         - name: Build RegexCorrectness
           uses: leanprover/lean-action@v1
           with:

--- a/correctness/RegexCorrectness/Regex/Basic.lean
+++ b/correctness/RegexCorrectness/Regex/Basic.lean
@@ -54,7 +54,7 @@ theorem le_maxTag {re : Regex} (s : IsSearchRegex re) : 1 ≤ re.maxTag := by
   apply NFA.lt_of_mem_tags_compile s.nfa_eq.symm
   simp [expr, Expr.tags]
 
-theorem captures_of_captureNext {re bufferSize it matched} (h : VM.captureNext (VM.BufferStrategy bufferSize) re.nfa re.wf it = .some matched)
+theorem captures_of_captureNext {re bufferSize it matched} (h : VM.captureNext (BufferStrategy bufferSize) re.nfa re.wf it = .some matched)
   (s : IsSearchRegex re) (v : it.Valid) (le : 2 ≤ bufferSize) :
   ∃ l m r groups,
     it.toString = ⟨l ++ m ++ r⟩ ∧
@@ -90,7 +90,7 @@ theorem searchNext_some {re it first last} (h : VM.searchNext re.nfa re.wf it = 
   | none => simp at h
   | some matched =>
     have ⟨l, m, r, groups, eqstring, c, eqv, eq₁, eq₂⟩ := captures_of_captureNext h' s v (Nat.le_refl _)
-    simp [VM.BufferStrategy] at eq₁ eq₂
+    simp [BufferStrategy] at eq₁ eq₂
     simp [eq₁, eq₂] at h
     exact ⟨l, m, r, groups, eqstring, c, by simp [←h]⟩
 

--- a/correctness/RegexCorrectness/Regex/Captures.lean
+++ b/correctness/RegexCorrectness/Regex/Captures.lean
@@ -92,7 +92,7 @@ theorem captures_of_next?_some {self self' : Captures} {captured} (h : self.next
         simp [hcaptured 0]
         have h₁ := (eqv 0).1 (by omega)
         have h₂ := (eqv 0).2 (by omega)
-        simp [VM.BufferStrategy] at eq₁ eq₂
+        simp [BufferStrategy] at eq₁ eq₂
         simp [eq₁] at h₁
         simp [eq₂] at h₂
         have ⟨_, eq₁⟩ := h₁

--- a/correctness/RegexCorrectness/Regex/Captures.lean
+++ b/correctness/RegexCorrectness/Regex/Captures.lean
@@ -27,11 +27,12 @@ def Valid (self : Captures) : Prop :=
   self.regex.IsSearchRegex ∧ self.currentPos.ValidPlus self.haystack
 
 theorem captures_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self'))
-  (v : self.Valid) :
+  (v : self.Valid) (bt : ¬self.regex.useBacktracker) :
   self'.Valid ∧ captured.Spec v.1 self.haystack := by
   unfold next? at h
   split at h
   next le =>
+    simp [Regex.captureNextBuf, bt] at h
     generalize h' : VM.captureNextBuf self.regex.nfa self.regex.wf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩ = matched at h
     match matched with
     | none => simp at h
@@ -114,12 +115,12 @@ theorem captures_of_next?_some {self self' : Captures} {captured} (h : self.next
         exact ⟨⟨v.1, String.Pos.validPlus_of_next_valid pos_valid⟩, l, m, r, groups, by simp [eqstring], c, captured₀, hcaptured⟩
   next => simp at h
 
-theorem regex_eq_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self')) :
+theorem regex_eq_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self')) (bt : ¬self.regex.useBacktracker) :
   self'.regex = self.regex := by
   unfold next? at h
   split at h
   next =>
-    simp at h
+    simp [Regex.captureNextBuf, bt] at h
     set captured' := VM.captureNextBuf self.regex.nfa self.regex.wf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩
     match h' : captured' with
     | none => simp at h
@@ -138,12 +139,12 @@ theorem regex_eq_of_next?_some {self self' : Captures} {captured} (h : self.next
           simp [←h]
   next => simp at h
 
-theorem haystack_eq_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self')) :
+theorem haystack_eq_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self')) (bt : ¬self.regex.useBacktracker) :
   self'.haystack = self.haystack := by
   unfold next? at h
   split at h
   next =>
-    simp at h
+    simp [Regex.captureNextBuf, bt] at h
     set captured' := VM.captureNextBuf self.regex.nfa self.regex.wf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩
     match h' : captured' with
     | none => simp at h

--- a/correctness/RegexCorrectness/Regex/Matches.lean
+++ b/correctness/RegexCorrectness/Regex/Matches.lean
@@ -26,12 +26,13 @@ def Valid (self : Matches) : Prop :=
   self.regex.IsSearchRegex ∧ self.currentPos.ValidPlus self.haystack
 
 theorem captures_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self'))
-  (v : self.Valid) :
+  (v : self.Valid) (bt : ¬self.regex.useBacktracker) :
   self'.Valid ∧ Spec v.1 self.haystack positions := by
   unfold next? at h
   split at h
   next le =>
     have pos_valid := v.2.valid_of_le le
+    simp [Regex.searchNext, bt] at h
     generalize h' : VM.searchNext self.regex.nfa self.regex.wf ⟨self.haystack, self.currentPos⟩ = matched at h
     match matched with
     | none => simp at h
@@ -54,11 +55,12 @@ theorem captures_of_next?_some {self self' : Matches} {positions} (h : self.next
         exact ⟨⟨v.1, String.Pos.validPlus_of_next_valid pos_valid⟩, l, m, r, groups, by simp [eqstring], c, eq₁, eq₂⟩
   next => simp at h
 
-theorem regex_eq_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self')) :
+theorem regex_eq_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self')) (bt : ¬self.regex.useBacktracker) :
   self'.regex = self.regex := by
   unfold next? at h
   split at h
   next =>
+    simp [Regex.searchNext, bt] at h
     set matched := VM.searchNext self.regex.nfa self.regex.wf ⟨self.haystack, self.currentPos⟩
     match h' : matched with
     | none => simp at h
@@ -67,11 +69,12 @@ theorem regex_eq_of_next?_some {self self' : Matches} {positions} (h : self.next
       split at h <;> simp at h <;> simp [←h]
   next => simp at h
 
-theorem haystack_eq_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self')) :
+theorem haystack_eq_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self')) (bt : ¬self.regex.useBacktracker) :
   self'.haystack = self.haystack := by
   unfold next? at h
   split at h
   next =>
+    simp [Regex.searchNext, bt] at h
     set matched := VM.searchNext self.regex.nfa self.regex.wf ⟨self.haystack, self.currentPos⟩
     match h' : matched with
     | none => simp at h

--- a/correctness/RegexCorrectness/Regex/Utilities.lean
+++ b/correctness/RegexCorrectness/Regex/Utilities.lean
@@ -11,31 +11,31 @@ namespace Regex
 variable {re : Regex} {haystack : String}
 
 theorem captures_of_find_some {positions} (h : re.find haystack = .some positions)
-  (s : re.IsSearchRegex) :
+  (s : re.IsSearchRegex) (bt : ¬re.useBacktracker) :
   Matches.Spec s haystack positions := by
   simp [Regex.find] at h
   have ⟨_, h⟩ := h
   have v := Captures.valid_captures haystack s
-  exact (Matches.captures_of_next?_some h v).2
+  exact (Matches.captures_of_next?_some h v bt).2
 
 theorem captures_of_mem_findAll.go {m : Matches} {accum : Array (Pos × Pos)}
-  (v : m.Valid) (inv : ∀ positions ∈ accum, Matches.Spec v.1 m.haystack positions) :
+  (v : m.Valid) (bt : ¬m.regex.useBacktracker) (inv : ∀ positions ∈ accum, Matches.Spec v.1 m.haystack positions) :
   ∀ positions ∈ findAll.go m accum, Matches.Spec v.1 m.haystack positions := by
   induction m, accum using findAll.go.induct with
   | case1 m accum positions m' next_some? ih =>
     -- next match is found
     rw [findAll.go, next_some?]
     simp
-    have regex_eq := Matches.regex_eq_of_next?_some next_some?
-    have haystack_eq := Matches.haystack_eq_of_next?_some next_some?
+    have regex_eq := Matches.regex_eq_of_next?_some next_some? bt
+    have haystack_eq := Matches.haystack_eq_of_next?_some next_some? bt
     simp [regex_eq, haystack_eq] at ih
 
-    have ⟨v', spec⟩ := Matches.captures_of_next?_some next_some? v
+    have ⟨v', spec⟩ := Matches.captures_of_next?_some next_some? v bt
     have inv' (p₁ p₂ : Pos) (mem : (p₁, p₂) ∈ accum ∨ (p₁, p₂) = positions) : Matches.Spec v.1 m.haystack (p₁, p₂) := by
       cases mem with
       | inl mem => exact inv (p₁, p₂) mem
       | inr eq => exact eq ▸ spec
-    exact ih v' inv'
+    exact ih v' (by simp [bt]) inv'
   | case2 m accum next_none? =>
     -- next match is not found
     rw [findAll.go, next_none?]
@@ -43,38 +43,38 @@ theorem captures_of_mem_findAll.go {m : Matches} {accum : Array (Pos × Pos)}
     exact inv
 
 theorem captures_of_mem_findAll {positions} (mem : positions ∈ re.findAll haystack)
-  (s : re.IsSearchRegex) :
+  (s : re.IsSearchRegex) (bt : ¬re.useBacktracker) :
   Matches.Spec s haystack positions := by
   simp [Regex.findAll] at mem
   have v := Matches.vaild_matches haystack s
-  exact captures_of_mem_findAll.go v (by simp) positions mem
+  exact captures_of_mem_findAll.go v bt (by simp) positions mem
 
 theorem captures_of_capture_some {captured} (h : re.capture haystack = .some captured)
-  (s : re.IsSearchRegex) :
+  (s : re.IsSearchRegex) (bt : ¬re.useBacktracker) :
   captured.Spec s haystack := by
   simp [Regex.capture] at h
   have ⟨_, h⟩ := h
   have v := Captures.valid_captures haystack s
-  exact (Captures.captures_of_next?_some h v).2
+  exact (Captures.captures_of_next?_some h v bt).2
 
 theorem captures_of_mem_captureAll.go {captures : Captures} {accum : Array CapturedGroups}
-  (v : captures.Valid) (inv : ∀ captured ∈ accum, captured.Spec v.1 captures.haystack) :
+  (v : captures.Valid) (bt : ¬captures.regex.useBacktracker) (inv : ∀ captured ∈ accum, captured.Spec v.1 captures.haystack) :
   ∀ captured ∈ captureAll.go captures accum, captured.Spec v.1 captures.haystack := by
   induction captures, accum using captureAll.go.induct with
   | case1 captures accum groups captures' next?_some ih =>
     -- next capture is found
     rw [captureAll.go, next?_some]
     simp
-    have regex_eq := Captures.regex_eq_of_next?_some next?_some
-    have haystack_eq := Captures.haystack_eq_of_next?_some next?_some
+    have regex_eq := Captures.regex_eq_of_next?_some next?_some bt
+    have haystack_eq := Captures.haystack_eq_of_next?_some next?_some bt
     simp [regex_eq, haystack_eq] at ih
 
-    have ⟨v', spec⟩ := Captures.captures_of_next?_some next?_some v
+    have ⟨v', spec⟩ := Captures.captures_of_next?_some next?_some v bt
     have inv' (captured : CapturedGroups) (mem : captured ∈ accum ∨ captured = groups) : captured.Spec v.1 captures.haystack := by
       cases mem with
       | inl mem => exact inv captured mem
       | inr eq => exact eq ▸ spec
-    exact ih v' inv'
+    exact ih v' (by simp [bt]) inv'
   | case2 captures accum next?_none =>
     -- next capture is not found
     rw [captureAll.go, next?_none]
@@ -82,10 +82,10 @@ theorem captures_of_mem_captureAll.go {captures : Captures} {accum : Array Captu
     exact inv
 
 theorem captures_of_mem_captureAll {captured} (mem : captured ∈ re.captureAll haystack)
-  (s : re.IsSearchRegex) :
+  (s : re.IsSearchRegex) (bt : ¬re.useBacktracker) :
   captured.Spec s haystack := by
   simp [Regex.captureAll] at mem
   have v := Captures.valid_captures haystack s
-  exact captures_of_mem_captureAll.go v (by simp) captured mem
+  exact captures_of_mem_captureAll.go v bt (by simp) captured mem
 
 end Regex

--- a/correctness/RegexCorrectness/VM/EpsilonClosure/Basic.lean
+++ b/correctness/RegexCorrectness/VM/EpsilonClosure/Basic.lean
@@ -1,7 +1,6 @@
 import Regex.Data.SparseSet
 import Regex.NFA.Basic
 import Regex.VM
-import Regex.VM.Strategy
 import RegexCorrectness.VM.Path
 
 set_option autoImplicit false

--- a/correctness/RegexCorrectness/VM/Path/VMPath.lean
+++ b/correctness/RegexCorrectness/VM/Path/VMPath.lean
@@ -1,5 +1,5 @@
 import Regex.Data.SparseSet
-import Regex.VM.Strategy
+import Regex.VM
 import RegexCorrectness.VM.Path.EpsilonClosure
 import RegexCorrectness.VM.Path.CharStep
 

--- a/regex/Regex/Backtracker.lean
+++ b/regex/Regex/Backtracker.lean
@@ -1,0 +1,1 @@
+import Regex.Backtracker.Basic

--- a/regex/Regex/Backtracker/Basic.lean
+++ b/regex/Regex/Backtracker/Basic.lean
@@ -1,0 +1,112 @@
+import Regex.Data.String
+import Regex.NFA
+import Regex.Strategy
+import Regex.Backtracker.BitMatrix
+
+open String (Iterator)
+
+set_option autoImplicit false
+
+namespace Regex.Backtracker
+
+structure BoundedIterator (startIdx : Nat) where
+  it : Iterator
+  ge : startIdx ≤ it.pos.byteIdx
+  le : it.pos ≤ it.toString.endPos
+
+namespace BoundedIterator
+
+def maxIdx {startIdx : Nat} (bit : BoundedIterator startIdx) : Nat := bit.it.toString.endPos.byteIdx
+
+def pos {startIdx : Nat} (bit : BoundedIterator startIdx) : String.Pos := bit.it.pos
+
+def index {startIdx : Nat} (bit : BoundedIterator startIdx) : Fin (bit.maxIdx + 1 - startIdx) :=
+  have lt : bit.it.pos.byteIdx - startIdx < bit.maxIdx + 1 - startIdx := by
+    exact Nat.sub_lt_sub_right bit.ge (Nat.lt_of_le_of_lt bit.le (Nat.lt_succ_self _))
+  ⟨bit.it.pos.byteIdx - startIdx, lt⟩
+
+def hasNext {startIdx : Nat} (bit : BoundedIterator startIdx) : Bool := bit.it.hasNext
+
+def next {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : BoundedIterator startIdx :=
+  let it' := bit.it.next' h
+  have ge' : startIdx ≤ it'.pos.byteIdx := Nat.le_of_lt (Nat.lt_of_le_of_lt bit.ge bit.it.lt_next)
+  have le' : it'.pos ≤ it'.toString.endPos := bit.it.next_le_endPos h
+  ⟨it', ge', le'⟩
+
+def curr {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : Char := bit.it.curr' h
+
+theorem next_maxIdx {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : (bit.next h).maxIdx = bit.maxIdx := rfl
+
+end BoundedIterator
+
+structure StackEntry (σ : Strategy) (nfa : NFA) (startIdx maxIdx : Nat) where
+  update : σ.Update
+  state : Fin nfa.nodes.size
+  it : BoundedIterator startIdx
+  eq : it.maxIdx = maxIdx
+
+def captureNextAux (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (startIdx maxIdx : Nat)
+  (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (stack : List (StackEntry σ nfa startIdx maxIdx)) :
+  (Option σ.Update × BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) :=
+  match stack with
+  | [] => (.none, visited)
+  | ⟨update, state, it, eq⟩ :: stack' =>
+    if h : visited.get state (it.index.cast (by simp [eq])) then
+      captureNextAux σ nfa wf startIdx maxIdx visited stack'
+    else
+      let visited' := visited.set state (it.index.cast (by simp [eq]))
+      have : nfa.nodes.size * (maxIdx + 1 - startIdx) + 1 - visited'.popcount < nfa.nodes.size * (maxIdx + 1 - startIdx) + 1 - visited.popcount :=
+        BitMatrix.popcount_decreasing visited state (it.index.cast (by simp [eq])) h
+      match hn : nfa[state] with
+      | .done => (.some update, visited')
+      | .fail => (.none, visited')
+      | .epsilon state' =>
+        have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
+        captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it, eq⟩ :: stack')
+      | .split state₁ state₂ =>
+        have isLt : state₁ < nfa.nodes.size ∧ state₂ < nfa.nodes.size := wf.inBounds' state hn
+        captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state₁, isLt.1⟩, it, eq⟩ :: ⟨update, ⟨state₂, isLt.2⟩, it, eq⟩ :: stack')
+      | .save offset state' =>
+        have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
+        let update' := σ.write update offset it.pos
+        captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update', ⟨state', isLt⟩, it, eq⟩ :: stack')
+      | .anchor a state' =>
+        have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
+        if a.test it.it then
+          captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it, eq⟩ :: stack')
+        else
+          captureNextAux σ nfa wf startIdx maxIdx visited' stack'
+      | .char c state' =>
+        have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
+        if h : it.hasNext then
+          if c = it.curr h then
+            captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it.next h, eq ▸ it.next_maxIdx h⟩ :: stack')
+          else
+            captureNextAux σ nfa wf startIdx maxIdx visited' stack'
+        else
+          captureNextAux σ nfa wf startIdx maxIdx visited' stack'
+      | .sparse cs state' =>
+        have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
+        if h : it.hasNext then
+          if it.curr h ∈ cs then
+            captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it.next h, eq ▸ it.next_maxIdx h⟩ :: stack')
+          else
+            captureNextAux σ nfa wf startIdx maxIdx visited' stack'
+        else
+          captureNextAux σ nfa wf startIdx maxIdx visited' stack'
+termination_by (nfa.nodes.size * (maxIdx + 1 - startIdx) + 1 - visited.popcount, stack)
+
+def captureNext (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator) : Option σ.Update :=
+  let startIdx := it.pos.byteIdx
+  let maxIdx := it.toString.endPos.byteIdx
+  if le : it.pos ≤ it.toString.endPos then
+    let bit : BoundedIterator startIdx := ⟨it, by omega, le⟩
+    (captureNextAux σ nfa wf startIdx maxIdx (BitMatrix.zero _ _) [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩]).1
+  else
+    .none
+
+def captureNextBuf (nfa : NFA) (wf : nfa.WellFormed) (bufferSize : Nat) (it : Iterator) : Option (Buffer bufferSize) :=
+  let _ := BufferStrategy bufferSize
+  captureNext (BufferStrategy bufferSize) nfa wf it
+
+end Regex.Backtracker

--- a/regex/Regex/Backtracker/Basic.lean
+++ b/regex/Regex/Backtracker/Basic.lean
@@ -3,7 +3,7 @@ import Regex.NFA
 import Regex.Strategy
 import Regex.Backtracker.BitMatrix
 
-open String (Iterator)
+open String (Iterator Pos)
 
 set_option autoImplicit false
 
@@ -120,5 +120,9 @@ where
 def captureNextBuf (nfa : NFA) (wf : nfa.WellFormed) (bufferSize : Nat) (it : Iterator) : Option (Buffer bufferSize) :=
   let _ := BufferStrategy bufferSize
   captureNext (BufferStrategy bufferSize) nfa wf it
+
+def searchNext (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator) : Option (Pos × Pos) := do
+  let slots ← captureNextBuf nfa wf 2 it
+  pure (← slots[0], ← slots[1])
 
 end Regex.Backtracker

--- a/regex/Regex/Backtracker/BitMatrix.lean
+++ b/regex/Regex/Backtracker/BitMatrix.lean
@@ -1,0 +1,38 @@
+import Regex.Data.BitVec
+
+namespace Regex.Backtracker
+
+structure BitMatrix (w h : Nat) where
+  bv : BitVec (w * h)
+deriving Repr
+
+namespace BitMatrix
+
+instance : ToString (BitMatrix w h) := ⟨fun m => toString m.bv⟩
+
+def zero (w h : Nat) : BitMatrix w h := ⟨BitVec.zero _⟩
+
+def index {w h : Nat} (x : Fin w) (y : Fin h) : Fin (w * h) :=
+  have : y.val * w + x.val < w * h := by
+    calc y.val * w + x.val
+      _ < y.val * w + w := by omega
+      _ = (y.val + 1) * w := (Nat.succ_mul _ _).symm
+      _ ≤ h * w := Nat.mul_le_mul_right w (by omega)
+      _ = w * h := Nat.mul_comm _ _
+  ⟨y.val * w + x.val, this⟩
+
+def get (m : BitMatrix w h) (x : Fin w) (y : Fin h) : Bool := m.bv[index x y]
+
+def set (m : BitMatrix w h) (x : Fin w) (y : Fin h) : BitMatrix w h :=
+  ⟨m.bv.set (index x y)⟩
+
+def popcount (m : BitMatrix w h) : Nat := m.bv.popcount
+
+theorem popcount_le {m : BitMatrix w h} : popcount m ≤ w * h := BitVec.popcount_le m.bv
+
+theorem popcount_decreasing (m : BitMatrix w h) (x : Fin w) (y : Fin h) (hget : ¬m.get x y) : w * h + 1 - popcount (m.set x y) < w * h + 1 - popcount m :=
+  BitVec.sub_lt_popcount_set_not_getElem m.bv (index x y).val (index x y).isLt hget
+
+end BitMatrix
+
+end Regex.Backtracker

--- a/regex/Regex/Data/BitVec.lean
+++ b/regex/Regex/Data/BitVec.lean
@@ -1,0 +1,43 @@
+import Regex.Data.Nat
+
+namespace BitVec
+
+def set {w : Nat} (b : BitVec w) (i : Nat) : BitVec w :=
+  if i < w then
+    b ||| (1 <<< i)
+  else
+    b
+
+@[simp]
+theorem set_lt {w : Nat} (b : BitVec w) (i : Nat) (h : i < w) : b.set i = b ||| (1 <<< i) := by
+  simp [set, h]
+
+theorem getElem_set_eq {w : Nat} (b : BitVec w) (i : Nat) (h : i < w) : (b.set i)[i] := by
+  simp [BitVec.ofNat, h]
+
+theorem getElem_set_ne {w : Nat} (b : BitVec w) (i j : Nat) (h : i < w) (h' : j < w) (hne : i ≠ j) : (b.set i)[j] = b[j] := by
+  simp only [set, h, ↓reduceIte, natCast_eq_ofNat, BitVec.ofNat, getElem_or, getElem_ofFin,
+    Fin.val_ofNat', Nat.testBit_mod_two_pow, h', decide_true, Nat.testBit_shiftLeft, ge_iff_le,
+    Bool.true_and, Bool.or_iff_left_iff_imp, Bool.and_eq_true, decide_eq_true_eq, and_imp]
+  intro le test
+  match h'' : j - i with
+  | 0 => omega
+  | n + 1 => simp [h'', Nat.testBit_succ] at test
+
+def popcount {w : Nat} (b : BitVec w) : Nat := b.toNat.popcount
+
+theorem popcount_set_not_getElem {w : Nat} (b : BitVec w) (i : Nat) (h : i < w) (h' : ¬b[i]) : popcount (b.set i) = popcount b + 1 := by
+  conv =>
+    lhs
+    simp [popcount, h, Nat.popcount_or_one_shiftLeft, ←BitVec.getElem_eq_testBit_toNat, h']
+  rfl
+
+theorem popcount_le {w : Nat} (b : BitVec w) : popcount b ≤ w := Nat.popcount_le_of_lt_pow b.isLt
+
+theorem sub_lt_popcount_set_not_getElem {w : Nat} (b : BitVec w) (i : Nat) (h : i < w) (h' : ¬b[i]) : w + 1 - popcount (b.set i) < w + 1 - popcount b := by
+  have : popcount (b.set i) = popcount b + 1 := popcount_set_not_getElem b i h h'
+  rw [this]
+  have : popcount b ≤ w := popcount_le b
+  omega
+
+end BitVec

--- a/regex/Regex/Data/Nat.lean
+++ b/regex/Regex/Data/Nat.lean
@@ -1,0 +1,114 @@
+namespace Nat
+
+def popcount (n : Nat) : Nat :=
+  if n = 0 then
+    0
+  else
+    popcount (n / 2) + n % 2
+
+@[simp]
+theorem popcount_zero : popcount 0 = 0 := by
+  conv =>
+    lhs
+    unfold popcount
+    simp
+
+theorem popcount_ne {n : Nat} (h : n ≠ 0) : popcount n = popcount (n / 2) + n % 2 := by
+  conv =>
+    lhs
+    unfold popcount
+    simp [h]
+
+theorem popcount_odd {n : Nat} (h : n.testBit 0) : popcount n = popcount (n / 2) + 1 := by
+  conv =>
+    lhs
+    unfold popcount
+  split
+  next h' => simp [h'] at h
+  next h' => simp only [Nat.add_left_cancel_iff, mod_two_eq_one_iff_testBit_zero, h]
+
+theorem popcount_even {n : Nat} (h : ¬n.testBit 0) : popcount n = popcount (n / 2) := by
+  conv =>
+    lhs
+    unfold popcount
+  split
+  next h' => simp [h']
+  next h' => simp only [Nat.add_right_eq_self, mod_two_eq_zero_iff_testBit_zero, h]
+
+theorem popcount_le_of_lt_pow {n w : Nat} (h : n < 2 ^ w) : popcount n ≤ w := by
+  induction n using popcount.induct generalizing w with
+  | case1 => simp
+  | case2 n ne ih =>
+    match w with
+    | 0 => simp [ne] at h
+    | w + 1 =>
+      simp [popcount_ne ne]
+      apply Nat.add_le_add (ih (w := w) (Nat.div_lt_of_lt_mul (by omega))) (by omega)
+
+theorem one_shiftLeft_lt_pow {n w : Nat} (h : n < w) : 1 <<< n < 2 ^ w := by
+  rw [one_shiftLeft]
+  exact Nat.pow_lt_pow_of_lt (by omega) h
+
+@[simp]
+theorem one_shiftLeft_mod_two_pow {n w : Nat} (h : n < w) : (1 <<< n) % (2 ^ w) = 1 <<< n :=
+  mod_eq_of_lt (one_shiftLeft_lt_pow h)
+
+theorem zero_of_or_zero {n m : Nat} (h : n ||| m = 0) : n = 0 ∧ m = 0 := by
+  have : ∀ i, (n ||| m).testBit i = false := h ▸ zero_testBit
+  simp at this
+  exact ⟨eq_of_testBit_eq fun i => by rw [(this i).1, zero_testBit], eq_of_testBit_eq fun i => by rw [(this i).2, zero_testBit]⟩
+
+theorem or_ne_zero {n m : Nat} (h : m ≠ 0) : n ||| m ≠ 0 := by
+  refine Decidable.by_contra fun h' => ?_
+  rw [Decidable.not_not] at h'
+  exact h (zero_of_or_zero h').2
+
+theorem or_one_shiftLeft_ne_zero {n : Nat} : (n ||| 1 <<< i) ≠ 0 := by
+  have : 1 <<< i ≠ 0 := by
+    rw [one_shiftLeft]
+    exact Nat.ne_zero_of_lt (Nat.two_pow_pos i)
+  exact or_ne_zero this
+
+theorem or_one_mod_two {n : Nat} : (n ||| 1) % 2 = 1 := by
+  simp [Nat.or_mod_two_eq_one]
+
+theorem one_shiftLeft_succ_div_two : (1 <<< (i + 1)) / 2 = 1 <<< i := by
+  simp [one_shiftLeft]
+  omega
+
+theorem or_one_shiftLeft_succ_mod_two {n : Nat} : (n ||| 1 <<< (i + 1)) % 2 = n % 2 := by
+  rw [one_shiftLeft]
+  match h : n % 2 with
+  | 0 => simp [mod_two_eq_zero_iff_testBit_zero, h]
+  | 1 =>
+    rw [mod_two_eq_one_iff_testBit_zero]
+    simp [h]
+  | n + 2 => omega
+
+theorem ne_zero_of_testBit {n i : Nat} (h : n.testBit i) : n ≠ 0 := by
+  intro h'
+  have := (h' ▸ zero_testBit) i
+  simpa [h]
+
+theorem popcount_or_one_shiftLeft (n i : Nat) : popcount (n ||| (1 <<< i)) = if n.testBit i then popcount n else popcount n + 1 := by
+  induction i generalizing n with
+  | zero =>
+    split
+    next h => simp [popcount_ne, or_ne_zero, or_one_mod_two, or_div_two, popcount_odd h]
+    next h => simp [popcount_ne, or_ne_zero, or_one_mod_two, or_div_two, popcount_even h]
+  | succ i ih =>
+    simp [popcount_ne, or_one_shiftLeft_ne_zero, or_div_two, or_one_shiftLeft_succ_mod_two]
+    rw [one_shiftLeft_succ_div_two, ih (n / 2), ←testBit_succ]
+    if h' : n.testBit (i + 1) then
+      simp [h']
+      have : n ≠ 0 := ne_zero_of_testBit h'
+      exact (popcount_ne this).symm
+    else
+      simp [h']
+      if h'' : n = 0 then
+        simp [h'']
+      else
+        simp [popcount_ne h'']
+        omega
+
+end Nat

--- a/regex/Regex/Data/String.lean
+++ b/regex/Regex/Data/String.lean
@@ -1,4 +1,136 @@
+namespace Char
+
+theorem default_utf8Size : (default : Char).utf8Size = 1 := rfl
+
+end Char
+
+namespace String
+
+theorem utf8GetAux_not_valid (cs : List Char) (i p : Pos) (nv : ¬Pos.isValid.go p cs i) : utf8GetAux cs i p = default := by
+  induction cs generalizing i with
+  | nil => simp [utf8GetAux]
+  | cons c cs ih =>
+    simp [Pos.isValid.go] at nv
+    simp [utf8GetAux, nv.1]
+    exact ih (i + c) (by simp [nv.2])
+
+theorem get_not_valid (s : String) (p : Pos) (nv : ¬p.isValid s) : s.get p = default := by
+  simp [get]
+  exact utf8GetAux_not_valid s.data 0 p nv
+
+theorem next_not_valid (s : String) (p : Pos) (nv : ¬p.isValid s) : s.next p = p + ⟨1⟩ := by
+  simp [next, get_not_valid s p nv]
+  rfl
+
+theorem next_le_endPos_not_valid (s : String) (p : Pos) (lt : p < s.endPos) (nv : ¬p.isValid s) : s.next p ≤ s.endPos := by
+  have : p.byteIdx < s.endPos.byteIdx := lt
+  have : s.next p = p + ⟨1⟩ := next_not_valid s p nv
+  have : (s.next p).byteIdx = p.byteIdx + 1 := by
+    simp [this]
+  show (s.next p).byteIdx ≤ s.endPos.byteIdx
+  omega
+
+-- From Batteries
+private theorem utf8GetAux_of_valid (cs cs' : List Char) {i p : Nat} (hp : i + utf8ByteSize.go cs = p) :
+    utf8GetAux (cs ++ cs') ⟨i⟩ ⟨p⟩ = cs'.headD default := by
+  match cs, cs' with
+  | [], [] => rfl
+  | [], c::cs' => simp [← hp, utf8GetAux, utf8ByteSize.go]
+  | c::cs, cs' =>
+    simp only [List.cons_append, utf8GetAux, Char.reduceDefault]
+    rw [if_neg]
+    case hnc =>
+      simp only [← hp, utf8ByteSize.go, Pos.ext_iff]
+      have : c.utf8Size > 0 := Char.utf8Size_pos c
+      omega
+    refine utf8GetAux_of_valid cs cs' ?_
+    simpa [Nat.add_assoc, Nat.add_comm, utf8ByteSize.go] using hp
+
+-- From Batteries
+private theorem get_of_valid (cs cs' : List Char) : get ⟨cs ++ cs'⟩ ⟨utf8ByteSize.go cs⟩ = cs'.headD default :=
+  utf8GetAux_of_valid _ _ (Nat.zero_add _)
+
+@[simp]
+theorem utf8Size.go_append (cs₁ cs₂ : List Char) : utf8ByteSize.go (cs₁ ++ cs₂) = utf8ByteSize.go cs₁ + utf8ByteSize.go cs₂ := by
+  induction cs₁ with
+  | nil => simp [utf8ByteSize.go]
+  | cons c cs₁ ih =>
+    simp [utf8ByteSize.go, ih]
+    omega
+
+@[simp]
+theorem utf8Size.go_nil : utf8ByteSize.go [] = 0 := rfl
+
+@[simp]
+theorem utf8Size.go_cons (c : Char) (cs : List Char) : utf8ByteSize.go (c :: cs) = utf8ByteSize.go cs + c.utf8Size := by
+  simp [utf8ByteSize.go]
+
+@[simp]
+theorem utf8Size.go_singleton (c : Char) : utf8ByteSize.go [c] = c.utf8Size := by simp
+
+private theorem split_of_valid' (cs₁ cs₂ : List Char) (p : Pos) (v : Pos.isValid.go p cs₂ ⟨utf8ByteSize.go cs₁⟩) :
+  ∃ cs₁' cs₂', cs₁ ++ cs₂ = cs₁' ++ cs₂' ∧ p = ⟨utf8ByteSize.go cs₁'⟩ := by
+  induction cs₂ generalizing cs₁ with
+  | nil =>
+    simp [Pos.isValid.go] at v
+    exact ⟨cs₁, [], rfl, by simp [←v]⟩
+  | cons c cs₂ ih =>
+    simp [Pos.isValid.go] at v
+    cases v with
+    | inl eq => exact ⟨cs₁, c :: cs₂, rfl, by simp [←eq]⟩
+    | inr v =>
+      have ⟨cs₁', cs₂', seq⟩ := ih (cs₁ ++ [c]) (by simp; exact v)
+      simp at seq
+      exact ⟨cs₁', cs₂', seq⟩
+
+private theorem split_of_valid (s : String) (p : Pos) (v : p.isValid s) : ∃ cs₁ cs₂, s = ⟨cs₁ ++ cs₂⟩ ∧ p = ⟨utf8ByteSize.go cs₁⟩ := by
+  have ⟨cs₁, cs₂, seq, eq⟩ := split_of_valid' [] s.data p v
+  simp at seq
+  exact ⟨cs₁, cs₂, by simp [String.ext_iff, seq], eq⟩
+
+private theorem split_of_valid_lt (s : String) (p : Pos) (v : p.isValid s) (lt : p < s.endPos) : ∃ cs₁ c cs₂, s = ⟨cs₁ ++ c :: cs₂⟩ ∧ p = ⟨utf8ByteSize.go cs₁⟩ := by
+  have ⟨cs₁, cs₂, seq, eq⟩ := split_of_valid' [] s.data p v
+  simp at seq
+  match cs₂ with
+  | [] =>
+    simp at seq
+    simp [←seq] at eq
+    simp [eq, endPos, utf8ByteSize] at lt
+  | c :: cs₂ => exact ⟨cs₁, c, cs₂, by simp [String.ext_iff, seq], eq⟩
+
+theorem next_le_endPos_valid (s : String) (p : Pos) (v : p.isValid s) (lt : p < s.endPos) : s.next p ≤ s.endPos := by
+  have ⟨cs₁, c, cs₂, seq, eq⟩ := split_of_valid_lt s p v lt
+  have := get_of_valid cs₁ (c :: cs₂)
+  subst s p
+  simp [next, this, endPos, utf8ByteSize]
+  show utf8ByteSize.go cs₁ + c.utf8Size ≤ utf8ByteSize.go cs₁ + (utf8ByteSize.go cs₂ + c.utf8Size)
+  omega
+
+theorem next_le_endPos (s : String) (p : Pos) (lt : p < s.endPos) : s.next p ≤ s.endPos := by
+  match v : p.isValid s with
+  | true => exact next_le_endPos_valid s p v lt
+  | false => exact next_le_endPos_not_valid s p lt (by simp [v])
+
+end String
+
 namespace String.Iterator
+
+theorem next'_eq_next (it : Iterator) (h : it.hasNext) : it.next' h = it.next := by
+  simp [next', next]
+
+theorem next_toString (it : Iterator) : it.next.toString = it.toString := by
+  simp [next, toString]
+
+theorem next_le_endPos (it : Iterator) (h : it.hasNext) : (it.next' h).pos ≤ (it.next' h).toString.endPos := by
+  have lt : it.pos < it.toString.endPos := by
+    simp [hasNext] at h
+    exact h
+  simp [next'_eq_next, next_toString]
+  exact String.next_le_endPos it.toString it.pos lt
+
+theorem lt_next (it : Iterator) : it.pos < it.next.pos := by
+  simp [pos, next]
+  exact String.lt_next _ _
 
 @[simp]
 theorem next'_remainingBytes_lt {it : Iterator} {h : it.hasNext} : (it.next' h).remainingBytes < it.remainingBytes := by

--- a/regex/Regex/Data/String.lean
+++ b/regex/Regex/Data/String.lean
@@ -132,6 +132,11 @@ theorem lt_next (it : Iterator) : it.pos < it.next.pos := by
   simp [pos, next]
   exact String.lt_next _ _
 
+theorem next_le_four (it : Iterator) : it.next.pos ≤ it.pos + ⟨4⟩ := by
+  simp [pos, next, String.next]
+  show it.pos.byteIdx + Char.utf8Size (it.toString.get it.pos) ≤ it.pos.byteIdx + 4
+  simp [Char.utf8Size_le_four]
+
 @[simp]
 theorem next'_remainingBytes_lt {it : Iterator} {h : it.hasNext} : (it.next' h).remainingBytes < it.remainingBytes := by
   simp [hasNext] at h

--- a/regex/Regex/Regex/Basic.lean
+++ b/regex/Regex/Regex/Basic.lean
@@ -3,13 +3,28 @@ import Regex.NFA
 import Regex.VM
 import Regex.Backtracker
 
+open String (Pos Iterator)
+
 structure Regex where
   nfa : Regex.NFA
   wf : nfa.WellFormed
   maxTag : Nat := nfa.maxTag
+  useBacktracker : Bool := false
 deriving Repr
 
 namespace Regex
+
+def captureNextBuf (self : Regex) (bufferSize : Nat) (it : Iterator) : Option (Buffer bufferSize) :=
+  if self.useBacktracker then
+    Backtracker.captureNextBuf self.nfa self.wf bufferSize it
+  else
+    VM.captureNextBuf self.nfa self.wf bufferSize it
+
+def searchNext (self : Regex) (it : Iterator) : Option (Pos × Pos) := do
+  if self.useBacktracker then
+    Backtracker.searchNext self.nfa self.wf it
+  else
+    VM.searchNext self.nfa self.wf it
 
 def parse (s : String) : Except Regex.Syntax.Parser.Error Regex := do
   let expr ← Regex.Syntax.Parser.parse s

--- a/regex/Regex/Regex/Basic.lean
+++ b/regex/Regex/Regex/Basic.lean
@@ -1,6 +1,7 @@
 import Regex.Syntax.Parser
 import Regex.NFA
 import Regex.VM
+import Regex.Backtracker
 
 structure Regex where
   nfa : Regex.NFA

--- a/regex/Regex/Regex/Captures.lean
+++ b/regex/Regex/Regex/Captures.lean
@@ -6,7 +6,7 @@ namespace Regex
 
 structure CapturedGroups where
   buffer : Array (Option Pos)
-deriving Repr
+deriving Repr, DecidableEq
 
 def CapturedGroups.get (self : CapturedGroups) (index : Nat) : Option (Pos × Pos) := do
   let start ← (← self.buffer[2 * index]?)

--- a/regex/Regex/Regex/Captures.lean
+++ b/regex/Regex/Regex/Captures.lean
@@ -30,7 +30,7 @@ deriving Repr
 
 def Captures.next? (self : Captures) : Option (CapturedGroups × Captures) := do
   if self.currentPos ≤ self.haystack.endPos then
-    let buffer ← VM.captureNextBuf self.regex.nfa self.regex.wf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩
+    let buffer ← self.regex.captureNextBuf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩
     let groups := CapturedGroups.mk buffer.toArray
     let pos ← groups.get 0
     if self.currentPos < pos.2 then

--- a/regex/Regex/Regex/Elab.lean
+++ b/regex/Regex/Regex/Elab.lean
@@ -76,7 +76,7 @@ instance : ToExpr Regex where
     let wfInstance := Expr.app (mkConst ``NFA.decWellFormed) nfa
     let wf := mkDecidableProof wfType wfInstance
     let maxTag := toExpr re.maxTag
-    mkApp3 (mkConst ``Regex.mk) nfa wf maxTag
+    mkApp4 (mkConst ``Regex.mk) nfa wf maxTag (mkConst ``false)
 
 elab "re!" lit:str : term => do
   match Regex.parse lit.getString with

--- a/regex/Regex/Regex/Matches.lean
+++ b/regex/Regex/Regex/Matches.lean
@@ -12,7 +12,7 @@ deriving Repr
 
 def Matches.next? (self : Matches) : Option ((Pos × Pos) × Matches) := do
   if self.currentPos ≤ self.haystack.endPos then
-    let pos ← VM.searchNext self.regex.nfa self.regex.wf ⟨self.haystack, self.currentPos⟩
+    let pos ← self.regex.searchNext ⟨self.haystack, self.currentPos⟩
     if self.currentPos < pos.2 then
       let next := { self with currentPos := pos.2 }
       pure (pos, next)

--- a/regex/Regex/Strategy.lean
+++ b/regex/Regex/Strategy.lean
@@ -1,12 +1,10 @@
-import Regex.Data.SparseSet
 import Regex.NFA
 
 set_option autoImplicit false
 
-open Regex.Data (SparseSet)
 open String (Pos)
 
-namespace Regex.VM
+namespace Regex
 
 structure Strategy where
   Update : Type
@@ -16,12 +14,6 @@ structure Strategy where
 abbrev Buffer (size : Nat) := Vector (Option Pos) size
 
 def Buffer.empty {size : Nat} : Buffer size := Vector.mkVector size none
-
-structure SearchState (σ : Strategy) (nfa : NFA) where
-  states : SparseSet nfa.nodes.size
-  updates : Vector σ.Update nfa.nodes.size
-
-abbrev εStack (σ : Strategy) (nfa : NFA) := List (σ.Update × Fin nfa.nodes.size)
 
 def BufferStrategy (size : Nat) : Strategy where
   Update := Buffer size
@@ -38,11 +30,11 @@ instance {size} : GetElem (BufferStrategy size).Update Nat (Option Pos) (fun _ i
   inferInstanceAs (GetElem (Vector (Option Pos) size) Nat (Option Pos) _)
 
 /--
-This strategy is used only for proofs and inefficient.
+This strategy is inefficient and used only for proofs.
 -/
 def HistoryStrategy : Strategy where
   Update := List (Nat × Pos)
   empty := []
   write update offset pos := update ++ [(offset, pos)]
 
-end Regex.VM
+end Regex

--- a/regex/Regex/VM/Basic.lean
+++ b/regex/Regex/VM/Basic.lean
@@ -1,6 +1,6 @@
 import Regex.Data.SparseSet
 import Regex.NFA.Basic
-import Regex.VM.Strategy
+import Regex.Strategy
 
 set_option autoImplicit false
 
@@ -13,6 +13,12 @@ open String (Pos Iterator)
   https://github.com/rust-lang/regex/tree/master/regex-lite
 -/
 namespace Regex.VM
+
+structure SearchState (σ : Strategy) (nfa : NFA) where
+  states : SparseSet nfa.nodes.size
+  updates : Vector σ.Update nfa.nodes.size
+
+abbrev εStack (σ : Strategy) (nfa : NFA) := List (σ.Update × Fin nfa.nodes.size)
 
 -- https://github.com/leanprover/lean4/issues/7826
 set_option wf.preprocess false in

--- a/regex/tests/CorpusTest-backtracker.csv
+++ b/regex/tests/CorpusTest-backtracker.csv
@@ -1,0 +1,840 @@
+test_name,result,error
+anchored/greedy,unsupported,
+anchored/greedy-earliest,unsupported,
+anchored/nongreedy,unsupported,
+anchored/nongreedy-all,unsupported,
+anchored/word-boundary-unicode-01,unsupported,
+anchored/word-boundary-nounicode-01,unsupported,
+anchored/no-match-at-start,unsupported,
+anchored/no-match-at-start-bounds,unsupported,
+anchored/no-match-at-start-reverse-inner,unsupported,
+anchored/no-match-at-start-reverse-inner-bounds,unsupported,
+anchored/no-match-at-start-reverse-anchored,unsupported,
+anchored/no-match-at-start-reverse-anchored-bounds,unsupported,
+bytes/word-boundary-ascii,unsupported,
+bytes/word-boundary-unicode,unsupported,
+bytes/word-boundary-ascii-not,unsupported,
+bytes/word-boundary-unicode-not,unsupported,
+bytes/perl-word-ascii,unsupported,
+bytes/perl-word-unicode,unsupported,
+bytes/perl-decimal-ascii,unsupported,
+bytes/perl-decimal-unicode,unsupported,
+bytes/perl-whitespace-ascii,unsupported,
+bytes/perl-whitespace-unicode,unsupported,
+bytes/mixed-dot,unsupported,
+bytes/case-one-ascii,unsupported,
+bytes/case-one-unicode,unsupported,
+bytes/case-class-simple-ascii,unsupported,
+bytes/case-class-ascii,unsupported,
+bytes/case-class-unicode,unsupported,
+bytes/negate-ascii,unsupported,
+bytes/negate-unicode,unsupported,
+bytes/dotstar-prefix-ascii,unsupported,
+bytes/dotstar-prefix-unicode,unsupported,
+bytes/null-bytes,unsupported,
+bytes/invalid-utf8-anchor-100,unsupported,
+bytes/invalid-utf8-anchor-200,unsupported,
+bytes/invalid-utf8-anchor-300,unsupported,
+bytes/word-boundary-ascii-100,unsupported,
+bytes/word-boundary-ascii-200,unsupported,
+crazy/nothing-empty,unsupported,
+crazy/nothing-something,unsupported,
+crazy/ranges,unsupported,
+crazy/ranges-not,unsupported,
+crazy/float1,ok,
+crazy/float2,ok,
+crazy/float3,ok,
+crazy/float4,ok,
+crazy/float5,ok,
+crazy/email,unsupported,
+crazy/email-not,unsupported,
+crazy/email-big,ok,
+crazy/date1,unsupported,
+crazy/date2,unsupported,
+crazy/date3,unsupported,
+crazy/start-end-empty,ok,
+crazy/start-end-empty-rev,ok,
+crazy/start-end-empty-many-1,ok,
+crazy/start-end-empty-many-2,ok,
+crazy/start-end-empty-rep,ok,
+crazy/start-end-empty-rep-rev,ok,
+crazy/neg-class-letter,ok,
+crazy/neg-class-letter-comma,ok,
+crazy/neg-class-letter-space,error,"expected '[^a[:space:]]' to compile, but it did not: expected EOF"
+crazy/neg-class-comma,ok,
+crazy/neg-class-space,error,"expected '[^[:space:]]' to compile, but it did not: expected EOF"
+crazy/neg-class-space-comma,error,"expected '[^,[:space:]]' to compile, but it did not: expected EOF"
+crazy/neg-class-comma-space,error,"expected '[^[:space:],]' to compile, but it did not: expected EOF"
+crazy/neg-class-ascii,error,"expected '[^[:alpha:]Z]' to compile, but it did not: expected EOF"
+crazy/lazy-many-many,ok,
+crazy/lazy-many-optional,ok,
+crazy/lazy-one-many-many,ok,
+crazy/lazy-one-many-optional,ok,
+crazy/lazy-range-min-many,ok,
+crazy/lazy-range-many,ok,
+crazy/greedy-many-many,ok,
+crazy/greedy-many-optional,ok,
+crazy/greedy-one-many-many,ok,
+crazy/greedy-one-many-optional,ok,
+crazy/greedy-range-min-many,ok,
+crazy/greedy-range-many,ok,
+crazy/empty1,ok,
+crazy/empty2,ok,
+crazy/empty3,ok,
+crazy/empty4,ok,
+crazy/empty5,ok,
+crazy/empty6,ok,
+crazy/empty7,ok,
+crazy/empty8,ok,
+crazy/empty9,ok,
+crazy/empty10,ok,
+crazy/empty11,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 1, end := 2 }] }, { id := 0, spans := #[some { start := 3, end := 3 }] }], got #[#[(some (0, 0))], #[(some (1, 2))], #[(some (2, 2))], #[(some (3, 3))]]"
+crlf/basic,error,"expected '(?mR)^[a-z]+$' to compile, but it did not: unexpected character: ?"
+crlf/start-end-non-empty,error,"expected '(?mR)^$' to compile, but it did not: unexpected character: ?"
+crlf/start-end-empty,error,"expected '(?mR)^$' to compile, but it did not: unexpected character: ?"
+crlf/start-end-before-after,error,"expected '(?mR)^$' to compile, but it did not: unexpected character: ?"
+crlf/start-no-split,error,"expected '(?mR)^' to compile, but it did not: unexpected character: ?"
+crlf/start-no-split-adjacent,error,"expected '(?mR)^' to compile, but it did not: unexpected character: ?"
+crlf/start-no-split-adjacent-cr,error,"expected '(?mR)^' to compile, but it did not: unexpected character: ?"
+crlf/start-no-split-adjacent-lf,error,"expected '(?mR)^' to compile, but it did not: unexpected character: ?"
+crlf/end-no-split,error,"expected '(?mR)$' to compile, but it did not: unexpected character: ?"
+crlf/end-no-split-adjacent,error,"expected '(?mR)$' to compile, but it did not: unexpected character: ?"
+crlf/end-no-split-adjacent-cr,error,"expected '(?mR)$' to compile, but it did not: unexpected character: ?"
+crlf/end-no-split-adjacent-lf,error,"expected '(?mR)$' to compile, but it did not: unexpected character: ?"
+crlf/dot-no-crlf,error,"expected '(?R).' to compile, but it did not: unexpected character: ?"
+crlf/onepass-wrong-crlf-with-capture,error,"expected '(?Rm:().$)' to compile, but it did not: unexpected character: ?"
+crlf/onepass-wrong-crlf-anchored,unsupported,
+earliest/no-greedy-100,unsupported,
+earliest/no-greedy-200,unsupported,
+earliest/is-ungreedy,unsupported,
+earliest/look-start-test,unsupported,
+earliest/look-end-test,unsupported,
+earliest/no-leftmost-first-100,unsupported,
+earliest/no-leftmost-first-200,unsupported,
+empty/100,ok,
+empty/110,ok,
+empty/120,ok,
+empty/130,ok,
+empty/200,ok,
+empty/210,ok,
+empty/220,ok,
+empty/230,ok,
+empty/240,ok,
+empty/300,ok,
+empty/310,ok,
+empty/320,ok,
+empty/330,ok,
+empty/400,ok,
+empty/500,ok,
+empty/510,ok,
+empty/520,ok,
+empty/600,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 1, end := 1 }] }, { id := 0, spans := #[some { start := 2, end := 2 }] }, { id := 0, spans := #[some { start := 3, end := 3 }] }], got #[#[(some (0, 3))], #[(some (3, 3))]]"
+empty/610,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 1, end := 1 }] }, { id := 0, spans := #[some { start := 2, end := 2 }] }, { id := 0, spans := #[some { start := 3, end := 3 }] }], got #[#[(some (0, 3))], #[(some (3, 3))]]"
+expensive/regression-many-repeat-no-stack-overflow,ok,
+expensive/backtrack-blow-visited-capacity,error,"expected '\pL{50}' to compile, but it did not: unexpected escaped character: p"
+flags/1,error,"expected '(?i)abc' to compile, but it did not: unexpected character: ?"
+flags/2,error,"expected '(?i)a(?-i)bc' to compile, but it did not: unexpected character: ?"
+flags/3,error,"expected '(?i)a(?-i)bc' to compile, but it did not: unexpected character: ?"
+flags/4,error,"expected '(?is)a.' to compile, but it did not: unexpected character: ?"
+flags/5,error,"expected '(?is)a.(?-is)a.' to compile, but it did not: unexpected character: ?"
+flags/6,error,"expected '(?is)a.(?-is)a.' to compile, but it did not: unexpected character: ?"
+flags/7,error,"expected '(?is)a.(?-is:a.)?' to compile, but it did not: unexpected character: ?"
+flags/8,error,"expected '(?U)a+' to compile, but it did not: unexpected character: ?"
+flags/9,error,"expected '(?U)a+?' to compile, but it did not: unexpected character: ?"
+flags/10,error,"expected '(?U)(?-U)a+' to compile, but it did not: unexpected character: ?"
+flags/11,unsupported,
+iter/1,ok,
+iter/2,ok,
+iter/empty1,ok,
+iter/empty2,ok,
+iter/empty3,ok,
+iter/empty4,ok,
+iter/empty5,ok,
+iter/empty6,ok,
+iter/empty7,ok,
+iter/empty8,ok,
+iter/empty9,ok,
+iter/empty10,ok,
+iter/empty11,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 1, end := 2 }] }, { id := 0, spans := #[some { start := 3, end := 3 }] }], got #[#[(some (0, 0))], #[(some (1, 2))], #[(some (2, 2))], #[(some (3, 3))]]"
+iter/start1,ok,
+iter/start2,ok,
+iter/anchored1,unsupported,
+iter/anchored2,unsupported,
+iter/anchored3,unsupported,
+iter/nonempty-followedby-empty,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 3 }] }, { id := 0, spans := #[some { start := 4, end := 4 }] }, { id := 0, spans := #[some { start := 5, end := 5 }] }, { id := 0, spans := #[some { start := 6, end := 6 }] }], got #[#[(some (0, 3))], #[(some (3, 6))], #[(some (6, 6))]]"
+iter/nonempty-followedby-oneempty,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 3 }] }, { id := 0, spans := #[some { start := 4, end := 4 }] }], got #[#[(some (0, 3))], #[(some (3, 4))], #[(some (4, 4))]]"
+iter/nonempty-followedby-onemixed,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 3 }] }, { id := 0, spans := #[some { start := 4, end := 7 }] }], got #[#[(some (0, 3))], #[(some (3, 7))], #[(some (7, 7))]]"
+iter/nonempty-followedby-twomixed,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 3 }] }, { id := 0, spans := #[some { start := 4, end := 4 }] }, { id := 0, spans := #[some { start := 5, end := 8 }] }], but got #[#[(some (0, 3))], #[(some (3, 8))], #[(some (8, 8))]]"
+leftmost-all/alt,unsupported,
+leftmost-all/multi,unsupported,
+leftmost-all/dotall,unsupported,
+line-terminator/nul,unsupported,
+line-terminator/dot-changes-with-line-terminator,unsupported,
+line-terminator/not-line-feed,unsupported,
+line-terminator/non-ascii,unsupported,
+line-terminator/carriage,unsupported,
+line-terminator/word-byte,unsupported,
+line-terminator/non-word-byte,unsupported,
+line-terminator/word-boundary,unsupported,
+line-terminator/word-boundary-at,unsupported,
+line-terminator/not-word-boundary-at,unsupported,
+misc/ascii-literal,ok,
+misc/ascii-literal-not,ok,
+misc/ascii-literal-anchored,unsupported,
+misc/ascii-literal-anchored-not,unsupported,
+misc/anchor-start-end-line,error,"expected '(?m)^bar$' to compile, but it did not: unexpected character: ?"
+misc/prefix-literal-match,ok,
+misc/prefix-literal-match-ascii,unsupported,
+misc/prefix-literal-no-match,ok,
+misc/one-literal-edge,ok,
+misc/terminates,ok,
+misc/suffix-100,ok,
+misc/suffix-200,ok,
+misc/suffix-300,ok,
+misc/suffix-400,ok,
+misc/suffix-500,ok,
+misc/suffix-600,ok,
+multiline/basic1,error,"expected '(?m)^[a-z]+$' to compile, but it did not: unexpected character: ?"
+multiline/basic1-crlf,error,"expected '(?Rm)^[a-z]+$' to compile, but it did not: unexpected character: ?"
+multiline/basic1-crlf-cr,error,"expected '(?Rm)^[a-z]+$' to compile, but it did not: unexpected character: ?"
+multiline/basic2,error,"expected '(?m)^$' to compile, but it did not: unexpected character: ?"
+multiline/basic2-crlf,error,"expected '(?Rm)^$' to compile, but it did not: unexpected character: ?"
+multiline/basic2-crlf-cr,error,"expected '(?Rm)^$' to compile, but it did not: unexpected character: ?"
+multiline/basic3,error,"expected '(?m)^' to compile, but it did not: unexpected character: ?"
+multiline/basic3-crlf,error,"expected '(?Rm)^' to compile, but it did not: unexpected character: ?"
+multiline/basic3-crlf-cr,error,"expected '(?Rm)^' to compile, but it did not: unexpected character: ?"
+multiline/basic4,error,"expected '(?m)$' to compile, but it did not: unexpected character: ?"
+multiline/basic4-crlf,error,"expected '(?Rm)$' to compile, but it did not: unexpected character: ?"
+multiline/basic4-crlf-cr,error,"expected '(?Rm)$' to compile, but it did not: unexpected character: ?"
+multiline/basic5,error,"expected '(?m)^[a-z]' to compile, but it did not: unexpected character: ?"
+multiline/basic5-crlf,error,"expected '(?Rm)^[a-z]' to compile, but it did not: unexpected character: ?"
+multiline/basic5-crlf-cr,error,"expected '(?Rm)^[a-z]' to compile, but it did not: unexpected character: ?"
+multiline/basic6,error,"expected '(?m)[a-z]^' to compile, but it did not: unexpected character: ?"
+multiline/basic6-crlf,error,"expected '(?Rm)[a-z]^' to compile, but it did not: unexpected character: ?"
+multiline/basic6-crlf-cr,error,"expected '(?Rm)[a-z]^' to compile, but it did not: unexpected character: ?"
+multiline/basic7,error,"expected '(?m)[a-z]$' to compile, but it did not: unexpected character: ?"
+multiline/basic7-crlf,error,"expected '(?Rm)[a-z]$' to compile, but it did not: unexpected character: ?"
+multiline/basic7-crlf-cr,error,"expected '(?Rm)[a-z]$' to compile, but it did not: unexpected character: ?"
+multiline/basic8,error,"expected '(?m)$[a-z]' to compile, but it did not: unexpected character: ?"
+multiline/basic8-crlf,error,"expected '(?Rm)$[a-z]' to compile, but it did not: unexpected character: ?"
+multiline/basic8-crlf-cr,error,"expected '(?Rm)$[a-z]' to compile, but it did not: unexpected character: ?"
+multiline/basic9,error,"expected '(?m)^$' to compile, but it did not: unexpected character: ?"
+multiline/basic9-crlf,error,"expected '(?Rm)^$' to compile, but it did not: unexpected character: ?"
+multiline/repeat1,error,"expected '(?m)(?:^$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat1-crlf,error,"expected '(?Rm)(?:^$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat1-crlf-cr,error,"expected '(?Rm)(?:^$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat1-no-multi,ok,
+multiline/repeat1-no-multi-crlf,error,"expected '(?R)(?:^$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat1-no-multi-crlf-cr,error,"expected '(?R)(?:^$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat2,error,"expected '(?m)(?:^|a)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat2-crlf,error,"expected '(?Rm)(?:^|a)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat2-crlf-cr,error,"expected '(?Rm)(?:^|a)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat2-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 2, end := 5 }] }], but got #[#[(some (0, 1))], #[(some (2, 5))]]"
+multiline/repeat2-no-multi-crlf,error,"expected '(?R)(?:^|a)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat2-no-multi-crlf-cr,error,"expected '(?R)(?:^|a)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat3,error,"expected '(?m)(?:^|a)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat3-crlf,error,"expected '(?Rm)(?:^|a)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat3-crlf-cr,error,"expected '(?Rm)(?:^|a)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat3-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 1, end := 1 }] }, { id := 0, spans := #[some { start := 2, end := 5 }] }, { id := 0, spans := #[some { start := 6, end := 6 }] }], got #[#[(some (0, 1))], #[(some (1, 1))], #[(some (2, 5))], #[(some (5, 5))], #[(some (6, 6))]]"
+multiline/repeat3-no-multi-crlf,error,"expected '(?R)(?:^|a)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat3-no-multi-crlf-cr,error,"expected '(?R)(?:^|a)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat4,error,"expected '(?m)(?:^|a+)' to compile, but it did not: unexpected character: ?"
+multiline/repeat4-crlf,error,"expected '(?Rm)(?:^|a+)' to compile, but it did not: unexpected character: ?"
+multiline/repeat4-crlf-cr,error,"expected '(?Rm)(?:^|a+)' to compile, but it did not: unexpected character: ?"
+multiline/repeat4-no-multi,ok,
+multiline/repeat4-no-multi-crlf,error,"expected '(?R)(?:^|a+)' to compile, but it did not: unexpected character: ?"
+multiline/repeat4-no-multi-crlf-cr,error,"expected '(?R)(?:^|a+)' to compile, but it did not: unexpected character: ?"
+multiline/repeat5,error,"expected '(?m)(?:^|a*)' to compile, but it did not: unexpected character: ?"
+multiline/repeat5-crlf,error,"expected '(?Rm)(?:^|a*)' to compile, but it did not: unexpected character: ?"
+multiline/repeat5-crlf-cr,error,"expected '(?Rm)(?:^|a*)' to compile, but it did not: unexpected character: ?"
+multiline/repeat5-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 1, end := 1 }] }, { id := 0, spans := #[some { start := 2, end := 5 }] }, { id := 0, spans := #[some { start := 6, end := 6 }] }], got #[#[(some (0, 0))], #[(some (1, 1))], #[(some (2, 5))], #[(some (5, 5))], #[(some (6, 6))]]"
+multiline/repeat5-no-multi-crlf,error,"expected '(?R)(?:^|a*)' to compile, but it did not: unexpected character: ?"
+multiline/repeat5-no-multi-crlf-cr,error,"expected '(?R)(?:^|a*)' to compile, but it did not: unexpected character: ?"
+multiline/repeat6,error,"expected '(?m)(?:^[a-z])+' to compile, but it did not: unexpected character: ?"
+multiline/repeat6-crlf,error,"expected '(?Rm)(?:^[a-z])+' to compile, but it did not: unexpected character: ?"
+multiline/repeat6-crlf-cr,error,"expected '(?Rm)(?:^[a-z])+' to compile, but it did not: unexpected character: ?"
+multiline/repeat6-no-multi,ok,
+multiline/repeat6-no-multi-crlf,error,"expected '(?R)(?:^[a-z])+' to compile, but it did not: unexpected character: ?"
+multiline/repeat6-no-multi-crlf-cr,error,"expected '(?R)(?:^[a-z])+' to compile, but it did not: unexpected character: ?"
+multiline/repeat7,error,"expected '(?m)(?:^[a-z]{3}\n?)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat7-crlf,error,"expected '(?Rm)(?:^[a-z]{3}\n?)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat7-crlf-cr,error,"expected '(?Rm)(?:^[a-z]{3}\r?)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat7-no-multi,ok,
+multiline/repeat7-no-multi-crlf,error,"expected '(?R)(?:^[a-z]{3}\n?)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat7-no-multi-crlf-cr,error,"expected '(?R)(?:^[a-z]{3}\r?)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat8,error,"expected '(?m)(?:^[a-z]{3}\n?)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat8-crlf,error,"expected '(?Rm)(?:^[a-z]{3}\n?)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat8-crlf-cr,error,"expected '(?Rm)(?:^[a-z]{3}\r?)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat8-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 4 }] }, { id := 0, spans := #[some { start := 5, end := 5 }] }, { id := 0, spans := #[some { start := 6, end := 6 }] }, { id := 0, spans := #[some { start := 7, end := 7 }] }, { id := 0, spans := #[some { start := 8, end := 8 }] }, { id := 0, spans := #[some { start := 9, end := 9 }] }, { id := 0, spans := #[some { start := 10, end := 10 }] }, { id := 0, spans := #[some { start := 11, end := 11 }] }], got #[#[(some (0, 4))], #[(some (4, 4))], #[(some (5, 5))], #[(some (6, 6))], #[(some (7, 7))], #[(some (8, 8))], #[(some (9, 9))], #[(some (10, 10))], #[(some (11, 11))]]"
+multiline/repeat8-no-multi-crlf,error,"expected '(?R)(?:^[a-z]{3}\n?)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat8-no-multi-crlf-cr,error,"expected '(?R)(?:^[a-z]{3}\r?)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat9,error,"expected '(?m)(?:\n?[a-z]{3}$)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat9-crlf,error,"expected '(?Rm)(?:\n?[a-z]{3}$)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat9-crlf-cr,error,"expected '(?Rm)(?:\r?[a-z]{3}$)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat9-no-multi,ok,
+multiline/repeat9-no-multi-crlf,error,"expected '(?R)(?:\n?[a-z]{3}$)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat9-no-multi-crlf-cr,error,"expected '(?R)(?:\r?[a-z]{3}$)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat10,error,"expected '(?m)(?:\n?[a-z]{3}$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat10-crlf,error,"expected '(?Rm)(?:\n?[a-z]{3}$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat10-crlf-cr,error,"expected '(?Rm)(?:\r?[a-z]{3}$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat10-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 1, end := 1 }] }, { id := 0, spans := #[some { start := 2, end := 2 }] }, { id := 0, spans := #[some { start := 3, end := 3 }] }, { id := 0, spans := #[some { start := 4, end := 4 }] }, { id := 0, spans := #[some { start := 5, end := 5 }] }, { id := 0, spans := #[some { start := 6, end := 6 }] }, { id := 0, spans := #[some { start := 7, end := 11 }] }], got #[#[(some (0, 0))], #[(some (1, 1))], #[(some (2, 2))], #[(some (3, 3))], #[(some (4, 4))], #[(some (5, 5))], #[(some (6, 6))], #[(some (7, 11))], #[(some (11, 11))]]"
+multiline/repeat10-no-multi-crlf,error,"expected '(?R)(?:\n?[a-z]{3}$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat10-no-multi-crlf-cr,error,"expected '(?R)(?:\r?[a-z]{3}$)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat11,error,"expected '(?m)^*' to compile, but it did not: unexpected character: ?"
+multiline/repeat11-crlf,error,"expected '(?Rm)^*' to compile, but it did not: unexpected character: ?"
+multiline/repeat11-crlf-cr,error,"expected '(?Rm)^*' to compile, but it did not: unexpected character: ?"
+multiline/repeat11-no-multi,ok,
+multiline/repeat11-no-multi-crlf,error,"expected '(?R)^*' to compile, but it did not: unexpected character: ?"
+multiline/repeat11-no-multi-crlf-cr,error,"expected '(?R)^*' to compile, but it did not: unexpected character: ?"
+multiline/repeat12,error,"expected '(?m)^+' to compile, but it did not: unexpected character: ?"
+multiline/repeat12-crlf,error,"expected '(?Rm)^+' to compile, but it did not: unexpected character: ?"
+multiline/repeat12-crlf-cr,error,"expected '(?Rm)^+' to compile, but it did not: unexpected character: ?"
+multiline/repeat12-no-multi,ok,
+multiline/repeat12-no-multi-crlf,error,"expected '(?R)^+' to compile, but it did not: unexpected character: ?"
+multiline/repeat12-no-multi-crlf-cr,error,"expected '(?R)^+' to compile, but it did not: unexpected character: ?"
+multiline/repeat13,error,"expected '(?m)$*' to compile, but it did not: unexpected character: ?"
+multiline/repeat13-crlf,error,"expected '(?Rm)$*' to compile, but it did not: unexpected character: ?"
+multiline/repeat13-crlf-cr,error,"expected '(?Rm)$*' to compile, but it did not: unexpected character: ?"
+multiline/repeat13-no-multi,ok,
+multiline/repeat13-no-multi-crlf,error,"expected '(?R)$*' to compile, but it did not: unexpected character: ?"
+multiline/repeat13-no-multi-crlf-cr,error,"expected '(?R)$*' to compile, but it did not: unexpected character: ?"
+multiline/repeat14,error,"expected '(?m)$+' to compile, but it did not: unexpected character: ?"
+multiline/repeat14-crlf,error,"expected '(?Rm)$+' to compile, but it did not: unexpected character: ?"
+multiline/repeat14-crlf-cr,error,"expected '(?Rm)$+' to compile, but it did not: unexpected character: ?"
+multiline/repeat14-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 4, end := 4 }] }], got #[#[(some (4, 4))], #[(some (4, 4))]]"
+multiline/repeat14-no-multi-crlf,error,"expected '(?R)$+' to compile, but it did not: unexpected character: ?"
+multiline/repeat14-no-multi-crlf-cr,error,"expected '(?R)$+' to compile, but it did not: unexpected character: ?"
+multiline/repeat15,error,"expected '(?m)(?:$\n)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat15-crlf,error,"expected '(?Rm)(?:$\n)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat15-crlf-cr,error,"expected '(?Rm)(?:$\r)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat15-no-multi,ok,
+multiline/repeat15-no-multi-crlf,error,"expected '(?R)(?:$\n)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat15-no-multi-crlf-cr,error,"expected '(?R)(?:$\r)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat16,error,"expected '(?m)(?:$\n)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat16-crlf,error,"expected '(?Rm)(?:$\n)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat16-crlf-cr,error,"expected '(?Rm)(?:$\r)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat16-no-multi,ok,
+multiline/repeat16-no-multi-crlf,error,"expected '(?R)(?:$\n)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat16-no-multi-crlf-cr,error,"expected '(?R)(?:$\r)*' to compile, but it did not: unexpected character: ?"
+multiline/repeat17,error,"expected '(?m)(?:$\n^)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat17-crlf,error,"expected '(?Rm)(?:$\n^)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat17-crlf-cr,error,"expected '(?Rm)(?:$\r^)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat17-no-multi,ok,
+multiline/repeat17-no-multi-crlf,error,"expected '(?R)(?:$\n^)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat17-no-multi-crlf-cr,error,"expected '(?R)(?:$\r^)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat18,error,"expected '(?m)(?:^|$)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat18-crlf,error,"expected '(?Rm)(?:^|$)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat18-crlf-cr,error,"expected '(?Rm)(?:^|$)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat18-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 7, end := 7 }] }], got #[#[(some (0, 0))], #[(some (7, 7))], #[(some (7, 7))]]"
+multiline/repeat18-no-multi-crlf,error,"expected '(?R)(?:^|$)+' to compile, but it did not: unexpected character: ?"
+multiline/repeat18-no-multi-crlf-cr,error,"expected '(?R)(?:^|$)+' to compile, but it did not: unexpected character: ?"
+multiline/match-line-100,error,"expected '(?m)^.+$' to compile, but it did not: unexpected character: ?"
+multiline/match-line-100-crlf,error,"expected '(?Rm)^.+$' to compile, but it did not: unexpected character: ?"
+multiline/match-line-100-crlf-cr,error,"expected '(?Rm)^.+$' to compile, but it did not: unexpected character: ?"
+multiline/match-line-200,unsupported,
+multiline/match-line-200-crlf,unsupported,
+multiline/match-line-200-crlf-cr,unsupported,
+no-unicode/invalid-utf8-literal1,unsupported,
+no-unicode/mixed,unsupported,
+no-unicode/case1,unsupported,
+no-unicode/case2,unsupported,
+no-unicode/case3,unsupported,
+no-unicode/case4,unsupported,
+no-unicode/negate1,ok,
+no-unicode/negate2,unsupported,
+no-unicode/dotstar-prefix1,unsupported,
+no-unicode/dotstar-prefix2,unsupported,
+no-unicode/null-bytes1,unsupported,
+no-unicode/word-ascii,unsupported,
+no-unicode/word-unicode,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 3 }] }], but got #[#[(some (0, 1))]]"
+no-unicode/decimal-ascii,unsupported,
+no-unicode/decimal-unicode,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 8 }] }], got #[#[(some (0, 1))], #[(some (7, 8))]]"
+no-unicode/space-ascii,unsupported,
+no-unicode/space-unicode,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 4 }] }], but got #[#[(some (0, 1))]]"
+no-unicode/iter1-bytes,unsupported,
+no-unicode/iter1-utf8,ok,
+no-unicode/iter2-bytes,unsupported,
+no-unicode/unanchored-invalid-utf8-match-100,unsupported,
+no-unicode/unanchored-invalid-utf8-nomatch,unsupported,
+no-unicode/anchored-iter-empty-utf8,unsupported,
+overlapping/ungreedy-dotstar-matches-everything-100,unsupported,
+overlapping/greedy-dotstar-matches-everything-100,unsupported,
+overlapping/repetition-plus-leftmost-first-100,unsupported,
+overlapping/repetition-plus-leftmost-first-110,unsupported,
+overlapping/repetition-plus-all-100,unsupported,
+overlapping/repetition-plus-all-110,unsupported,
+overlapping/repetition-plus-leftmost-first-200,unsupported,
+overlapping/repetition-plus-all-200,unsupported,
+overlapping/repetition-star-leftmost-first-100,unsupported,
+overlapping/repetition-star-all-100,unsupported,
+overlapping/repetition-star-leftmost-first-200,unsupported,
+overlapping/repetition-star-all-200,unsupported,
+overlapping/start-end-rep-leftmost-first,unsupported,
+overlapping/start-end-rep-all,unsupported,
+overlapping/alt-leftmost-first-100,unsupported,
+overlapping/alt-all-100,unsupported,
+overlapping/empty-000,unsupported,
+overlapping/empty-alt-000,unsupported,
+overlapping/empty-alt-010,unsupported,
+overlapping/iter1-bytes,unsupported,
+overlapping/iter1-utf8,unsupported,
+overlapping/iter1-incomplete-utf8,unsupported,
+overlapping/scratch,unsupported,
+regex-lite/perl-class-decimal,ok,
+regex-lite/perl-class-space,ok,
+regex-lite/perl-class-word,ok,
+regex-lite/word-boundary,unsupported,
+regex-lite/word-boundary-negated,unsupported,
+regex-lite/empty-no-split-codepoint,ok,
+regex-lite/dot-always-matches-codepoint,unsupported,
+regex-lite/negated-class-always-matches-codepoint,unsupported,
+regex-lite/case-insensitive-is-ascii-only,unsupported,
+regression/invalid-regex-no-crash-100,ok,
+regression/invalid-regex-no-crash-200,ok,
+regression/invalid-regex-no-crash-300,ok,
+regression/invalid-regex-no-crash-400,ok,
+regression/unsorted-binary-search-100,error,"expected '(?i-u)[a_]+' to compile, but it did not: unexpected character: ?"
+regression/unsorted-binary-search-200,error,"expected '(?i-u)[A_]+' to compile, but it did not: unexpected character: ?"
+regression/unicode-case-lower-nocase-flag,error,"expected '(?i)\p{Ll}+' to compile, but it did not: unexpected character: ?"
+regression/negated-char-class-100,error,"expected '(?i)[^x]' to compile, but it did not: unexpected character: ?"
+regression/negated-char-class-200,error,"expected '(?i)[^x]' to compile, but it did not: unexpected character: ?"
+regression/ascii-word-underscore,error,"expected '[[:word:]]' to compile, but it did not: expected EOF"
+regression/captures-repeat,error,"expected '([a-f]){2}(?P<foo>[x-z])' to compile, but it did not: unexpected character: ?"
+regression/alt-in-alt-100,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 1 }] }, { id := 0, spans := #[some { start := 2, end := 2 }] }], got #[#[(some (0, 1))], #[(some (2, 2))], #[(some (2, 2))]]"
+regression/alt-in-alt-200,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 3 }] }], but got #[#[(some (0, 5))]]"
+regression/leftmost-first-prefix,ok,
+regression/many-alternates,ok,
+regression/word-boundary-alone-100,unsupported,
+regression/word-boundary-alone-200,unsupported,
+regression/word-boundary-ascii-no-capture,unsupported,
+regression/word-boundary-ascii-capture,unsupported,
+regression/partial-anchor,ok,
+regression/endl-or-word-boundary,unsupported,
+regression/zero-or-end,error,"expected '(?i-u:\x00)|$' to compile, but it did not: unexpected character: ?"
+regression/y-or-endl,error,"expected '(?i-u:y)|(?m:$)' to compile, but it did not: unexpected character: ?"
+regression/word-boundary-start-x,unsupported,
+regression/word-boundary-ascii-start-x,unsupported,
+regression/end-not-word-boundary,unsupported,
+regression/partial-anchor-alternate-begin,ok,
+regression/partial-anchor-alternate-end,ok,
+regression/lits-unambiguous-100,ok,
+regression/lits-unambiguous-200,error,"expected '((IMG|CAM|MG|MB2)_|(DSCN|CIMG))(?P<n>[0-9]+)$' to compile, but it did not: unexpected character: ?"
+regression/negated-full-byte-range,unsupported,
+regression/strange-anchor-non-complete-prefix,ok,
+regression/strange-anchor-non-complete-suffix,ok,
+regression/captures-after-dfa-premature-end-100,ok,
+regression/captures-after-dfa-premature-end-200,ok,
+regression/captures-after-dfa-premature-end-300,ok,
+regression/captures-after-dfa-premature-end-400,unsupported,
+regression/literal-panic,ok,
+regression/empty-flag-expr,error,"expected '(?:(?:(?x)))' to compile, but it did not: unexpected character: ?"
+regression/invalid-repetition,ok,
+regression/flags-are-unset,error,"expected '(?:(?i)foo)|Bar' to compile, but it did not: unexpected character: ?"
+regression/empty-group-with-unicode,ok,
+regression/word-boundary-weird,unsupported,
+regression/word-boundary-weird-ascii,unsupported,
+regression/word-boundary-weird-minimal-ascii,unsupported,
+regression/reverse-suffix-100,ok,
+regression/reverse-suffix-200,ok,
+regression/reverse-suffix-300,unsupported,
+regression/stops,unsupported,
+regression/stops-ascii,unsupported,
+regression/adjacent-line-boundary-100,error,"expected '(?m)^(?:[^ ]+?)$' to compile, but it did not: unexpected character: ?"
+regression/adjacent-line-boundary-200,error,"expected '(?m)^(?:[^ ]+?)$' to compile, but it did not: unexpected character: ?"
+regression/anchored-prefix-100,error,"expected '^a[[:^space:]]' to compile, but it did not: expected EOF"
+regression/anchored-prefix-200,error,"expected '^a[[:^space:]]' to compile, but it did not: expected EOF"
+regression/anchored-prefix-300,ok,
+regression/aho-corasick-100,ok,
+regression/interior-anchor-capture,ok,
+regression/ruff-whitespace-around-keywords,unsupported,
+regression/i429-0,unsupported,
+regression/i429-1,unsupported,
+regression/i429-2,unsupported,
+regression/i429-3,unsupported,
+regression/i429-3-utf8,unsupported,
+regression/i429-4,unsupported,
+regression/i429-5,unsupported,
+regression/i429-6,unsupported,
+regression/i429-7,unsupported,
+regression/i429-8,unsupported,
+regression/i429-9,unsupported,
+regression/i429-10,unsupported,
+regression/i429-11,unsupported,
+regression/i429-12,unsupported,
+regression/i969,unsupported,
+regression/fowler-basic154-unanchored,ok,
+regression/word-boundary-interact-poorly-with-literal-optimizations,unsupported,
+regression/impossible-branch,ok,
+regression/captures-wrong-order,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 1 }, none, some { start := 0, end := 1 }] }], but got #[#[(some (0, 1)), (some (0, 1))]]"
+regression/negated-unicode-word-boundary-dfa-fail,unsupported,
+regression/missed-match,ok,
+regression/regex-to-glob,unsupported,
+regression/reverse-inner-plus-shorter-than-expected,ok,
+regression/reverse-inner-short,ok,
+regression/prefilter-with-aho-corasick-standard-semantics,unsupported,
+regression/non-prefix-literal-quit-state,unsupported,
+regression/hir-optimization-out-of-order-class,error,"expected '^[[:alnum:]./-]+$' to compile, but it did not: expected EOF"
+regression/improper-reverse-suffix-optimization,ok,
+set/basic10,unsupported,
+set/basic10-leftmost-first,unsupported,
+set/basic20,unsupported,
+set/basic30,unsupported,
+set/basic40,unsupported,
+set/basic50,unsupported,
+set/basic60,unsupported,
+set/basic60-leftmost-first,unsupported,
+set/basic61,unsupported,
+set/basic61-leftmost-first,unsupported,
+set/basic70,unsupported,
+set/basic71,unsupported,
+set/basic80,unsupported,
+set/basic81,unsupported,
+set/basic82,unsupported,
+set/basic90,unsupported,
+set/basic91,unsupported,
+set/basic100,unsupported,
+set/basic101,unsupported,
+set/basic102,unsupported,
+set/basic110,unsupported,
+set/basic111,unsupported,
+set/basic120,unsupported,
+set/basic121,unsupported,
+set/basic122,unsupported,
+set/basic130,unsupported,
+set/empty10,unsupported,
+set/empty10-leftmost-first,unsupported,
+set/empty11,unsupported,
+set/empty11-leftmost-first,unsupported,
+set/empty20,unsupported,
+set/empty20-leftmost-first,unsupported,
+set/empty21,unsupported,
+set/empty21-leftmost-first,unsupported,
+set/empty22,unsupported,
+set/empty23,unsupported,
+set/empty30,unsupported,
+set/empty30-leftmost-first,unsupported,
+set/empty31,unsupported,
+set/empty31-leftmost-first,unsupported,
+set/empty40,unsupported,
+set/empty40-leftmost-first,unsupported,
+set/nomatch10,unsupported,
+set/nomatch20,unsupported,
+set/nomatch30,unsupported,
+set/nomatch40,unsupported,
+set/caps-010,unsupported,
+set/caps-020,unsupported,
+set/caps-030,unsupported,
+set/caps-110,unsupported,
+set/caps-120,unsupported,
+set/caps-121,unsupported,
+substring/unicode-word-start,unsupported,
+substring/unicode-word-end,unsupported,
+substring/ascii-word-start,unsupported,
+substring/ascii-word-end,unsupported,
+unicode/literal1,ok,
+unicode/literal2,ok,
+unicode/literal3,unsupported,
+unicode/literal4,unsupported,
+unicode/wb-100,unsupported,
+unicode/wb-200,unsupported,
+unicode/wb-300,unsupported,
+unicode/wb-400,unsupported,
+unicode/class1,ok,
+unicode/class2,error,"expected '\pN' to compile, but it did not: unexpected escaped character: p"
+unicode/class3,error,"expected '\pN+' to compile, but it did not: unexpected escaped character: p"
+unicode/class4,error,"expected '\PN+' to compile, but it did not: unexpected escaped character: P"
+unicode/class5,error,"expected '[\PN]+' to compile, but it did not: unexpected escaped character: P"
+unicode/class6,error,"expected '[^\PN]+' to compile, but it did not: unexpected escaped character: P"
+unicode/class7,error,"expected '\p{Lu}+' to compile, but it did not: unexpected escaped character: p"
+unicode/class8,unsupported,
+unicode/class9,error,"expected '\pL+' to compile, but it did not: unexpected escaped character: p"
+unicode/class10,error,"expected '\p{Ll}+' to compile, but it did not: unexpected escaped character: p"
+unicode/perl1,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 4 }] }], got #[#[(some (0, 1))], #[(some (3, 4))]]"
+unicode/perl2,ok,
+unicode/perl3,ok,
+unicode/perl4,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 8 }] }], got #[#[(some (0, 1))], #[(some (7, 8))]]"
+unicode/perl5,ok,
+unicode/perl6,ok,
+unicode/perl7,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 3 }] }], got #[]"
+unicode/perl8,ok,
+unicode/perl9,ok,
+unicode/class-gencat1,error,"expected '\p{Cased_Letter}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat2,error,"expected '\p{Close_Punctuation}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat3,error,"expected '\p{Connector_Punctuation}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat4,error,"expected '\p{Control}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat5,error,"expected '\p{Currency_Symbol}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat6,error,"expected '\p{Dash_Punctuation}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat7,error,"expected '\p{Decimal_Number}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat8,error,"expected '\p{Enclosing_Mark}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat9,error,"expected '\p{Final_Punctuation}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat10,error,"expected '\p{Format}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat11,error,"expected '\p{Initial_Punctuation}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat12,error,"expected '\p{Letter}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat13,error,"expected '\p{Letter_Number}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat14,error,"expected '\p{Line_Separator}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat15,error,"expected '\p{Lowercase_Letter}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat16,error,"expected '\p{Mark}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat17,error,"expected '\p{Math}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat18,error,"expected '\p{Modifier_Letter}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat19,error,"expected '\p{Modifier_Symbol}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat20,error,"expected '\p{Nonspacing_Mark}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat21,error,"expected '\p{Number}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat22,error,"expected '\p{Open_Punctuation}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat23,error,"expected '\p{Other}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat24,error,"expected '\p{Other_Letter}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat25,error,"expected '\p{Other_Number}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat26,error,"expected '\p{Other_Punctuation}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat27,error,"expected '\p{Other_Symbol}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat28,error,"expected '\p{Paragraph_Separator}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat29,error,"expected '\p{Private_Use}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat30,error,"expected '\p{Punctuation}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat31,error,"expected '\p{Separator}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat32,error,"expected '\p{Space_Separator}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat33,error,"expected '\p{Spacing_Mark}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat34,error,"expected '\p{Symbol}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat35,error,"expected '\p{Titlecase_Letter}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat36,error,"expected '\p{Unassigned}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gencat37,error,"expected '\p{Uppercase_Letter}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-emoji1,error,"expected '\p{Emoji}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-emoji2,error,"expected '\p{emoji}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-emoji3,error,"expected '\p{extendedpictographic}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-emoji4,error,"expected '\p{extendedpictographic}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gcb1,error,"expected '\p{grapheme_cluster_break=prepend}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gcb2,error,"expected '\p{gcb=regional_indicator}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gcb3,error,"expected '\p{gcb=ri}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gcb4,error,"expected '\p{regionalindicator}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gcb5,error,"expected '\p{gcb=lvt}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-gcb6,error,"expected '\p{gcb=zwj}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-word-break1,error,"expected '\p{word_break=Hebrew_Letter}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-word-break2,error,"expected '\p{wb=hebrewletter}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-word-break3,error,"expected '\p{wb=ExtendNumLet}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-word-break4,error,"expected '\p{wb=WSegSpace}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-word-break5,error,"expected '\p{wb=numeric}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-sentence-break1,error,"expected '\p{sentence_break=Lower}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-sentence-break2,error,"expected '\p{sb=lower}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-sentence-break3,error,"expected '\p{sb=Close}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-sentence-break4,error,"expected '\p{sb=Close}' to compile, but it did not: unexpected escaped character: p"
+unicode/class-sentence-break5,error,"expected '\p{sb=SContinue}' to compile, but it did not: unexpected escaped character: p"
+utf8/empty-utf8yes,ok,
+utf8/empty-utf8yes-overlapping,unsupported,
+utf8/empty-utf8no,unsupported,
+utf8/empty-utf8no-overlapping,unsupported,
+utf8/empty-utf8yes-bounds,unsupported,
+utf8/empty-utf8yes-bounds-overlapping,unsupported,
+utf8/empty-utf8no-bounds,unsupported,
+utf8/empty-utf8no-bounds-overlapping,unsupported,
+utf8/empty-utf8yes-anchored,unsupported,
+utf8/empty-utf8yes-anchored-overlapping,unsupported,
+utf8/empty-utf8no-anchored,unsupported,
+utf8/empty-utf8no-anchored-overlapping,unsupported,
+utf8/empty-utf8yes-anchored-bounds,unsupported,
+utf8/empty-utf8yes-anchored-bounds-overlapping,unsupported,
+utf8/empty-utf8no-anchored-bounds,unsupported,
+utf8/empty-utf8no-anchored-bounds-overlapping,unsupported,
+utf8/empty-utf8yes-startbound,unsupported,
+utf8/empty-utf8yes-startbound-overlapping,unsupported,
+utf8/empty-utf8no-startbound,unsupported,
+utf8/empty-utf8no-startbound-overlapping,unsupported,
+utf8/empty-utf8yes-anchored-startbound,unsupported,
+utf8/empty-utf8yes-anchored-startbound-overlapping,unsupported,
+utf8/empty-utf8no-anchored-startbound,unsupported,
+utf8/empty-utf8no-anchored-startbound-overlapping,unsupported,
+utf8/empty-utf8yes-anchored-endbound,unsupported,
+utf8/empty-utf8yes-anchored-endbound-overlapping,unsupported,
+utf8/empty-utf8no-anchored-endbound,unsupported,
+utf8/empty-utf8no-anchored-endbound-overlapping,unsupported,
+word-boundary-special/word-start-ascii-010,unsupported,
+word-boundary-special/word-start-ascii-020,unsupported,
+word-boundary-special/word-start-ascii-030,unsupported,
+word-boundary-special/word-start-ascii-040,unsupported,
+word-boundary-special/word-start-ascii-050,unsupported,
+word-boundary-special/word-start-ascii-060,unsupported,
+word-boundary-special/word-start-ascii-060-bounds,unsupported,
+word-boundary-special/word-start-ascii-070,unsupported,
+word-boundary-special/word-start-ascii-080,unsupported,
+word-boundary-special/word-start-ascii-090,unsupported,
+word-boundary-special/word-start-ascii-110,unsupported,
+word-boundary-special/word-end-ascii-010,unsupported,
+word-boundary-special/word-end-ascii-020,unsupported,
+word-boundary-special/word-end-ascii-030,unsupported,
+word-boundary-special/word-end-ascii-040,unsupported,
+word-boundary-special/word-end-ascii-050,unsupported,
+word-boundary-special/word-end-ascii-060,unsupported,
+word-boundary-special/word-end-ascii-060-bounds,unsupported,
+word-boundary-special/word-end-ascii-070,unsupported,
+word-boundary-special/word-end-ascii-080,unsupported,
+word-boundary-special/word-end-ascii-090,unsupported,
+word-boundary-special/word-end-ascii-110,unsupported,
+word-boundary-special/word-start-unicode-010,unsupported,
+word-boundary-special/word-start-unicode-020,unsupported,
+word-boundary-special/word-start-unicode-030,unsupported,
+word-boundary-special/word-start-unicode-040,unsupported,
+word-boundary-special/word-start-unicode-050,unsupported,
+word-boundary-special/word-start-unicode-060,unsupported,
+word-boundary-special/word-start-unicode-060-bounds,unsupported,
+word-boundary-special/word-start-unicode-070,unsupported,
+word-boundary-special/word-start-unicode-080,unsupported,
+word-boundary-special/word-start-unicode-090,unsupported,
+word-boundary-special/word-start-unicode-110,unsupported,
+word-boundary-special/word-end-unicode-010,unsupported,
+word-boundary-special/word-end-unicode-020,unsupported,
+word-boundary-special/word-end-unicode-030,unsupported,
+word-boundary-special/word-end-unicode-040,unsupported,
+word-boundary-special/word-end-unicode-050,unsupported,
+word-boundary-special/word-end-unicode-060,unsupported,
+word-boundary-special/word-end-unicode-060-bounds,unsupported,
+word-boundary-special/word-end-unicode-070,unsupported,
+word-boundary-special/word-end-unicode-080,unsupported,
+word-boundary-special/word-end-unicode-090,unsupported,
+word-boundary-special/word-end-unicode-110,unsupported,
+word-boundary-special/word-start-half-ascii-010,unsupported,
+word-boundary-special/word-start-half-ascii-020,unsupported,
+word-boundary-special/word-start-half-ascii-030,unsupported,
+word-boundary-special/word-start-half-ascii-040,unsupported,
+word-boundary-special/word-start-half-ascii-050,unsupported,
+word-boundary-special/word-start-half-ascii-060,unsupported,
+word-boundary-special/word-start-half-ascii-060-noutf8,unsupported,
+word-boundary-special/word-start-half-ascii-060-bounds,unsupported,
+word-boundary-special/word-start-half-ascii-070,unsupported,
+word-boundary-special/word-start-half-ascii-080,unsupported,
+word-boundary-special/word-start-half-ascii-090,unsupported,
+word-boundary-special/word-start-half-ascii-110,unsupported,
+word-boundary-special/word-end-half-ascii-010,unsupported,
+word-boundary-special/word-end-half-ascii-020,unsupported,
+word-boundary-special/word-end-half-ascii-030,unsupported,
+word-boundary-special/word-end-half-ascii-040,unsupported,
+word-boundary-special/word-end-half-ascii-050,unsupported,
+word-boundary-special/word-end-half-ascii-060,unsupported,
+word-boundary-special/word-end-half-ascii-060-bounds,unsupported,
+word-boundary-special/word-end-half-ascii-070,unsupported,
+word-boundary-special/word-end-half-ascii-080,unsupported,
+word-boundary-special/word-end-half-ascii-090,unsupported,
+word-boundary-special/word-end-half-ascii-110,unsupported,
+word-boundary-special/word-start-half-unicode-010,unsupported,
+word-boundary-special/word-start-half-unicode-020,unsupported,
+word-boundary-special/word-start-half-unicode-030,unsupported,
+word-boundary-special/word-start-half-unicode-040,unsupported,
+word-boundary-special/word-start-half-unicode-050,unsupported,
+word-boundary-special/word-start-half-unicode-060,unsupported,
+word-boundary-special/word-start-half-unicode-060-bounds,unsupported,
+word-boundary-special/word-start-half-unicode-070,unsupported,
+word-boundary-special/word-start-half-unicode-080,unsupported,
+word-boundary-special/word-start-half-unicode-090,unsupported,
+word-boundary-special/word-start-half-unicode-110,unsupported,
+word-boundary-special/word-end-half-unicode-010,unsupported,
+word-boundary-special/word-end-half-unicode-020,unsupported,
+word-boundary-special/word-end-half-unicode-030,unsupported,
+word-boundary-special/word-end-half-unicode-040,unsupported,
+word-boundary-special/word-end-half-unicode-050,unsupported,
+word-boundary-special/word-end-half-unicode-060,unsupported,
+word-boundary-special/word-end-half-unicode-060-bounds,unsupported,
+word-boundary-special/word-end-half-unicode-070,unsupported,
+word-boundary-special/word-end-half-unicode-080,unsupported,
+word-boundary-special/word-end-half-unicode-090,unsupported,
+word-boundary-special/word-end-half-unicode-110,unsupported,
+word-boundary-special/word-start-half-ascii-carriage,unsupported,
+word-boundary-special/word-start-half-ascii-linefeed,unsupported,
+word-boundary-special/word-start-half-ascii-customlineterm,unsupported,
+word-boundary/wb1,unsupported,
+word-boundary/wb2,unsupported,
+word-boundary/wb3,unsupported,
+word-boundary/wb4,unsupported,
+word-boundary/wb5,unsupported,
+word-boundary/wb6,unsupported,
+word-boundary/wb7,unsupported,
+word-boundary/wb8,unsupported,
+word-boundary/wb9,unsupported,
+word-boundary/wb10,unsupported,
+word-boundary/wb11,unsupported,
+word-boundary/wb12,unsupported,
+word-boundary/wb13,unsupported,
+word-boundary/wb14,unsupported,
+word-boundary/wb15,unsupported,
+word-boundary/wb16,unsupported,
+word-boundary/wb17,unsupported,
+word-boundary/wb18,unsupported,
+word-boundary/wb19,unsupported,
+word-boundary/wb20,unsupported,
+word-boundary/wb21,unsupported,
+word-boundary/wb22,unsupported,
+word-boundary/wb23,unsupported,
+word-boundary/wb24,unsupported,
+word-boundary/wb25,unsupported,
+word-boundary/wb26,unsupported,
+word-boundary/wb27,unsupported,
+word-boundary/wb28,unsupported,
+word-boundary/wb29,unsupported,
+word-boundary/wb30,unsupported,
+word-boundary/wb31,unsupported,
+word-boundary/wb32,unsupported,
+word-boundary/wb33,unsupported,
+word-boundary/wb34,unsupported,
+word-boundary/wb35,unsupported,
+word-boundary/wb36,unsupported,
+word-boundary/wb37,unsupported,
+word-boundary/wb38,unsupported,
+word-boundary/wb39,unsupported,
+word-boundary/wb40,unsupported,
+word-boundary/wb41,unsupported,
+word-boundary/wb42,unsupported,
+word-boundary/wb43,unsupported,
+word-boundary/wb44,unsupported,
+word-boundary/nb1,unsupported,
+word-boundary/nb2,unsupported,
+word-boundary/nb3,unsupported,
+word-boundary/nb4,unsupported,
+word-boundary/nb5,unsupported,
+word-boundary/nb6,unsupported,
+word-boundary/nb7,unsupported,
+word-boundary/nb8,unsupported,
+word-boundary/nb9,unsupported,
+word-boundary/nb10,unsupported,
+word-boundary/nb11,unsupported,
+word-boundary/nb12,unsupported,
+word-boundary/nb13,unsupported,
+word-boundary/nb14,unsupported,
+word-boundary/nb15,unsupported,
+word-boundary/nb16,unsupported,
+word-boundary/nb17,unsupported,
+word-boundary/nb18,unsupported,
+word-boundary/nb19,unsupported,
+word-boundary/nb20,unsupported,
+word-boundary/nb21,unsupported,
+word-boundary/nb22,unsupported,
+word-boundary/nb23,unsupported,
+word-boundary/nb24,unsupported,
+word-boundary/nb25,unsupported,
+word-boundary/nb26,unsupported,
+word-boundary/nb27,unsupported,
+word-boundary/nb28,unsupported,
+word-boundary/nb29,unsupported,
+word-boundary/nb30,unsupported,
+word-boundary/nb31,unsupported,
+word-boundary/nb32,unsupported,
+word-boundary/nb33,unsupported,
+word-boundary/nb34,unsupported,
+word-boundary/nb35,unsupported,
+word-boundary/nb36,unsupported,
+word-boundary/nb37,unsupported,
+word-boundary/nb38,unsupported,
+word-boundary/nb39,unsupported,
+word-boundary/unicode1,unsupported,
+word-boundary/unicode1-only-ascii,unsupported,
+word-boundary/unicode2,unsupported,
+word-boundary/unicode2-only-ascii,unsupported,
+word-boundary/unicode3,unsupported,
+word-boundary/unicode3-only-ascii,unsupported,
+word-boundary/unicode4,unsupported,
+word-boundary/unicode4-only-ascii,unsupported,
+word-boundary/unicode5,unsupported,
+word-boundary/unicode5-only-ascii,unsupported,
+word-boundary/unicode5-noutf8,unsupported,
+word-boundary/unicode5-noutf8-only-ascii,unsupported,
+word-boundary/unicode5-not,unsupported,
+word-boundary/unicode5-not-only-ascii,unsupported,
+word-boundary/unicode5-not-noutf8,unsupported,
+word-boundary/unicode5-not-noutf8-only-ascii,unsupported,
+word-boundary/unicode6,unsupported,
+word-boundary/unicode7,unsupported,
+word-boundary/unicode8,unsupported,
+word-boundary/alt-with-assertion-repetition,unsupported,

--- a/regex/tests/Test.lean
+++ b/regex/tests/Test.lean
@@ -1,5 +1,6 @@
 import Regex.Regex.Utilities
 import Regex.Regex.Elab
+import Regex.Backtracker
 
 namespace Epsilon
 
@@ -43,3 +44,62 @@ def empty_610 := Regex.parse! r##"(?:|a)+"##
 -- #guard empty_610.findAll "aaa" = #[(⟨0⟩, ⟨0⟩), (⟨1⟩, ⟨1⟩), (⟨2⟩, ⟨2⟩), (⟨3⟩, ⟨3⟩)]
 
 end Priority
+
+namespace Backtracker
+
+def simple_char := Regex.parse! r##"a"##
+#guard Regex.Backtracker.captureNextBuf simple_char.nfa simple_char.wf 2 "a".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
+#guard Regex.Backtracker.captureNextBuf simple_char.nfa simple_char.wf 2 "b".mkIterator = .none
+
+def simple_concat := Regex.parse! r##"ab"##
+#guard Regex.Backtracker.captureNextBuf simple_concat.nfa simple_concat.wf 2 "ab".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
+#guard Regex.Backtracker.captureNextBuf simple_concat.nfa simple_concat.wf 2 "ac".mkIterator = .none
+
+def simple_alt := Regex.parse! r##"a|b"##
+#guard Regex.Backtracker.captureNextBuf simple_alt.nfa simple_alt.wf 2 "a".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
+#guard Regex.Backtracker.captureNextBuf simple_alt.nfa simple_alt.wf 2 "b".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
+#guard Regex.Backtracker.captureNextBuf simple_alt.nfa simple_alt.wf 2 "c".mkIterator = .none
+
+def simple_star := Regex.parse! r##"a*"##
+#guard Regex.Backtracker.captureNextBuf simple_star.nfa simple_star.wf 2 "".mkIterator = .some #v[.some ⟨0⟩, .some ⟨0⟩]
+#guard Regex.Backtracker.captureNextBuf simple_star.nfa simple_star.wf 2 "a".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
+#guard Regex.Backtracker.captureNextBuf simple_star.nfa simple_star.wf 2 "aa".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
+
+def complex_pattern := Regex.parse! r##"(a|b)*c"##
+#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "c".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
+#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "ac".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
+#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "bc".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
+#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "aabbczy".mkIterator = .some #v[.some ⟨0⟩, .some ⟨5⟩]
+#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "d".mkIterator = .none
+
+def nested_groups := Regex.parse! r##"(a(b(c)))"##
+#guard Regex.Backtracker.captureNextBuf nested_groups.nfa nested_groups.wf 2 "abc".mkIterator = .some #v[.some ⟨0⟩, .some ⟨3⟩]
+#guard Regex.Backtracker.captureNextBuf nested_groups.nfa nested_groups.wf 2 "ab".mkIterator = .none
+#guard Regex.Backtracker.captureNextBuf nested_groups.nfa nested_groups.wf 2 "a".mkIterator = .none
+
+def complex_quantifiers := Regex.parse! r##"a{2,4}b{1,3}"##
+#guard Regex.Backtracker.captureNextBuf complex_quantifiers.nfa complex_quantifiers.wf 2 "aab".mkIterator = .some #v[.some ⟨0⟩, .some ⟨3⟩]
+#guard Regex.Backtracker.captureNextBuf complex_quantifiers.nfa complex_quantifiers.wf 2 "aaabbb".mkIterator = .some #v[.some ⟨0⟩, .some ⟨6⟩]
+#guard Regex.Backtracker.captureNextBuf complex_quantifiers.nfa complex_quantifiers.wf 2 "ab".mkIterator = .none
+#guard Regex.Backtracker.captureNextBuf complex_quantifiers.nfa complex_quantifiers.wf 2 "aabbb".mkIterator = .some #v[.some ⟨0⟩, .some ⟨5⟩]
+
+def alternation_with_groups := Regex.parse! r##"(ab|cd)(ef|gh)"##
+#guard Regex.Backtracker.captureNextBuf alternation_with_groups.nfa alternation_with_groups.wf 2 "abef".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
+#guard Regex.Backtracker.captureNextBuf alternation_with_groups.nfa alternation_with_groups.wf 2 "cdgh".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
+#guard Regex.Backtracker.captureNextBuf alternation_with_groups.nfa alternation_with_groups.wf 2 "abgh".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
+#guard Regex.Backtracker.captureNextBuf alternation_with_groups.nfa alternation_with_groups.wf 2 "cdef".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
+
+def complex_character_classes := Regex.parse! r##"[a-zA-Z0-9_]+@[a-zA-Z0-9]+\.[a-zA-Z]{2,}"##
+#guard Regex.Backtracker.captureNextBuf complex_character_classes.nfa complex_character_classes.wf 2 "test@example.com".mkIterator = .some #v[.some ⟨0⟩, .some ⟨16⟩]
+#guard Regex.Backtracker.captureNextBuf complex_character_classes.nfa complex_character_classes.wf 2 "user123@domain.org".mkIterator = .some #v[.some ⟨0⟩, .some ⟨18⟩]
+#guard Regex.Backtracker.captureNextBuf complex_character_classes.nfa complex_character_classes.wf 2 "invalid@email".mkIterator = .none
+#guard Regex.Backtracker.captureNextBuf complex_character_classes.nfa complex_character_classes.wf 2 "test@.com".mkIterator = .none
+
+def nested_quantifiers := Regex.parse! r##"(a+)*b"##
+#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "b".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
+#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "ab".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
+#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "aaab".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
+#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "a".mkIterator = .none
+#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "ba".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
+
+end Backtracker

--- a/regex/tests/Test.lean
+++ b/regex/tests/Test.lean
@@ -78,7 +78,6 @@ def simple_star := Regex.parse! r##"a*"##
 #guard simple_star.bt.capture "aa" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩]⟩
 
 def complex_pattern := Regex.parse! r##"(a|b)*c"##
-#eval complex_pattern.capture "c"
 #guard complex_pattern.capture "c" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩, .none, .none]⟩
 #guard complex_pattern.capture "ac" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩, .some ⟨0⟩, .some ⟨1⟩]⟩
 #guard complex_pattern.capture "bc" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩, .some ⟨0⟩, .some ⟨1⟩]⟩
@@ -129,7 +128,6 @@ def complex_character_classes := Regex.parse! r##"[a-zA-Z0-9_]+@[a-zA-Z0-9]+\.[a
 #guard complex_character_classes.bt.capture "test@.com" = .none
 
 def nested_quantifiers := Regex.parse! r##"(a+)*b"##
-#eval nested_quantifiers.capture "aaab"
 #guard nested_quantifiers.capture "b" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩, .none, .none]⟩
 #guard nested_quantifiers.capture "ab" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩, .some ⟨0⟩, .some ⟨1⟩]⟩
 #guard nested_quantifiers.capture "aaab" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨3⟩]⟩
@@ -140,5 +138,9 @@ def nested_quantifiers := Regex.parse! r##"(a+)*b"##
 #guard nested_quantifiers.bt.capture "aaab" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨3⟩]⟩
 #guard nested_quantifiers.bt.capture "a" = .none
 #guard nested_quantifiers.bt.capture "ba" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩, .none, .none]⟩
+
+def alt_in_alt_100 := re! r##"ab?|$"##
+#eval alt_in_alt_100.captureAll "az"
+#eval alt_in_alt_100.bt.captureAll "az"
 
 end Comparison

--- a/regex/tests/Test.lean
+++ b/regex/tests/Test.lean
@@ -69,7 +69,7 @@ def complex_pattern := Regex.parse! r##"(a|b)*c"##
 #guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "c".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
 #guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "ac".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
 #guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "bc".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
-#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "aabbczy".mkIterator = .some #v[.some ⟨0⟩, .some ⟨5⟩]
+#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "xyzaabbczy".mkIterator = .some #v[.some ⟨3⟩, .some ⟨8⟩]
 #guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "d".mkIterator = .none
 
 def nested_groups := Regex.parse! r##"(a(b(c)))"##

--- a/regex/tests/Test.lean
+++ b/regex/tests/Test.lean
@@ -45,61 +45,100 @@ def empty_610 := Regex.parse! r##"(?:|a)+"##
 
 end Priority
 
-namespace Backtracker
+namespace Comparison
+
+private def _root_.Regex.bt (regex : Regex) := { regex with useBacktracker := true }
 
 def simple_char := Regex.parse! r##"a"##
-#guard Regex.Backtracker.captureNextBuf simple_char.nfa simple_char.wf 2 "a".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
-#guard Regex.Backtracker.captureNextBuf simple_char.nfa simple_char.wf 2 "b".mkIterator = .none
+#guard simple_char.capture "a" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩]⟩
+#guard simple_char.capture "b" = .none
+#guard simple_char.bt.capture "a" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩]⟩
+#guard simple_char.bt.capture "b" = .none
 
 def simple_concat := Regex.parse! r##"ab"##
-#guard Regex.Backtracker.captureNextBuf simple_concat.nfa simple_concat.wf 2 "ab".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
-#guard Regex.Backtracker.captureNextBuf simple_concat.nfa simple_concat.wf 2 "ac".mkIterator = .none
+#guard simple_concat.capture "ab" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩]⟩
+#guard simple_concat.capture "ac" = .none
+#guard simple_concat.bt.capture "ab" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩]⟩
+#guard simple_concat.bt.capture "ac" = .none
 
 def simple_alt := Regex.parse! r##"a|b"##
-#guard Regex.Backtracker.captureNextBuf simple_alt.nfa simple_alt.wf 2 "a".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
-#guard Regex.Backtracker.captureNextBuf simple_alt.nfa simple_alt.wf 2 "b".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
-#guard Regex.Backtracker.captureNextBuf simple_alt.nfa simple_alt.wf 2 "c".mkIterator = .none
+#guard simple_alt.capture "a" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩]⟩
+#guard simple_alt.capture "b" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩]⟩
+#guard simple_alt.capture "c" = .none
+#guard simple_alt.bt.capture "a" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩]⟩
+#guard simple_alt.bt.capture "b" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩]⟩
+#guard simple_alt.bt.capture "c" = .none
 
 def simple_star := Regex.parse! r##"a*"##
-#guard Regex.Backtracker.captureNextBuf simple_star.nfa simple_star.wf 2 "".mkIterator = .some #v[.some ⟨0⟩, .some ⟨0⟩]
-#guard Regex.Backtracker.captureNextBuf simple_star.nfa simple_star.wf 2 "a".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
-#guard Regex.Backtracker.captureNextBuf simple_star.nfa simple_star.wf 2 "aa".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
+#guard simple_star.capture "" = .some ⟨#[.some ⟨0⟩, .some ⟨0⟩]⟩
+#guard simple_star.capture "a" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩]⟩
+#guard simple_star.capture "aa" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩]⟩
+#guard simple_star.bt.capture "" = .some ⟨#[.some ⟨0⟩, .some ⟨0⟩]⟩
+#guard simple_star.bt.capture "a" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩]⟩
+#guard simple_star.bt.capture "aa" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩]⟩
 
 def complex_pattern := Regex.parse! r##"(a|b)*c"##
-#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "c".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
-#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "ac".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
-#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "bc".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
-#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "xyzaabbczy".mkIterator = .some #v[.some ⟨3⟩, .some ⟨8⟩]
-#guard Regex.Backtracker.captureNextBuf complex_pattern.nfa complex_pattern.wf 2 "d".mkIterator = .none
+#eval complex_pattern.capture "c"
+#guard complex_pattern.capture "c" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩, .none, .none]⟩
+#guard complex_pattern.capture "ac" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩, .some ⟨0⟩, .some ⟨1⟩]⟩
+#guard complex_pattern.capture "bc" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩, .some ⟨0⟩, .some ⟨1⟩]⟩
+#guard complex_pattern.capture "xyzaabbczy" = .some ⟨#[.some ⟨3⟩, .some ⟨8⟩, .some ⟨6⟩, .some ⟨7⟩]⟩
+#guard complex_pattern.capture "d" = .none
+#guard complex_pattern.bt.capture "c" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩, .none, .none]⟩
+#guard complex_pattern.bt.capture "ac" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩, .some ⟨0⟩, .some ⟨1⟩]⟩
+#guard complex_pattern.bt.capture "bc" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩, .some ⟨0⟩, .some ⟨1⟩]⟩
+#guard complex_pattern.bt.capture "xyzaabbczy" = .some ⟨#[.some ⟨3⟩, .some ⟨8⟩, .some ⟨6⟩, .some ⟨7⟩]⟩
+#guard complex_pattern.bt.capture "d" = .none
 
 def nested_groups := Regex.parse! r##"(a(b(c)))"##
-#guard Regex.Backtracker.captureNextBuf nested_groups.nfa nested_groups.wf 2 "abc".mkIterator = .some #v[.some ⟨0⟩, .some ⟨3⟩]
-#guard Regex.Backtracker.captureNextBuf nested_groups.nfa nested_groups.wf 2 "ab".mkIterator = .none
-#guard Regex.Backtracker.captureNextBuf nested_groups.nfa nested_groups.wf 2 "a".mkIterator = .none
+#guard nested_groups.capture "abc" = .some ⟨#[.some ⟨0⟩, .some ⟨3⟩, .some ⟨0⟩, .some ⟨3⟩, .some ⟨1⟩, .some ⟨3⟩, .some ⟨2⟩, .some ⟨3⟩]⟩
+#guard nested_groups.capture "ab" = .none
+#guard nested_groups.capture "a" = .none
+#guard nested_groups.bt.capture "abc" = .some ⟨#[.some ⟨0⟩, .some ⟨3⟩, .some ⟨0⟩, .some ⟨3⟩, .some ⟨1⟩, .some ⟨3⟩, .some ⟨2⟩, .some ⟨3⟩]⟩
+#guard nested_groups.bt.capture "ab" = .none
+#guard nested_groups.bt.capture "a" = .none
 
 def complex_quantifiers := Regex.parse! r##"a{2,4}b{1,3}"##
-#guard Regex.Backtracker.captureNextBuf complex_quantifiers.nfa complex_quantifiers.wf 2 "aab".mkIterator = .some #v[.some ⟨0⟩, .some ⟨3⟩]
-#guard Regex.Backtracker.captureNextBuf complex_quantifiers.nfa complex_quantifiers.wf 2 "aaabbb".mkIterator = .some #v[.some ⟨0⟩, .some ⟨6⟩]
-#guard Regex.Backtracker.captureNextBuf complex_quantifiers.nfa complex_quantifiers.wf 2 "ab".mkIterator = .none
-#guard Regex.Backtracker.captureNextBuf complex_quantifiers.nfa complex_quantifiers.wf 2 "aabbb".mkIterator = .some #v[.some ⟨0⟩, .some ⟨5⟩]
+#guard complex_quantifiers.capture "aab" = .some ⟨#[.some ⟨0⟩, .some ⟨3⟩]⟩
+#guard complex_quantifiers.capture "aaabbb" = .some ⟨#[.some ⟨0⟩, .some ⟨6⟩]⟩
+#guard complex_quantifiers.capture "ab" = .none
+#guard complex_quantifiers.capture "aabbb" = .some ⟨#[.some ⟨0⟩, .some ⟨5⟩]⟩
+#guard complex_quantifiers.bt.capture "aab" = .some ⟨#[.some ⟨0⟩, .some ⟨3⟩]⟩
+#guard complex_quantifiers.bt.capture "aaabbb" = .some ⟨#[.some ⟨0⟩, .some ⟨6⟩]⟩
+#guard complex_quantifiers.bt.capture "ab" = .none
+#guard complex_quantifiers.bt.capture "aabbb" = .some ⟨#[.some ⟨0⟩, .some ⟨5⟩]⟩
 
 def alternation_with_groups := Regex.parse! r##"(ab|cd)(ef|gh)"##
-#guard Regex.Backtracker.captureNextBuf alternation_with_groups.nfa alternation_with_groups.wf 2 "abef".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
-#guard Regex.Backtracker.captureNextBuf alternation_with_groups.nfa alternation_with_groups.wf 2 "cdgh".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
-#guard Regex.Backtracker.captureNextBuf alternation_with_groups.nfa alternation_with_groups.wf 2 "abgh".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
-#guard Regex.Backtracker.captureNextBuf alternation_with_groups.nfa alternation_with_groups.wf 2 "cdef".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
+#guard alternation_with_groups.capture "abef" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨2⟩, .some ⟨2⟩, .some ⟨4⟩]⟩
+#guard alternation_with_groups.capture "cdgh" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨2⟩, .some ⟨2⟩, .some ⟨4⟩]⟩
+#guard alternation_with_groups.capture "abgh" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨2⟩, .some ⟨2⟩, .some ⟨4⟩]⟩
+#guard alternation_with_groups.capture "cdef" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨2⟩, .some ⟨2⟩, .some ⟨4⟩]⟩
+#guard alternation_with_groups.bt.capture "abef" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨2⟩, .some ⟨2⟩, .some ⟨4⟩]⟩
+#guard alternation_with_groups.bt.capture "cdgh" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨2⟩, .some ⟨2⟩, .some ⟨4⟩]⟩
+#guard alternation_with_groups.bt.capture "abgh" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨2⟩, .some ⟨2⟩, .some ⟨4⟩]⟩
+#guard alternation_with_groups.bt.capture "cdef" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨2⟩, .some ⟨2⟩, .some ⟨4⟩]⟩
 
 def complex_character_classes := Regex.parse! r##"[a-zA-Z0-9_]+@[a-zA-Z0-9]+\.[a-zA-Z]{2,}"##
-#guard Regex.Backtracker.captureNextBuf complex_character_classes.nfa complex_character_classes.wf 2 "test@example.com".mkIterator = .some #v[.some ⟨0⟩, .some ⟨16⟩]
-#guard Regex.Backtracker.captureNextBuf complex_character_classes.nfa complex_character_classes.wf 2 "user123@domain.org".mkIterator = .some #v[.some ⟨0⟩, .some ⟨18⟩]
-#guard Regex.Backtracker.captureNextBuf complex_character_classes.nfa complex_character_classes.wf 2 "invalid@email".mkIterator = .none
-#guard Regex.Backtracker.captureNextBuf complex_character_classes.nfa complex_character_classes.wf 2 "test@.com".mkIterator = .none
+#guard complex_character_classes.capture "test@example.com" = .some ⟨#[.some ⟨0⟩, .some ⟨16⟩]⟩
+#guard complex_character_classes.capture "user123@domain.org" = .some ⟨#[.some ⟨0⟩, .some ⟨18⟩]⟩
+#guard complex_character_classes.capture "invalid@email" = .none
+#guard complex_character_classes.capture "test@.com" = .none
+#guard complex_character_classes.bt.capture "test@example.com" = .some ⟨#[.some ⟨0⟩, .some ⟨16⟩]⟩
+#guard complex_character_classes.bt.capture "user123@domain.org" = .some ⟨#[.some ⟨0⟩, .some ⟨18⟩]⟩
+#guard complex_character_classes.bt.capture "invalid@email" = .none
+#guard complex_character_classes.bt.capture "test@.com" = .none
 
 def nested_quantifiers := Regex.parse! r##"(a+)*b"##
-#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "b".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
-#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "ab".mkIterator = .some #v[.some ⟨0⟩, .some ⟨2⟩]
-#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "aaab".mkIterator = .some #v[.some ⟨0⟩, .some ⟨4⟩]
-#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "a".mkIterator = .none
-#guard Regex.Backtracker.captureNextBuf nested_quantifiers.nfa nested_quantifiers.wf 2 "ba".mkIterator = .some #v[.some ⟨0⟩, .some ⟨1⟩]
+#eval nested_quantifiers.capture "aaab"
+#guard nested_quantifiers.capture "b" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩, .none, .none]⟩
+#guard nested_quantifiers.capture "ab" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩, .some ⟨0⟩, .some ⟨1⟩]⟩
+#guard nested_quantifiers.capture "aaab" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨3⟩]⟩
+#guard nested_quantifiers.capture "a" = .none
+#guard nested_quantifiers.capture "ba" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩, .none, .none]⟩
+#guard nested_quantifiers.bt.capture "b" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩, .none, .none]⟩
+#guard nested_quantifiers.bt.capture "ab" = .some ⟨#[.some ⟨0⟩, .some ⟨2⟩, .some ⟨0⟩, .some ⟨1⟩]⟩
+#guard nested_quantifiers.bt.capture "aaab" = .some ⟨#[.some ⟨0⟩, .some ⟨4⟩, .some ⟨0⟩, .some ⟨3⟩]⟩
+#guard nested_quantifiers.bt.capture "a" = .none
+#guard nested_quantifiers.bt.capture "ba" = .some ⟨#[.some ⟨0⟩, .some ⟨1⟩, .none, .none]⟩
 
-end Backtracker
+end Comparison


### PR DESCRIPTION
The PR introduces a bounded backtracking engine to the library. The backtracker works as if we implement regex matching as a recursive function (like in a parser combinator), but it records the visited `(position, NFA state)` pair to avoid the exponential behavior. It's runtime complexity is `O(NM)` where `N = input.length` and `M = NFA.nodes.size` and space complexity is also `O(NM)`. Since the memory usage can grow linearly as the input (while the NFA simulation takes only `O(M)`), the backtracker should be used when the haystack is short enough.

We don't prove the properties of the backtracker yet, so the proofs of utility functions take additional hypothesis to exclude the backtracker for now.