### PR TITLE
Verify backtracker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
             cd regex
             time lake exe CorpusTest --verify
             time lake exe CorpusTest --verify --backtracker
+            time lake exe CorpusTest --verify --backtracker
+            time lake exe CorpusTest --verify
         - name: Build RegexCorrectness
           uses: leanprover/lean-action@v1
           with:

--- a/correctness/RegexCorrectness/Backtracker.lean
+++ b/correctness/RegexCorrectness/Backtracker.lean
@@ -1,0 +1,6 @@
+import RegexCorrectness.Backtracker.Basic
+import RegexCorrectness.Backtracker.Path
+import RegexCorrectness.Backtracker.Traversal
+import RegexCorrectness.Backtracker.Compile
+import RegexCorrectness.Backtracker.Refinement
+import RegexCorrectness.Backtracker.Correctness

--- a/correctness/RegexCorrectness/Backtracker/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Basic.lean
@@ -2,9 +2,10 @@ import Regex.Backtracker
 
 set_option autoImplicit false
 
+open Regex.Data (BoundedIterator)
+
 namespace Regex.Backtracker
 
-set_option linter.unusedVariables false in
 theorem captureNextAux.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (startIdx maxIdx : Nat)
   (motive : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx) → List (StackEntry σ nfa startIdx maxIdx) → Prop)
   (base : ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)), motive visited [])
@@ -190,12 +191,10 @@ section
 
 variable {σ nfa wf startIdx maxIdx visited}
 
-@[simp]
 theorem captureNextAux_base :
   captureNextAux σ nfa wf startIdx maxIdx visited [] = (.none, visited) := by
   simp [captureNextAux]
 
-@[simp]
 theorem captureNextAux_visited {update state it eq stack'} (mem : visited.get state (it.index' eq)) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') = captureNextAux σ nfa wf startIdx maxIdx visited stack' := by
   conv =>
@@ -203,7 +202,6 @@ theorem captureNextAux_visited {update state it eq stack'} (mem : visited.get st
     unfold captureNextAux
     simp [mem]
 
-@[simp]
 theorem captureNextAux_done {update state it eq stack'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .done) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') = (.some update, visited.set state (it.index' eq)) := by
   simp at hn
@@ -213,7 +211,6 @@ theorem captureNextAux_done {update state it eq stack'} (mem : ¬visited.get sta
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_fail {update state it eq stack'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .fail) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') = (.none, visited.set state (it.index' eq)) := by
   conv =>
@@ -222,7 +219,6 @@ theorem captureNextAux_fail {update state it eq stack'} (mem : ¬visited.get sta
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_epsilon {update state it eq stack' state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .epsilon state') :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it, eq⟩ :: stack') := by
@@ -232,7 +228,6 @@ theorem captureNextAux_epsilon {update state it eq stack' state'} (mem : ¬visit
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_split {update state it eq stack' state₁ state₂} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .split state₁ state₂) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state₁, it, eq⟩ :: ⟨update, state₂, it, eq⟩ :: stack') := by
@@ -242,7 +237,6 @@ theorem captureNextAux_split {update state it eq stack' state₁ state₂} (mem 
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_save {update state it eq stack' offset state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .save offset state') :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨σ.write update offset it.pos, state', it, eq⟩ :: stack') := by
@@ -252,7 +246,6 @@ theorem captureNextAux_save {update state it eq stack' offset state'} (mem : ¬v
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_anchor_pos {update state it eq stack' a state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .anchor a state') (h : Data.Anchor.test it.it a) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it, eq⟩ :: stack') := by
@@ -262,7 +255,6 @@ theorem captureNextAux_anchor_pos {update state it eq stack' a state'} (mem : ¬
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_anchor_neg {update state it eq stack' a state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .anchor a state') (h : ¬Data.Anchor.test it.it a) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
@@ -272,7 +264,6 @@ theorem captureNextAux_anchor_neg {update state it eq stack' a state'} (mem : ¬
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_char_pos {update state it eq stack' c state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .char c state') (h : it.hasNext) (hc : it.curr h = c) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it.next h, eq⟩ :: stack') := by
@@ -282,7 +273,6 @@ theorem captureNextAux_char_pos {update state it eq stack' c state'} (mem : ¬vi
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_char_neg {update state it eq stack' c state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .char c state') (h : it.hasNext) (hc : ¬it.curr h = c) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
@@ -292,7 +282,6 @@ theorem captureNextAux_char_neg {update state it eq stack' c state'} (mem : ¬vi
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_char_end {update state it eq stack' c state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .char c state') (h : ¬it.hasNext) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
@@ -302,7 +291,6 @@ theorem captureNextAux_char_end {update state it eq stack' c state'} (mem : ¬vi
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_sparse_pos {update state it eq stack' cs state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .sparse cs state') (h : it.hasNext) (hc : it.curr h ∈ cs) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it.next h, eq⟩ :: stack') := by
@@ -312,7 +300,6 @@ theorem captureNextAux_sparse_pos {update state it eq stack' cs state'} (mem : �
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_sparse_neg {update state it eq stack' cs state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .sparse cs state') (h : it.hasNext) (hc : ¬it.curr h ∈ cs) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
@@ -322,7 +309,6 @@ theorem captureNextAux_sparse_neg {update state it eq stack' cs state'} (mem : �
     simp [mem]
   split <;> simp_all
 
-@[simp]
 theorem captureNextAux_sparse_end {update state it eq stack' cs state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .sparse cs state') (h : ¬it.hasNext) :
   captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
   captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
@@ -331,6 +317,71 @@ theorem captureNextAux_sparse_end {update state it eq stack' cs state'} (mem : �
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
+
+end
+
+theorem captureNext.go.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (startIdx : Nat)
+  (motive : (bit : BoundedIterator startIdx) → BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx) → Prop)
+  (found : ∀ (bit : BoundedIterator startIdx) (visited : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)) (update : σ.Update) (visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)),
+    captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.some update, visited') →
+    motive bit visited)
+  (not_found_next : ∀ (bit : BoundedIterator startIdx) (visited visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)),
+    captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.none, visited') →
+    (h : bit.hasNext) →
+    (ih : motive (bit.next h) visited') →
+    motive bit visited)
+  (not_found_end : ∀ (bit : BoundedIterator startIdx) (visited visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)),
+    captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.none, visited') →
+    ¬bit.hasNext →
+    motive bit visited)
+  (bit : BoundedIterator startIdx) (visited : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)) :
+  motive bit visited :=
+  captureNext.go.induct σ nfa wf startIdx motive
+    found
+    (fun bit visited visited' hres h _ ih => not_found_next bit visited visited' hres h ih)
+    not_found_end
+    bit visited
+
+/-
+Simplification lemmas for `captureNext.go`.
+-/
+section
+
+variable {σ nfa wf startIdx bit visited}
+
+theorem captureNext.go_found {update visited'} (h : captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.some update, visited')) :
+  captureNext.go σ nfa wf startIdx bit visited = (.some update, visited') := by
+  unfold captureNext.go
+  split <;> simp_all
+
+theorem captureNext.go_not_found_next {visited'} (h : captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.none, visited')) (h' : bit.hasNext) :
+  captureNext.go σ nfa wf startIdx bit visited = captureNext.go σ nfa wf startIdx (bit.next h') visited' := by
+  conv =>
+    lhs
+    unfold captureNext.go
+  split <;> simp_all
+
+theorem captureNext.go_not_found_end {visited'} (h : captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.none, visited')) (h' : ¬bit.hasNext) :
+  captureNext.go σ nfa wf startIdx bit visited = (.none, visited') := by
+  unfold captureNext.go
+  split <;> simp_all
+
+end
+
+/-
+Simplification lemmas for `captureNext`.
+-/
+section
+
+variable {σ nfa wf it}
+
+theorem captureNext_le (le : it.pos ≤ it.toString.endPos) :
+  captureNext σ nfa wf it = (captureNext.go σ nfa wf it.pos.byteIdx ⟨it, Nat.le_refl _, le⟩ (BitMatrix.zero _ _)).1 := by
+  simp [captureNext, le]
+
+theorem captureNext_not_le (h : ¬it.pos ≤ it.toString.endPos) :
+  captureNext σ nfa wf it = .none := by
+  simp [captureNext, h]
 
 end
 

--- a/correctness/RegexCorrectness/Backtracker/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Basic.lean
@@ -1,0 +1,337 @@
+import Regex.Backtracker
+
+set_option autoImplicit false
+
+namespace Regex.Backtracker
+
+set_option linter.unusedVariables false in
+theorem captureNextAux.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (startIdx maxIdx : Nat)
+  (motive : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx) → List (StackEntry σ nfa startIdx maxIdx) → Prop)
+  (base : ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)), motive visited [])
+  (visited :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    visited.get state (it.index' eq) →
+    motive visited stack' →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (done :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    nfa[state] = NFA.Node.done →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (fail :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    nfa[state] = NFA.Node.fail →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (epsilon :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.epsilon state' →
+    motive visited' (⟨update, state', it, eq⟩ :: stack') →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (split :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (state₁ state₂ : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.split state₁ state₂ →
+    motive visited' (⟨update, state₁, it, eq⟩ :: ⟨update, state₂, it, eq⟩ :: stack') →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (save :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (offset : Nat) (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.save offset state' →
+    let update' := σ.write update offset it.pos;
+    motive visited' (⟨update', state', it, eq⟩ :: stack') →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (anchor_pos :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (a : Data.Anchor) (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.anchor a state' →
+    Data.Anchor.test it.it a →
+    motive visited' (⟨update, state', it, eq⟩ :: stack') →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (anchor_neg :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (a : Data.Anchor) (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.anchor a state' →
+    ¬Data.Anchor.test it.it a →
+    motive visited' stack' →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (char_pos :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (c : Char) (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.char c state' →
+    (h : it.hasNext) →
+    it.curr h = c →
+    motive visited' (⟨update, state', it.next h, eq⟩ :: stack') →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (char_neg :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (c : Char) (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.char c state' →
+    (h : it.hasNext) →
+    ¬it.curr h = c →
+    motive visited' stack' →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (char_end :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (c : Char) (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.char c state' →
+    ¬it.hasNext →
+    motive visited' stack' →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (sparse_pos :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (cs : Data.Classes) (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.sparse cs state' →
+    (h : it.hasNext) →
+    it.curr h ∈ cs →
+    motive visited' (⟨update, state', it.next h, eq⟩ :: stack') →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (sparse_neg :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (cs : Data.Classes) (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.sparse cs state' →
+    (h : it.hasNext) →
+    ¬it.curr h ∈ cs →
+    motive visited' stack' →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (sparse_end :
+    ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (stack' : List (StackEntry σ nfa startIdx maxIdx)),
+    ¬visited.get state (it.index' eq) →
+    let visited' := visited.set state (it.index' eq);
+    ∀ (cs : Data.Classes) (state' : Fin nfa.nodes.size),
+    nfa[state] = NFA.Node.sparse cs state' →
+    ¬it.hasNext →
+    motive visited' stack' →
+    motive visited (⟨update, state, it, eq⟩ :: stack'))
+  (matrix : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (stack : List (StackEntry σ nfa startIdx maxIdx)) :
+  motive matrix stack :=
+  captureNextAux.induct σ nfa wf startIdx maxIdx motive base visited
+    (fun visited update state it eq stack' mem _ hn =>
+      done visited update state it eq stack' mem hn)
+    (fun visited update state it eq stack' mem _ hn =>
+      fail visited update state it eq stack' mem hn)
+    (fun visited update state it eq stack' mem _ state' hn isLt ih =>
+      epsilon visited update state it eq stack' mem ⟨state', isLt⟩ hn ih)
+    (fun visited update state it eq stack' mem _ state₁ state₂ hn isLt ih =>
+      split visited update state it eq stack' mem ⟨state₁, isLt.1⟩ ⟨state₂, isLt.2⟩ hn ih)
+    (fun visited update state it eq stack' mem _ offset state' hn isLt ih =>
+      save visited update state it eq stack' mem offset ⟨state', isLt⟩ hn ih)
+    (fun visited update state it eq stack' mem _ a state' hn isLt ih =>
+      anchor_pos visited update state it eq stack' mem a ⟨state', isLt⟩ hn ih)
+    (fun visited update state it eq stack' mem _ a state' hn isLt ih =>
+      anchor_neg visited update state it eq stack' mem a ⟨state', isLt⟩ hn ih)
+    (fun visited update state it eq stack' mem _ state' isLt h hn ih =>
+      char_pos visited update state it eq stack' mem (it.curr h) ⟨state', isLt⟩ hn h rfl ih)
+    (fun visited update state it eq stack' mem _ c state' hn isLt h ne ih =>
+      char_neg visited update state it eq stack' mem c ⟨state', isLt⟩ hn h ne ih)
+    (fun visited update state it eq stack' mem _ c state' hn isLt h ih =>
+      char_end visited update state it eq stack' mem c ⟨state', isLt⟩ hn h ih)
+    (fun visited update state it eq stack' mem _ cs state' hn isLt h ih =>
+      sparse_pos visited update state it eq stack' mem cs ⟨state', isLt⟩ hn h ih)
+    (fun visited update state it eq stack' mem _ cs state' hn isLt h ih =>
+      sparse_neg visited update state it eq stack' mem cs ⟨state', isLt⟩ hn h ih)
+    (fun visited update state it eq stack' mem _ cs state' hn isLt h ih =>
+      sparse_end visited update state it eq stack' mem cs ⟨state', isLt⟩ hn h ih)
+    matrix stack
+
+/-
+Simplification lemmas for `captureNextAux`.
+-/
+section
+
+variable {σ nfa wf startIdx maxIdx visited}
+
+@[simp]
+theorem captureNextAux_base :
+  captureNextAux σ nfa wf startIdx maxIdx visited [] = (.none, visited) := by
+  simp [captureNextAux]
+
+@[simp]
+theorem captureNextAux_visited {update state it eq stack'} (mem : visited.get state (it.index' eq)) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') = captureNextAux σ nfa wf startIdx maxIdx visited stack' := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+
+@[simp]
+theorem captureNextAux_done {update state it eq stack'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .done) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') = (.some update, visited.set state (it.index' eq)) := by
+  simp at hn
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_fail {update state it eq stack'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .fail) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') = (.none, visited.set state (it.index' eq)) := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_epsilon {update state it eq stack' state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .epsilon state') :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it, eq⟩ :: stack') := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_split {update state it eq stack' state₁ state₂} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .split state₁ state₂) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state₁, it, eq⟩ :: ⟨update, state₂, it, eq⟩ :: stack') := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_save {update state it eq stack' offset state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .save offset state') :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨σ.write update offset it.pos, state', it, eq⟩ :: stack') := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_anchor_pos {update state it eq stack' a state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .anchor a state') (h : Data.Anchor.test it.it a) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it, eq⟩ :: stack') := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_anchor_neg {update state it eq stack' a state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .anchor a state') (h : ¬Data.Anchor.test it.it a) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_char_pos {update state it eq stack' c state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .char c state') (h : it.hasNext) (hc : it.curr h = c) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it.next h, eq⟩ :: stack') := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_char_neg {update state it eq stack' c state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .char c state') (h : it.hasNext) (hc : ¬it.curr h = c) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_char_end {update state it eq stack' c state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .char c state') (h : ¬it.hasNext) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_sparse_pos {update state it eq stack' cs state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .sparse cs state') (h : it.hasNext) (hc : it.curr h ∈ cs) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it.next h, eq⟩ :: stack') := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_sparse_neg {update state it eq stack' cs state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .sparse cs state') (h : it.hasNext) (hc : ¬it.curr h ∈ cs) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+@[simp]
+theorem captureNextAux_sparse_end {update state it eq stack' cs state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .sparse cs state') (h : ¬it.hasNext) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+  conv =>
+    lhs
+    unfold captureNextAux
+    simp [mem]
+  split <;> simp_all
+
+end
+
+end Regex.Backtracker

--- a/correctness/RegexCorrectness/Backtracker/Compile.lean
+++ b/correctness/RegexCorrectness/Backtracker/Compile.lean
@@ -11,26 +11,29 @@ open Regex.Data (BoundedIterator Span)
 
 namespace Regex.Backtracker
 
-theorem captureNext.go.path_done_of_some {nfa wf startIdx bit} {update} {visited visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)}
+theorem captureNext.go.path_done_of_some {nfa wf startIdx bit update} {visited visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)}
   (v : bit.Valid) (hres : captureNext.go HistoryStrategy nfa wf startIdx bit visited = (.some update, visited')) :
-  ∃ state span, nfa[state] = .done ∧ Path nfa wf span state update := by
+  ∃ l r state span, span.toString = bit.it.toString ∧ nfa[state] = .done ∧ Path nfa wf l r span state update := by
   induction bit, visited using captureNext.go.induct' HistoryStrategy nfa wf startIdx with
   | found bit visited update' visited' haux =>
     simp [captureNext.go_found haux] at hres
     simp [hres] at haux
-    have inv₀ : captureNextAux.UpperInv wf [⟨[], ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] := by
+    have ⟨l, r, vf⟩ := (bit.valid_of_valid v).validFor
+    have inv₀ : captureNextAux.UpperInv wf l.reverse r [⟨[], ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] := by
       refine ⟨?_⟩
       simp
-      have ⟨l, r, vf⟩ := (bit.valid_of_valid v).validFor
-      exact ⟨⟨l.reverse, [], r⟩, (Span.validFor ⟨l.reverse, [], r⟩).eq_it (by simp [vf]), .init⟩
-    exact captureNextAux.path_done_of_some haux inv₀
+      have vfs := Span.validFor ⟨l.reverse, [], r⟩
+      simp at vfs
+      exact ⟨⟨l.reverse, [], r⟩, vfs.eq_it vf, .init⟩
+    have ⟨state, span, hn, path⟩ := captureNextAux.path_done_of_some haux inv₀
+    exact ⟨l.reverse, r, state, span, by simp [path.string_eq, vf.out], hn, path⟩
   | not_found_next bit visited visited' haux hnext ih =>
     simp [captureNext.go_not_found_next haux hnext] at hres
     exact ih (bit.next_valid hnext v) hres
   | not_found_end bit visited visited' haux hnext => simp [captureNext.go_not_found_end haux hnext] at hres
 
 theorem captureNext.path_done_of_some {nfa wf it update} (hres : captureNext HistoryStrategy nfa wf it = .some update) (v : it.Valid) :
-  ∃ state span, nfa[state] = .done ∧ Path nfa wf span state update := by
+  ∃ l r state span, span.toString = it.toString ∧ nfa[state] = .done ∧ Path nfa wf l r span state update := by
   if le : it.pos ≤ it.toString.endPos then
     simp [captureNext_le le] at hres
     let result := go HistoryStrategy nfa wf it.pos.byteIdx ⟨it, (Nat.le_refl _), le⟩ (BitMatrix.zero _ _)
@@ -45,11 +48,11 @@ theorem captureNext.capture_of_some_compile {e it update} (hres : captureNext Hi
     span.toString = it.toString ∧
     e.Captures ⟨l, [], r⟩ span groups ∧
     EquivUpdate groups update := by
-  have ⟨state, span, hn, path⟩ := captureNext.path_done_of_some hres v
+  have ⟨l, r, state, span, eqstring, hn, path⟩ := captureNext.path_done_of_some hres v
   have eq_zero := (NFA.done_iff_zero_compile rfl state).mp hn
   have ne : state.val ≠ (NFA.compile e).start := eq_zero ▸ Nat.ne_of_lt (NFA.lt_zero_start_compile rfl)
-  have ⟨l, r, path⟩ := path.nfaPath_of_ne ne
+  have path := path.nfaPath_of_ne ne
   have ⟨groups, eqv, c⟩ := NFA.captures_of_path_compile rfl (eq_zero ▸ path.compile_liftBound rfl)
-  exact ⟨l, r, span, groups, sorry, c, eqv⟩
+  exact ⟨l, r, span, groups, eqstring, c, eqv⟩
 
 end Regex.Backtracker

--- a/correctness/RegexCorrectness/Backtracker/Compile.lean
+++ b/correctness/RegexCorrectness/Backtracker/Compile.lean
@@ -1,0 +1,55 @@
+import RegexCorrectness.Data.BoundedIterator
+import RegexCorrectness.Data.Span
+import RegexCorrectness.Backtracker.Traversal
+import RegexCorrectness.NFA.Semantics
+
+set_option autoImplicit false
+
+open String (Pos)
+open Regex.NFA (EquivUpdate)
+open Regex.Data (BoundedIterator Span)
+
+namespace Regex.Backtracker
+
+theorem captureNext.go.path_done_of_some {nfa wf startIdx bit} {update} {visited visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)}
+  (v : bit.Valid) (hres : captureNext.go HistoryStrategy nfa wf startIdx bit visited = (.some update, visited')) :
+  ∃ state span, nfa[state] = .done ∧ Path nfa wf span state update := by
+  induction bit, visited using captureNext.go.induct' HistoryStrategy nfa wf startIdx with
+  | found bit visited update' visited' haux =>
+    simp [captureNext.go_found haux] at hres
+    simp [hres] at haux
+    have inv₀ : captureNextAux.UpperInv wf [⟨[], ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] := by
+      refine ⟨?_⟩
+      simp
+      have ⟨l, r, vf⟩ := (bit.valid_of_valid v).validFor
+      exact ⟨⟨l.reverse, [], r⟩, (Span.validFor ⟨l.reverse, [], r⟩).eq_it (by simp [vf]), .init⟩
+    exact captureNextAux.path_done_of_some haux inv₀
+  | not_found_next bit visited visited' haux hnext ih =>
+    simp [captureNext.go_not_found_next haux hnext] at hres
+    exact ih (bit.next_valid hnext v) hres
+  | not_found_end bit visited visited' haux hnext => simp [captureNext.go_not_found_end haux hnext] at hres
+
+theorem captureNext.path_done_of_some {nfa wf it update} (hres : captureNext HistoryStrategy nfa wf it = .some update) (v : it.Valid) :
+  ∃ state span, nfa[state] = .done ∧ Path nfa wf span state update := by
+  if le : it.pos ≤ it.toString.endPos then
+    simp [captureNext_le le] at hres
+    let result := go HistoryStrategy nfa wf it.pos.byteIdx ⟨it, (Nat.le_refl _), le⟩ (BitMatrix.zero _ _)
+    change result.1 = .some update at hres
+    have : result = (.some update, result.2) := by simp [Prod.ext_iff, hres]
+    exact captureNext.go.path_done_of_some (BoundedIterator.valid_of_it_valid _ v) this
+  else
+    simp [captureNext_not_le le] at hres
+
+theorem captureNext.capture_of_some_compile {e it update} (hres : captureNext HistoryStrategy (NFA.compile e) NFA.compile_wf it = .some update) (v : it.Valid) :
+  ∃ l r span groups,
+    span.toString = it.toString ∧
+    e.Captures ⟨l, [], r⟩ span groups ∧
+    EquivUpdate groups update := by
+  have ⟨state, span, hn, path⟩ := captureNext.path_done_of_some hres v
+  have eq_zero := (NFA.done_iff_zero_compile rfl state).mp hn
+  have ne : state.val ≠ (NFA.compile e).start := eq_zero ▸ Nat.ne_of_lt (NFA.lt_zero_start_compile rfl)
+  have ⟨l, r, path⟩ := path.nfaPath_of_ne ne
+  have ⟨groups, eqv, c⟩ := NFA.captures_of_path_compile rfl (eq_zero ▸ path.compile_liftBound rfl)
+  exact ⟨l, r, span, groups, sorry, c, eqv⟩
+
+end Regex.Backtracker

--- a/correctness/RegexCorrectness/Backtracker/Correctness.lean
+++ b/correctness/RegexCorrectness/Backtracker/Correctness.lean
@@ -12,16 +12,19 @@ namespace Regex.Backtracker
 theorem captureNext_correct {e bufferSize it matchedB}
   (disj : e.Disjoint)
   (hresB : captureNext (BufferStrategy bufferSize) (NFA.compile e) NFA.compile_wf it = .some matchedB) (v : it.Valid) :
-  ∃ l r span groups,
-    span.toString = it.toString ∧
-    e.Captures ⟨l, [], r⟩ span groups ∧
+  ∃ l m r groups,
+    it.toString = ⟨l ++ m ++ r⟩ ∧
+    e.Captures ⟨l, [], m ++ r⟩ ⟨l, m.reverse, r⟩ groups ∧
     EquivMaterializedUpdate (materializeRegexGroups groups) matchedB := by
   match hresH : captureNext HistoryStrategy (NFA.compile e) NFA.compile_wf it with
   | .some matchedH =>
     have ref := hresH ▸ hresB ▸ captureNext.refines (NFA.compile e) NFA.compile_wf bufferSize it
     simp [refineUpdateOpt, refineUpdate] at ref
     have ⟨l, r, span, groups, eqstring, c, eqv⟩ := captureNext.capture_of_some_compile hresH v
-    exact ⟨l, r, span, groups, eqstring, c, ref ▸ eqv.materialize c disj⟩
+    have ⟨m, eql, eqm, eqr⟩ := c.span_eq
+    simp at eql eqm eqr
+    have : span.m.reverse ++ span.r = r := by simp [eqr, ←eqm]
+    exact ⟨l, span.m.reverse, span.r, groups, by rw [←eqstring, Span.toString, eql], by simpa [this, eql] using c, ref ▸ eqv.materialize c disj⟩
   | .none =>
     have := hresH ▸ hresB ▸ captureNext.refines (NFA.compile e) NFA.compile_wf bufferSize it
     simp [refineUpdateOpt] at this

--- a/correctness/RegexCorrectness/Backtracker/Correctness.lean
+++ b/correctness/RegexCorrectness/Backtracker/Correctness.lean
@@ -1,0 +1,29 @@
+import RegexCorrectness.Backtracker.Compile
+import RegexCorrectness.Backtracker.Refinement
+
+set_option autoImplicit false
+
+open Regex.Data (Span)
+open Regex (NFA)
+open Regex.Strategy (EquivMaterializedUpdate materializeRegexGroups materializeUpdates refineUpdateOpt refineUpdate)
+
+namespace Regex.Backtracker
+
+theorem captureNext_correct {e bufferSize it matchedB}
+  (disj : e.Disjoint)
+  (hresB : captureNext (BufferStrategy bufferSize) (NFA.compile e) NFA.compile_wf it = .some matchedB) (v : it.Valid) :
+  ∃ l r span groups,
+    span.toString = it.toString ∧
+    e.Captures ⟨l, [], r⟩ span groups ∧
+    EquivMaterializedUpdate (materializeRegexGroups groups) matchedB := by
+  match hresH : captureNext HistoryStrategy (NFA.compile e) NFA.compile_wf it with
+  | .some matchedH =>
+    have ref := hresH ▸ hresB ▸ captureNext.refines (NFA.compile e) NFA.compile_wf bufferSize it
+    simp [refineUpdateOpt, refineUpdate] at ref
+    have ⟨l, r, span, groups, eqstring, c, eqv⟩ := captureNext.capture_of_some_compile hresH v
+    exact ⟨l, r, span, groups, eqstring, c, ref ▸ eqv.materialize c disj⟩
+  | .none =>
+    have := hresH ▸ hresB ▸ captureNext.refines (NFA.compile e) NFA.compile_wf bufferSize it
+    simp [refineUpdateOpt] at this
+
+end Regex.Backtracker

--- a/correctness/RegexCorrectness/Backtracker/Path.lean
+++ b/correctness/RegexCorrectness/Backtracker/Path.lean
@@ -6,38 +6,44 @@ open Regex.Data (Span)
 
 namespace Regex.Backtracker
 
-inductive Path (nfa : NFA) (wf : nfa.WellFormed) : Span → Fin nfa.nodes.size → List (Nat × String.Pos) → Prop where
-  | init {l r} : Path nfa wf ⟨l, [], r⟩ ⟨nfa.start, wf.start_lt⟩ []
-  | more {i j : Fin nfa.nodes.size} {span₁ span₂ update₁ update₂ update₃} (prev : Path nfa wf span₁ i update₁) (step : nfa.Step 0 i span₁ j span₂ update₂)
+inductive Path (nfa : NFA) (wf : nfa.WellFormed) (l r : List Char) : Span → Fin nfa.nodes.size → List (Nat × String.Pos) → Prop where
+  | init : Path nfa wf l r ⟨l, [], r⟩ ⟨nfa.start, wf.start_lt⟩ []
+  | more {i j : Fin nfa.nodes.size} {span₁ span₂ update₁ update₂ update₃} (prev : Path nfa wf l r span₁ i update₁) (step : nfa.Step 0 i span₁ j span₂ update₂)
     (equpdate : update₃ = update₁ ++ List.ofOption update₂) :
-    Path nfa wf span₂ j update₃
+    Path nfa wf l r span₂ j update₃
 
 namespace Path
 
-theorem eq_or_nfaPath {nfa : NFA} {wf : nfa.WellFormed} {span i update} (path : Path nfa wf span i update) :
-  ∃ l r,
-    (span = ⟨l, [], r⟩ ∧ i.val = nfa.start ∧ update = []) ∨
-    nfa.Path 0 nfa.start ⟨l, [], r⟩ i span update := by
+theorem span_eq {nfa : NFA} {wf : nfa.WellFormed} {l r span i update} (path : Path nfa wf l r span i update) :
+  l = span.l ∧ r = span.m.reverse ++ span.r := by
   induction path with
-  | @init l r =>
-    exists l, r
-    simp
+  | init => simp
   | @more i j span₁ span₂ update₁ update₂ update₃ prev step equpdate ih =>
-    have ⟨l, r, h⟩ := ih
-    exists l, r
-    match h with
+    match step.span_eq_or_next with
+    | .inl eq => simp [eq, ih]
+    | .inr ⟨c, r', eqr, eq⟩ => simp_all
+
+theorem string_eq {nfa : NFA} {wf : nfa.WellFormed} {l r span i update} (path : Path nfa wf l r span i update) :
+  span.toString = ⟨l ++ r⟩ := by
+  simp [Span.toString, ←path.span_eq]
+
+theorem eq_or_nfaPath {nfa : NFA} {wf : nfa.WellFormed} {l r span i update} (path : Path nfa wf l r span i update) :
+  (span = ⟨l, [], r⟩ ∧ i.val = nfa.start ∧ update = []) ∨
+  nfa.Path 0 nfa.start ⟨l, [], r⟩ i span update := by
+  induction path with
+  | init => simp
+  | @more i j span₁ span₂ update₁ update₂ update₃ prev step equpdate ih =>
+    match ih with
     | .inl ⟨eqspan, eqi, equpdate'⟩ =>
       simp [equpdate, equpdate']
-      exact .inr (.last (eqspan ▸ eqi ▸ step))
+      refine .inr (.last (eqspan ▸ eqi ▸ step))
     | .inr path =>
       simp [equpdate]
-      exact .inr (path.trans (.last step))
+      refine .inr (path.trans (.last step))
 
-theorem nfaPath_of_ne {nfa : NFA} {wf : nfa.WellFormed} {span i update} (path : Path nfa wf span i update) (ne : i.val ≠ nfa.start) :
-  ∃ l r, nfa.Path 0 nfa.start ⟨l, [], r⟩ i span update := by
-  have ⟨l, r, h⟩ := eq_or_nfaPath path
-  simp [ne] at h
-  exact ⟨l, r, h⟩
+theorem nfaPath_of_ne {nfa : NFA} {wf : nfa.WellFormed} {l r span i update} (path : Path nfa wf l r span i update) (ne : i.val ≠ nfa.start) :
+  nfa.Path 0 nfa.start ⟨l, [], r⟩ i span update := by
+  simpa [ne] using eq_or_nfaPath path
 
 end Path
 

--- a/correctness/RegexCorrectness/Backtracker/Path.lean
+++ b/correctness/RegexCorrectness/Backtracker/Path.lean
@@ -1,0 +1,44 @@
+import RegexCorrectness.NFA.Semantics.Path
+
+set_option autoImplicit false
+
+open Regex.Data (Span)
+
+namespace Regex.Backtracker
+
+inductive Path (nfa : NFA) (wf : nfa.WellFormed) : Span → Fin nfa.nodes.size → List (Nat × String.Pos) → Prop where
+  | init {l r} : Path nfa wf ⟨l, [], r⟩ ⟨nfa.start, wf.start_lt⟩ []
+  | more {i j : Fin nfa.nodes.size} {span₁ span₂ update₁ update₂ update₃} (prev : Path nfa wf span₁ i update₁) (step : nfa.Step 0 i span₁ j span₂ update₂)
+    (equpdate : update₃ = update₁ ++ List.ofOption update₂) :
+    Path nfa wf span₂ j update₃
+
+namespace Path
+
+theorem eq_or_nfaPath {nfa : NFA} {wf : nfa.WellFormed} {span i update} (path : Path nfa wf span i update) :
+  ∃ l r,
+    (span = ⟨l, [], r⟩ ∧ i.val = nfa.start ∧ update = []) ∨
+    nfa.Path 0 nfa.start ⟨l, [], r⟩ i span update := by
+  induction path with
+  | @init l r =>
+    exists l, r
+    simp
+  | @more i j span₁ span₂ update₁ update₂ update₃ prev step equpdate ih =>
+    have ⟨l, r, h⟩ := ih
+    exists l, r
+    match h with
+    | .inl ⟨eqspan, eqi, equpdate'⟩ =>
+      simp [equpdate, equpdate']
+      exact .inr (.last (eqspan ▸ eqi ▸ step))
+    | .inr path =>
+      simp [equpdate]
+      exact .inr (path.trans (.last step))
+
+theorem nfaPath_of_ne {nfa : NFA} {wf : nfa.WellFormed} {span i update} (path : Path nfa wf span i update) (ne : i.val ≠ nfa.start) :
+  ∃ l r, nfa.Path 0 nfa.start ⟨l, [], r⟩ i span update := by
+  have ⟨l, r, h⟩ := eq_or_nfaPath path
+  simp [ne] at h
+  exact ⟨l, r, h⟩
+
+end Path
+
+end Regex.Backtracker

--- a/correctness/RegexCorrectness/Backtracker/Refinement.lean
+++ b/correctness/RegexCorrectness/Backtracker/Refinement.lean
@@ -1,0 +1,184 @@
+import RegexCorrectness.Backtracker.Traversal
+import RegexCorrectness.Strategy
+
+set_option autoImplicit false
+
+open Regex (NFA)
+open Regex.Data (BoundedIterator)
+open Regex.Strategy (refineUpdate refineUpdateOpt refineUpdates materializeUpdates)
+open String (Pos)
+namespace Regex.Backtracker
+
+variable {nfa : NFA} {wf : nfa.WellFormed} {startIdx maxIdx bufferSize : Nat}
+
+def StackEntry.Refines (entryH : StackEntry HistoryStrategy nfa startIdx maxIdx) (entryB : StackEntry (BufferStrategy bufferSize) nfa startIdx maxIdx) : Prop :=
+  refineUpdate entryH.update entryB.update ∧ entryH.state = entryB.state ∧ entryH.it = entryB.it
+
+theorem StackEntry.Refines.simpL {update state it eq} {entryB : StackEntry (BufferStrategy bufferSize) nfa startIdx maxIdx} (ref : StackEntry.Refines ⟨update, state, it, eq⟩ entryB) :
+  entryB = ⟨entryB.update, state, it, eq⟩ := by
+  unfold StackEntry.Refines at ref
+  simp_all
+
+theorem StackEntry.Refines.mk {update} {state state' : Fin nfa.nodes.size} {it it' : BoundedIterator startIdx} {eq : it.maxIdx = maxIdx} {eq' : it'.maxIdx = maxIdx} {entryB : StackEntry (BufferStrategy bufferSize) nfa startIdx maxIdx}
+  (ref : StackEntry.Refines ⟨update, state, it, eq⟩ entryB) :
+  StackEntry.Refines ⟨update, state', it', eq'⟩ ⟨entryB.update, state', it', eq'⟩ := by
+  simp [Refines] at ref
+  simp [Refines, ref]
+
+theorem StackEntry.Refines.empty {state : Fin nfa.nodes.size} {it : BoundedIterator startIdx} {eq : it.maxIdx = maxIdx} : StackEntry.Refines ⟨HistoryStrategy.empty, state, it, eq⟩ ⟨(BufferStrategy bufferSize).empty, state, it, eq⟩ := by
+  simp [Refines]
+
+inductive RefineStack : List (StackEntry HistoryStrategy nfa startIdx maxIdx) → List (StackEntry (BufferStrategy bufferSize) nfa startIdx maxIdx) → Prop where
+  | nil : RefineStack [] []
+  | cons (entryH entryB stackH stackB) : entryH.Refines entryB → RefineStack stackH stackB → RefineStack (entryH :: stackH) (entryB :: stackB)
+
+def Refines (resultH : Option (List (Nat × Pos)) × BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (resultB : Option (Buffer bufferSize) × BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) : Prop :=
+  refineUpdateOpt resultH.1 resultB.1 ∧ resultH.2 = resultB.2
+
+theorem captureNextAux.refines (nfa wf startIdx maxIdx bufferSize visited) {stackH stackB} (refStack : RefineStack stackH stackB) :
+  Refines (captureNextAux HistoryStrategy nfa wf startIdx maxIdx visited stackH) (captureNextAux (BufferStrategy bufferSize) nfa wf startIdx maxIdx visited stackB) := by
+  induction visited, stackH using captureNextAux.induct' HistoryStrategy nfa wf startIdx maxIdx generalizing stackB with
+  | base visited =>
+    cases refStack with
+    | nil => simp [captureNextAux_base, Refines, refineUpdateOpt]
+  | visited visited update state' it eq stackH mem ih =>
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_visited mem]
+      exact ih refStack
+  | done visited update state' it eq stackH mem hn =>
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_done mem hn, Refines, refineUpdateOpt, refEntry.1]
+  | fail visited update state' it eq stackH mem hn =>
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_fail mem hn, Refines, refineUpdateOpt]
+  | epsilon visited update state it eq stackH mem visited' state' hn =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_epsilon mem hn]
+      exact ih (.cons _ _ _ _ refEntry.mk refStack)
+  | split visited update state it eq stackH mem visited' state₁ state₂ hn =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_split mem hn]
+      exact ih (.cons _ _ _ _ refEntry.mk (.cons _ _ _ _ refEntry.mk refStack))
+  | save visited update state it eq stackH mem visited' offset state' hn update' =>
+    -- This is the only interesting case, where we update the history/buffer
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_save mem hn]
+      refine ih (.cons _ _ _ _ ?_ refStack)
+      simp [StackEntry.Refines, refineUpdate] at refEntry
+      simp [StackEntry.Refines, update', refineUpdate, HistoryStrategy, BufferStrategy, refEntry.1]
+  | anchor_pos visited update state it eq stackH mem visited' a state' hn ht =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_anchor_pos mem hn ht]
+      exact ih (.cons _ _ _ _ refEntry.mk refStack)
+  | anchor_neg visited update state it eq stackH mem visited' a state' hn ht =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_anchor_neg mem hn ht]
+      exact ih refStack
+  | char_pos visited update state it eq stackH mem visited' c state' hn hnext hc =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_char_pos mem hn hnext hc]
+      exact ih (.cons _ _ _ _ refEntry.mk refStack)
+  | char_neg visited update state it eq stackH mem visited' c state' hn hnext hc =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_char_neg mem hn hnext hc]
+      exact ih refStack
+  | char_end visited update state it eq stackH mem visited' c state' hn hnext =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_char_end mem hn hnext]
+      exact ih refStack
+  | sparse_pos visited update state it eq stackH mem visited' cs state' hn hnext hc =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_sparse_pos mem hn hnext hc]
+      exact ih (.cons _ _ _ _ refEntry.mk refStack)
+  | sparse_neg visited update state it eq stackH mem visited' cs state' hn hnext hc =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_sparse_neg mem hn hnext hc]
+      exact ih refStack
+  | sparse_end visited update state it eq stackH mem visited' cs state' hn hnext =>
+    rename_i ih
+    cases refStack with
+    | cons entryH entryB stackH stackB refEntry refStack =>
+      rw [refEntry.simpL]
+      simp [captureNextAux_sparse_end mem hn hnext]
+      exact ih refStack
+
+theorem captureNext.go.refines (nfa wf startIdx bufferSize bit visited) :
+  Refines (captureNext.go HistoryStrategy nfa wf startIdx bit visited) (captureNext.go (BufferStrategy bufferSize) nfa wf startIdx bit visited) := by
+  induction bit, visited using captureNext.go.induct' HistoryStrategy nfa wf startIdx with
+  | found bit visited updateH visitedH hauxH =>
+    let entryH : StackEntry HistoryStrategy nfa startIdx bit.maxIdx := ⟨HistoryStrategy.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩
+    let entryB : StackEntry (BufferStrategy bufferSize) nfa startIdx bit.maxIdx := ⟨(BufferStrategy bufferSize).empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩
+    have refStack : RefineStack [entryH] [entryB] := .cons entryH entryB [] [] .empty .nil
+    have refResult := captureNextAux.refines nfa wf startIdx bit.maxIdx bufferSize visited refStack
+    match hauxB : captureNextAux (BufferStrategy bufferSize) nfa wf startIdx bit.maxIdx visited [entryB] with
+    | (.some updateB, visitedB) =>
+      simp [Refines, entryH, hauxH, hauxB, refineUpdateOpt] at refResult
+      simp [captureNext.go_found hauxH, captureNext.go_found hauxB, Refines, refineUpdateOpt, refResult]
+    | (.none, _) => simp [Refines, entryH, hauxH, hauxB, refineUpdateOpt] at refResult
+  | not_found_next bit visited visitedH hauxH hnext ih =>
+    let entryH : StackEntry HistoryStrategy nfa startIdx bit.maxIdx := ⟨HistoryStrategy.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩
+    let entryB : StackEntry (BufferStrategy bufferSize) nfa startIdx bit.maxIdx := ⟨(BufferStrategy bufferSize).empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩
+    have refStack : RefineStack [entryH] [entryB] := .cons entryH entryB [] [] .empty .nil
+    have refResult := captureNextAux.refines nfa wf startIdx bit.maxIdx bufferSize visited refStack
+    match hauxB : captureNextAux (BufferStrategy bufferSize) nfa wf startIdx bit.maxIdx visited [entryB] with
+    | (.some _, _) => simp [Refines, entryH, hauxH, hauxB, refineUpdateOpt] at refResult
+    | (.none, visitedB) =>
+      simp [Refines, entryH, hauxH, hauxB, refineUpdateOpt] at refResult
+      simp [captureNext.go_not_found_next hauxH hnext, captureNext.go_not_found_next hauxB hnext]
+      exact refResult ▸ ih
+  | not_found_end bit visited visitedH hauxH hnext =>
+    let entryH : StackEntry HistoryStrategy nfa startIdx bit.maxIdx := ⟨HistoryStrategy.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩
+    let entryB : StackEntry (BufferStrategy bufferSize) nfa startIdx bit.maxIdx := ⟨(BufferStrategy bufferSize).empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩
+    have refStack : RefineStack [entryH] [entryB] := .cons entryH entryB [] [] .empty .nil
+    have refResult := captureNextAux.refines nfa wf startIdx bit.maxIdx bufferSize visited refStack
+    match hauxB : captureNextAux (BufferStrategy bufferSize) nfa wf startIdx bit.maxIdx visited [entryB] with
+    | (.some _, _) => simp [Refines, entryH, hauxH, hauxB, refineUpdateOpt] at refResult
+    | (.none, visitedB) =>
+      simp [Refines, entryH, hauxH, hauxB, refineUpdateOpt] at refResult
+      simp [captureNext.go_not_found_end hauxH hnext, captureNext.go_not_found_end hauxB hnext, Refines, refineUpdateOpt, refResult]
+
+theorem captureNext.refines (nfa wf bufferSize it) :
+  refineUpdateOpt (captureNext HistoryStrategy nfa wf it) (captureNext (BufferStrategy bufferSize) nfa wf it) := by
+  if le : it.pos ≤ it.toString.endPos then
+    simp [captureNext_le le]
+    exact (captureNext.go.refines nfa wf it.pos.byteIdx bufferSize ⟨it, Nat.le_refl _, le⟩ (BitMatrix.zero _ _)).1
+  else
+    simp [captureNext_not_le le, refineUpdateOpt]
+
+end Regex.Backtracker

--- a/correctness/RegexCorrectness/Backtracker/Traversal.lean
+++ b/correctness/RegexCorrectness/Backtracker/Traversal.lean
@@ -116,26 +116,39 @@ theorem mem_of_mem_top_stack {entry stack'} (hstack : entry :: stack' = stack) :
 
 end
 
+/-
+Here, we consider a minimal invariant enough to prove the "soundness" of the backtracker; a capture group found by the backtracker indeed corresponds to a match by the regex.
+Therefore, we are only concenred about that the states in the stack are reachable from the start node starting from a particular position.
+
+NOTE: if we want to show that the backtracker is complete (i.e., if the regex matches a string, then the backtracker will find a capture group), we need new invariants
+about the visited set so that we can reason about the case the backtracker returns `.none`.
+
+Current candidates are:
+
+1. Closure under transition: ∀ (state, pos) ∈ visited, nfa.Step 0 state pos state' pos' → (state', pos') ∈ visited ∨ ∃ entry ∈ stack, entry.state = state' ∧ entry.it.poss = pos'
+  * At the end of the traversal, we can use this invariant to show that the visited set is a reflexive-transitive closure of the step relation.
+2. Upper bound of the visited set: ∀ (state, pos) ∈ visited, (state, pos) ∈ visisted₀ ∨ ∃ span, Path nfa wf l r span state update
+  * We'll strengthen `UpperInv` to give an upper bound of the visited set.
+  * Combined with the closure property, we can show that the traversal adds just the states reachable from the starting node at a particular position.
+3. The visited set doesn't contain the `.done` state.
+  * This implies that if the traversal returns `.none`, then there is no match starting from the particular position.
+-/
 section
 
 variable {nfa wf startIdx maxIdx visited stack update' visited'}
 
-/-
-TODO: add property of the visited so that we can know that visited is bounded by reachable states from the start node starting from a particular position.
-TODO: should we expand Path to take the starting span?
--/
-structure UpperInv (wf : nfa.WellFormed) (stack : List (StackEntry HistoryStrategy nfa startIdx maxIdx)) where
-  reachable : ∀ entry ∈ stack, ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update
+structure UpperInv (wf : nfa.WellFormed) (l r : List Char) (stack : List (StackEntry HistoryStrategy nfa startIdx maxIdx)) where
+  reachable : ∀ entry ∈ stack, ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update
 
-theorem path_done_of_some (hres : captureNextAux HistoryStrategy nfa wf startIdx maxIdx visited stack = (.some update', visited'))
-  (inv : UpperInv wf stack) :
-  ∃ state span, nfa[state] = .done ∧ Path nfa wf span state update' := by
-  induction visited, stack using captureNextAux.induct' HistoryStrategy nfa wf startIdx maxIdx with
+theorem path_done_of_some {l r} (hres : captureNextAux HistoryStrategy nfa wf startIdx maxIdx visited stack = (.some update', visited'))
+  (inv : UpperInv wf l r stack) :
+  ∃ state span, nfa[state] = .done ∧ Path nfa wf l r span state update' := by
+  induction visited, stack using captureNextAux.induct' HistoryStrategy nfa wf startIdx with
   | base visited => simp [captureNextAux_base] at hres
   | visited visited update state it eq stack' mem ih =>
     simp [captureNextAux_visited mem] at hres
-    have inv' : UpperInv wf stack' := by
-      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+    have inv' : UpperInv wf l r stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
@@ -146,8 +159,8 @@ theorem path_done_of_some (hres : captureNextAux HistoryStrategy nfa wf startIdx
   | fail visited update state it eq stack' mem hn => simp [captureNextAux_fail mem hn] at hres
   | epsilon visited update state it eq stack' mem visited' state' hn ih =>
     rw [captureNextAux_epsilon mem hn] at hres
-    have inv' : UpperInv wf (⟨update, state', it, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update, state', it, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+    have inv' : UpperInv wf l r (⟨update, state', it, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
@@ -161,8 +174,8 @@ theorem path_done_of_some (hres : captureNextAux HistoryStrategy nfa wf startIdx
   | split visited update state it eq stack' mem visited' state₁ state₂ hn ih =>
     rw [captureNextAux_split mem hn] at hres
     let stack'' := ⟨update, state₁, it, eq⟩ :: ⟨update, state₂, it, eq⟩ :: stack'
-    have inv' : UpperInv wf stack'' := by
-      have reachable entry (mem : entry ∈ stack'') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+    have inv' : UpperInv wf l r stack'' := by
+      have reachable entry (mem : entry ∈ stack'') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update := by
         simp [stack''] at mem
         match mem with
         | .inl eq₁ =>
@@ -180,8 +193,8 @@ theorem path_done_of_some (hres : captureNextAux HistoryStrategy nfa wf startIdx
     exact ih hres inv'
   | save visited update state it eq stack' mem visited' offset state' hn update' ih =>
     rw [captureNextAux_save mem hn] at hres
-    have inv' : UpperInv wf (⟨update', state', it, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update', state', it, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+    have inv' : UpperInv wf l r (⟨update', state', it, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update', state', it, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
@@ -194,8 +207,8 @@ theorem path_done_of_some (hres : captureNextAux HistoryStrategy nfa wf startIdx
     exact ih hres inv'
   | anchor_pos visited update state it eq stack' mem visited' a state' hn ht ih =>
     rw [captureNextAux_anchor_pos mem hn ht] at hres
-    have inv' : UpperInv wf (⟨update, state', it, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update, state', it, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+    have inv' : UpperInv wf l r (⟨update, state', it, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
@@ -208,15 +221,15 @@ theorem path_done_of_some (hres : captureNextAux HistoryStrategy nfa wf startIdx
     exact ih hres inv'
   | anchor_neg visited update state it eq stack' mem visited' a state' hn ht ih =>
     rw [captureNextAux_anchor_neg mem hn ht] at hres
-    have inv' : UpperInv wf stack' := by
-      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+    have inv' : UpperInv wf l r stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
   | char_pos visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
     rw [captureNextAux_char_pos mem hn hnext hc] at hres
-    have inv' : UpperInv wf (⟨update, state', it.next hnext, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+    have inv' : UpperInv wf l r (⟨update, state', it.next hnext, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
@@ -235,22 +248,22 @@ theorem path_done_of_some (hres : captureNextAux HistoryStrategy nfa wf startIdx
     exact ih hres inv'
   | char_neg visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
     rw [captureNextAux_char_neg mem hn hnext hc] at hres
-    have inv' : UpperInv wf stack' := by
-      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+    have inv' : UpperInv wf l r stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
   | char_end visited update state it eq stack' mem visited' c state' hn hnext ih =>
     rw [captureNextAux_char_end mem hn hnext] at hres
-    have inv' : UpperInv wf stack' := by
-      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+    have inv' : UpperInv wf l r stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
   | sparse_pos visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
     rw [captureNextAux_sparse_pos mem hn hnext hc] at hres
-    have inv' : UpperInv wf (⟨update, state', it.next hnext, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+    have inv' : UpperInv wf l r (⟨update, state', it.next hnext, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
@@ -269,15 +282,15 @@ theorem path_done_of_some (hres : captureNextAux HistoryStrategy nfa wf startIdx
     exact ih hres inv'
   | sparse_neg visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
     rw [captureNextAux_sparse_neg mem hn hnext hc] at hres
-    have inv' : UpperInv wf stack' := by
-      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+    have inv' : UpperInv wf l r stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
   | sparse_end visited update state it eq stack' mem visited' cs state' hn hnext ih =>
     rw [captureNextAux_sparse_end mem hn hnext] at hres
-    have inv' : UpperInv wf stack' := by
-      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+    have inv' : UpperInv wf l r stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf l r span entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'

--- a/correctness/RegexCorrectness/Backtracker/Traversal.lean
+++ b/correctness/RegexCorrectness/Backtracker/Traversal.lean
@@ -1,18 +1,24 @@
+import Regex.Strategy
 import RegexCorrectness.Backtracker.Basic
+import RegexCorrectness.Backtracker.Path
 
 set_option autoImplicit false
 
+open Regex.Data (Span BoundedIterator)
+
 namespace Regex.Backtracker.captureNextAux
 
-variable {σ nfa wf it startIdx maxIdx visited stack update visited'}
+section
+
+variable {σ nfa wf it startIdx maxIdx visited stack}
 
 theorem mem_of_mem_visited {s i} (hmem : visited.get s i) :
   (captureNextAux σ nfa wf startIdx maxIdx visited stack).2.get s i := by
   induction visited, stack using captureNextAux.induct' σ nfa wf startIdx maxIdx with
-  | base visited => simp [hmem]
-  | visited visited update state it eq stack' mem ih => simp [mem, ih hmem]
-  | done visited update state bit eq stack' mem hn => simp [mem, hn, BitMatrix.get_set, hmem]
-  | fail visited update state bit eq stack' mem hn => simp [mem, hn, BitMatrix.get_set, hmem]
+  | base visited => simp [captureNextAux_base, hmem]
+  | visited visited update state it eq stack' mem ih => simp [captureNextAux_visited mem, ih hmem]
+  | done visited update state it eq stack' mem hn => simp [captureNextAux_done mem hn, BitMatrix.get_set, hmem]
+  | fail visited update state it eq stack' mem hn => simp [captureNextAux_fail mem hn, BitMatrix.get_set, hmem]
   | epsilon visited update state it eq stack' mem visited' state' hn ih =>
     rw [captureNextAux_epsilon mem hn]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
@@ -52,15 +58,15 @@ theorem mem_of_mem_top_stack {entry stack'} (hstack : entry :: stack' = stack) :
   induction visited, stack using captureNextAux.induct' σ nfa wf startIdx maxIdx with
   | base visited => simp at hstack
   | visited visited update state it eq stack' mem ih =>
-    simp [mem]
+    simp [captureNextAux_visited mem]
     simp at hstack
     exact mem_of_mem_visited (by simp [hstack, mem])
-  | done visited update state bit eq stack' mem hn =>
-    simp [mem, hn]
+  | done visited update state it eq stack' mem hn =>
+    simp [captureNextAux_done mem hn]
     simp at hstack
     simp [hstack, BitMatrix.get_set]
-  | fail visited update state bit eq stack' mem hn =>
-    simp [mem, hn]
+  | fail visited update state it eq stack' mem hn =>
+    simp [captureNextAux_fail mem hn]
     simp at hstack
     simp [hstack, BitMatrix.get_set]
   | epsilon visited update state it eq stack'' mem visited' state' hn ih =>
@@ -107,5 +113,175 @@ theorem mem_of_mem_top_stack {entry stack'} (hstack : entry :: stack' = stack) :
     rw [captureNextAux_sparse_end mem hn hnext]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+
+end
+
+section
+
+variable {nfa wf startIdx maxIdx visited stack update' visited'}
+
+/-
+TODO: add property of the visited so that we can know that visited is bounded by reachable states from the start node starting from a particular position.
+TODO: should we expand Path to take the starting span?
+-/
+structure UpperInv (wf : nfa.WellFormed) (stack : List (StackEntry HistoryStrategy nfa startIdx maxIdx)) where
+  reachable : ∀ entry ∈ stack, ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update
+
+theorem path_done_of_some (hres : captureNextAux HistoryStrategy nfa wf startIdx maxIdx visited stack = (.some update', visited'))
+  (inv : UpperInv wf stack) :
+  ∃ state span, nfa[state] = .done ∧ Path nfa wf span state update' := by
+  induction visited, stack using captureNextAux.induct' HistoryStrategy nfa wf startIdx maxIdx with
+  | base visited => simp [captureNextAux_base] at hres
+  | visited visited update state it eq stack' mem ih =>
+    simp [captureNextAux_visited mem] at hres
+    have inv' : UpperInv wf stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+        inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | done visited update state it eq stack' mem hn =>
+    simp [captureNextAux_done mem hn] at hres
+    have ⟨span, eqspan, path⟩ := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+    exact ⟨state, span, hn, hres.1 ▸ path⟩
+  | fail visited update state it eq stack' mem hn => simp [captureNextAux_fail mem hn] at hres
+  | epsilon visited update state it eq stack' mem visited' state' hn ih =>
+    rw [captureNextAux_epsilon mem hn] at hres
+    have inv' : UpperInv wf (⟨update, state', it, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+        simp at mem
+        cases mem with
+        | inl eq' =>
+          subst entry
+          have ⟨span, eqspan, path⟩ := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          simp at eqspan path
+          exact ⟨span, by simp [eqspan], path.more (.epsilon (Nat.zero_le _) state.isLt hn) (by simp)⟩
+        | inr mem => exact inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | split visited update state it eq stack' mem visited' state₁ state₂ hn ih =>
+    rw [captureNextAux_split mem hn] at hres
+    let stack'' := ⟨update, state₁, it, eq⟩ :: ⟨update, state₂, it, eq⟩ :: stack'
+    have inv' : UpperInv wf stack'' := by
+      have reachable entry (mem : entry ∈ stack'') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+        simp [stack''] at mem
+        match mem with
+        | .inl eq₁ =>
+          subst entry
+          have ⟨span, eqspan, path⟩ := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          simp at eqspan path
+          exact ⟨span, by simp [eqspan], path.more (.splitLeft (Nat.zero_le _) state.isLt hn) (by simp)⟩
+        | .inr (.inl eq₂) =>
+          subst entry
+          have ⟨span, eqspan, path⟩ := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          simp at eqspan path
+          exact ⟨span, by simp [eqspan], path.more (.splitRight (Nat.zero_le _) state.isLt hn) (by simp)⟩
+        | .inr (.inr mem) => exact inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | save visited update state it eq stack' mem visited' offset state' hn update' ih =>
+    rw [captureNextAux_save mem hn] at hres
+    have inv' : UpperInv wf (⟨update', state', it, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update', state', it, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+        simp at mem
+        cases mem with
+        | inl eq' =>
+          subst entry
+          have ⟨span, eqspan, path⟩ := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          simp at eqspan path
+          exact ⟨span, by simp [eqspan], path.more (.save (Nat.zero_le _) state.isLt hn) (by simp [update', HistoryStrategy, BoundedIterator.pos, ←eqspan, Span.curr_eq_pos])⟩
+        | inr mem => exact inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | anchor_pos visited update state it eq stack' mem visited' a state' hn ht ih =>
+    rw [captureNextAux_anchor_pos mem hn ht] at hres
+    have inv' : UpperInv wf (⟨update, state', it, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+        simp at mem
+        cases mem with
+        | inl eq' =>
+          subst entry
+          have ⟨span, eqspan, path⟩ := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          simp at eqspan path
+          exact ⟨span, by simp [eqspan], path.more (.anchor (Nat.zero_le _) state.isLt hn (eqspan ▸ ht)) (by simp)⟩
+        | inr mem => exact inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | anchor_neg visited update state it eq stack' mem visited' a state' hn ht ih =>
+    rw [captureNextAux_anchor_neg mem hn ht] at hres
+    have inv' : UpperInv wf stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+        inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | char_pos visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+    rw [captureNextAux_char_pos mem hn hnext hc] at hres
+    have inv' : UpperInv wf (⟨update, state', it.next hnext, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+        simp at mem
+        cases mem with
+        | inl eq' =>
+          subst entry
+          have ⟨span, eqspan, path⟩ := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          simp at eqspan path
+          simp [BoundedIterator.hasNext, BoundedIterator.curr, ←eqspan] at hnext hc
+          have ⟨r', eqr'⟩ := span.exists_cons_of_curr' hnext hc
+          refine ⟨span.next, by simp [span.next_iterator eqr', eqspan, BoundedIterator.next, String.Iterator.next'_eq_next], ?_⟩
+          simp
+          have step : NFA.Step nfa 0 state span state' span.next .none := by
+            simp [NFA.Step.iff_char hn, eqr', span.next_eq eqr']
+          exact path.more step (by simp)
+        | inr mem => exact inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | char_neg visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+    rw [captureNextAux_char_neg mem hn hnext hc] at hres
+    have inv' : UpperInv wf stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+        inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | char_end visited update state it eq stack' mem visited' c state' hn hnext ih =>
+    rw [captureNextAux_char_end mem hn hnext] at hres
+    have inv' : UpperInv wf stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+        inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | sparse_pos visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+    rw [captureNextAux_sparse_pos mem hn hnext hc] at hres
+    have inv' : UpperInv wf (⟨update, state', it.next hnext, eq⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext, eq⟩ :: stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update := by
+        simp at mem
+        cases mem with
+        | inl eq' =>
+          subst entry
+          have ⟨span, eqspan, path⟩ := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          simp at eqspan path
+          simp [BoundedIterator.hasNext, BoundedIterator.curr, ←eqspan] at hnext hc
+          have ⟨r', eqr'⟩ := span.exists_cons_of_curr' hnext rfl
+          refine ⟨span.next, by simp [span.next_iterator eqr', eqspan, BoundedIterator.next, String.Iterator.next'_eq_next], ?_⟩
+          simp
+          have step : NFA.Step nfa 0 state span state' span.next .none := by
+            simp [NFA.Step.iff_sparse hn, eqr', span.next_eq eqr', hc]
+          exact path.more step (by simp)
+        | inr mem => exact inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | sparse_neg visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+    rw [captureNextAux_sparse_neg mem hn hnext hc] at hres
+    have inv' : UpperInv wf stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+        inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+  | sparse_end visited update state it eq stack' mem visited' cs state' hn hnext ih =>
+    rw [captureNextAux_sparse_end mem hn hnext] at hres
+    have inv' : UpperInv wf stack' := by
+      have reachable entry (mem : entry ∈ stack') : ∃ span, span.iterator = entry.it.it ∧ Path nfa wf span entry.state entry.update :=
+        inv.reachable entry (by simp [mem])
+      exact ⟨reachable⟩
+    exact ih hres inv'
+
+end
 
 end Regex.Backtracker.captureNextAux

--- a/correctness/RegexCorrectness/Backtracker/Traversal.lean
+++ b/correctness/RegexCorrectness/Backtracker/Traversal.lean
@@ -1,0 +1,111 @@
+import RegexCorrectness.Backtracker.Basic
+
+set_option autoImplicit false
+
+namespace Regex.Backtracker.captureNextAux
+
+variable {σ nfa wf it startIdx maxIdx visited stack update visited'}
+
+theorem mem_of_mem_visited {s i} (hmem : visited.get s i) :
+  (captureNextAux σ nfa wf startIdx maxIdx visited stack).2.get s i := by
+  induction visited, stack using captureNextAux.induct' σ nfa wf startIdx maxIdx with
+  | base visited => simp [hmem]
+  | visited visited update state it eq stack' mem ih => simp [mem, ih hmem]
+  | done visited update state bit eq stack' mem hn => simp [mem, hn, BitMatrix.get_set, hmem]
+  | fail visited update state bit eq stack' mem hn => simp [mem, hn, BitMatrix.get_set, hmem]
+  | epsilon visited update state it eq stack' mem visited' state' hn ih =>
+    rw [captureNextAux_epsilon mem hn]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | split visited update state it eq stack' mem visited' state₁ state₂ hn ih =>
+    rw [captureNextAux_split mem hn]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | save visited update state it eq stack' mem visited' offset state' hn update' ih =>
+    rw [captureNextAux_save mem hn]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | anchor_pos visited update state it eq stack' mem visited' a state' hn ht ih =>
+    rw [captureNextAux_anchor_pos mem hn ht]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | anchor_neg visited update state it eq stack' mem visited' a state' hn ht ih =>
+    rw [captureNextAux_anchor_neg mem hn ht]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | char_pos visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+    rw [captureNextAux_char_pos mem hn hnext hc]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | char_neg visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+    rw [captureNextAux_char_neg mem hn hnext hc]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | char_end visited update state it eq stack' mem visited' c state' hn hnext ih =>
+    rw [captureNextAux_char_end mem hn hnext]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | sparse_pos visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+    rw [captureNextAux_sparse_pos mem hn hnext hc]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | sparse_neg visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+    rw [captureNextAux_sparse_neg mem hn hnext hc]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+  | sparse_end visited update state it eq stack' mem visited' cs state' hn hnext ih =>
+    rw [captureNextAux_sparse_end mem hn hnext]
+    exact ih (by simp [visited', BitMatrix.get_set, hmem])
+
+theorem mem_of_mem_top_stack {entry stack'} (hstack : entry :: stack' = stack) :
+  (captureNextAux σ nfa wf startIdx maxIdx visited stack).2.get entry.state (entry.it.index' entry.eq) := by
+  induction visited, stack using captureNextAux.induct' σ nfa wf startIdx maxIdx with
+  | base visited => simp at hstack
+  | visited visited update state it eq stack' mem ih =>
+    simp [mem]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [hstack, mem])
+  | done visited update state bit eq stack' mem hn =>
+    simp [mem, hn]
+    simp at hstack
+    simp [hstack, BitMatrix.get_set]
+  | fail visited update state bit eq stack' mem hn =>
+    simp [mem, hn]
+    simp at hstack
+    simp [hstack, BitMatrix.get_set]
+  | epsilon visited update state it eq stack'' mem visited' state' hn ih =>
+    rw [captureNextAux_epsilon mem hn]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | split visited update state it eq stack'' mem visited' state₁ state₂ hn ih =>
+    rw [captureNextAux_split mem hn]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | save visited update state it eq stack' mem visited' offset state' hn update' ih =>
+    rw [captureNextAux_save mem hn]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | anchor_pos visited update state it eq stack' mem visited' a state' hn ht ih =>
+    rw [captureNextAux_anchor_pos mem hn ht]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | anchor_neg visited update state it eq stack' mem visited' a state' hn ht ih =>
+    rw [captureNextAux_anchor_neg mem hn ht]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | char_pos visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+    rw [captureNextAux_char_pos mem hn hnext hc]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | char_neg visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+    rw [captureNextAux_char_neg mem hn hnext hc]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | char_end visited update state it eq stack' mem visited' c state' hn hnext ih =>
+    rw [captureNextAux_char_end mem hn hnext]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | sparse_pos visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+    rw [captureNextAux_sparse_pos mem hn hnext hc]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | sparse_neg visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+    rw [captureNextAux_sparse_neg mem hn hnext hc]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+  | sparse_end visited update state it eq stack' mem visited' cs state' hn hnext ih =>
+    rw [captureNextAux_sparse_end mem hn hnext]
+    simp at hstack
+    exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
+
+end Regex.Backtracker.captureNextAux

--- a/correctness/RegexCorrectness/Data/BoundedIterator.lean
+++ b/correctness/RegexCorrectness/Data/BoundedIterator.lean
@@ -1,0 +1,17 @@
+import Regex.Data.BoundedIterator
+import RegexCorrectness.Data.String
+
+open String (Iterator)
+
+namespace Regex.Data.BoundedIterator
+
+theorem valid_of_it_valid {startIdx} (bit : BoundedIterator startIdx) (v : bit.it.Valid) : bit.Valid := v.isValid
+
+theorem valid_of_valid {startIdx} (bit : BoundedIterator startIdx) (v : bit.Valid) : bit.it.Valid := Iterator.Valid.of_isValid v
+
+theorem next_valid {startIdx} (bit : BoundedIterator startIdx) (h : bit.hasNext) (v : bit.Valid) : (bit.next h).Valid := by
+  apply valid_of_it_valid
+  simp [next, String.Iterator.next'_eq_next]
+  exact (bit.valid_of_valid v).next h
+
+end Regex.Data.BoundedIterator

--- a/correctness/RegexCorrectness/Data/BoundedIterator.lean
+++ b/correctness/RegexCorrectness/Data/BoundedIterator.lean
@@ -1,6 +1,8 @@
 import Regex.Data.BoundedIterator
 import RegexCorrectness.Data.String
 
+set_option autoImplicit false
+
 open String (Iterator)
 
 namespace Regex.Data.BoundedIterator
@@ -13,5 +15,24 @@ theorem next_valid {startIdx} (bit : BoundedIterator startIdx) (h : bit.hasNext)
   apply valid_of_it_valid
   simp [next, String.Iterator.next'_eq_next]
   exact (bit.valid_of_valid v).next h
+
+def ValidFor {startIdx} (l r : List Char) (bit : BoundedIterator startIdx) : Prop := bit.it.ValidFor l r
+
+namespace ValidFor
+
+theorem hasNext {startIdx l r} {bit : BoundedIterator startIdx} (vf : ValidFor l r bit) : bit.hasNext ↔ r ≠ [] := by
+  unfold ValidFor at vf
+  exact vf.hasNext
+
+theorem next {startIdx l c r} {bit : BoundedIterator startIdx} (vf : ValidFor l (c :: r) bit) : ValidFor (c :: l) r (bit.next (by simp [vf.hasNext])) := by
+  unfold ValidFor at vf
+  exact vf.next
+
+theorem next' {startIdx l r} {bit : BoundedIterator startIdx} (h : bit.hasNext) (vf : ValidFor l r bit) : ∃ c r', ValidFor (c :: l) r' (bit.next h) := by
+  match r with
+  | [] => simp [vf.hasNext] at h
+  | c :: r' => exact ⟨c, r', vf.next⟩
+
+end ValidFor
 
 end Regex.Data.BoundedIterator

--- a/correctness/RegexCorrectness/Data/Span.lean
+++ b/correctness/RegexCorrectness/Data/Span.lean
@@ -44,6 +44,12 @@ theorem validFor (s : Span) : ValidFor (s.m ++ s.l.reverse) s.r s.iterator := by
 theorem exists_cons_of_not_atEnd {s : Span} (h : ¬s.iterator.atEnd) : ∃ r', s.r = s.iterator.curr :: r' :=
   s.validFor.exists_cons_of_not_atEnd h
 
+theorem exists_cons_of_curr' {s : Span} {c} (h : s.iterator.hasNext) (eq : s.iterator.curr' h = c) : ∃ r', s.r = c :: r' := by
+  have ⟨r', eqr⟩ := s.exists_cons_of_not_atEnd (by simpa [Iterator.atEnd, Iterator.hasNext] using h)
+  have eq' : s.iterator.curr' h = s.iterator.curr := rfl
+  rw [←eq', eq] at eqr
+  exact ⟨r', eqr⟩
+
 theorem curr_eq_pos {s : Span} : s.curr = s.iterator.pos := rfl
 
 theorem next_curr_eq_next_pos {s : Span} {c r'} (h : s.r = c :: r') : s.next.curr = s.iterator.next.pos := by

--- a/correctness/RegexCorrectness/Regex/Basic.lean
+++ b/correctness/RegexCorrectness/Regex/Basic.lean
@@ -2,6 +2,7 @@ import Regex.Regex
 import RegexCorrectness.Data.Expr.Semantics
 import RegexCorrectness.NFA.Compile
 import RegexCorrectness.Syntax.Ast
+import RegexCorrectness.Backtracker
 import RegexCorrectness.VM
 
 set_option autoImplicit false
@@ -54,7 +55,20 @@ theorem le_maxTag {re : Regex} (s : IsSearchRegex re) : 1 ≤ re.maxTag := by
   apply NFA.lt_of_mem_tags_compile s.nfa_eq.symm
   simp [expr, Expr.tags]
 
-theorem captures_of_captureNext {re bufferSize it matched} (h : VM.captureNext (BufferStrategy bufferSize) re.nfa re.wf it = .some matched)
+theorem captures_of_captureNext' {re bufferSize it matched} (h : re.captureNextBuf bufferSize it = .some matched)
+  (s : IsSearchRegex re) (v : it.Valid) :
+  ∃ l m r groups,
+    it.toString = ⟨l ++ m ++ r⟩ ∧
+    s.expr.Captures ⟨l, [], m ++ r⟩ ⟨l, m.reverse, r⟩ groups ∧
+    EquivMaterializedUpdate (materializeRegexGroups groups) matched := by
+  if bt : re.useBacktracker then
+    simp [Regex.captureNextBuf, bt, s.nfa_eq] at h
+    exact Backtracker.captureNext_correct s.disj h v
+  else
+    simp [Regex.captureNextBuf, bt] at h
+    exact VM.captureNext_correct s.nfa_eq.symm s.disj h v rfl
+
+theorem captures_of_captureNext {re bufferSize it matched} (h : re.captureNextBuf bufferSize it = .some matched)
   (s : IsSearchRegex re) (v : it.Valid) (le : 2 ≤ bufferSize) :
   ∃ l m r groups,
     it.toString = ⟨l ++ m ++ r⟩ ∧
@@ -62,8 +76,7 @@ theorem captures_of_captureNext {re bufferSize it matched} (h : VM.captureNext (
     EquivMaterializedUpdate (materializeRegexGroups groups) matched ∧
     matched[0] = .some ⟨String.utf8Len l⟩ ∧
     matched[1] = .some ⟨String.utf8Len l + String.utf8Len m⟩ := by
-  have ⟨l, m, r, groups, eqstring, c, eqv⟩ := VM.captureNext_correct s.nfa_eq.symm s.disj h v rfl
-  simp at eqv
+  have ⟨l, m, r, groups, eqstring, c, eqv⟩ := captures_of_captureNext' h s v
   refine ⟨l, m, r, groups, eqstring, c, eqv, ?_⟩
 
   generalize hspan : (⟨l, [], m ++ r⟩ : Span) = span at c
@@ -77,21 +90,19 @@ theorem captures_of_captureNext {re bufferSize it matched} (h : VM.captureNext (
     simp [←hspan, ←hspan', Span.curr, h₁, h₂] at eqv
     exact ⟨eqv.1.symm, eqv.2.symm⟩
 
-theorem searchNext_some {re it first last} (h : VM.searchNext re.nfa re.wf it = .some (first, last))
+theorem searchNext_some {re it first last} (h : re.searchNext it = .some (first, last))
   (s : IsSearchRegex re) (v : it.Valid) :
   ∃ l m r groups,
     it.toString = ⟨l ++ m ++ r⟩ ∧
     s.expr.Captures ⟨l, [], m ++ r⟩ ⟨l, m.reverse, r⟩ groups ∧
     first = ⟨String.utf8Len l⟩ ∧
     last = ⟨String.utf8Len l + String.utf8Len m⟩ := by
-  simp [VM.searchNext] at h
-  generalize h' : VM.captureNextBuf re.nfa re.wf 2 it = matched at h
-  cases matched with
-  | none => simp at h
-  | some matched =>
+  simp [Regex.searchNext, s.nfa_eq] at h
+  match h' : re.captureNextBuf 2 it with
+  | .none => simp [h'] at h
+  | .some matched =>
     have ⟨l, m, r, groups, eqstring, c, eqv, eq₁, eq₂⟩ := captures_of_captureNext h' s v (Nat.le_refl _)
-    simp [BufferStrategy] at eq₁ eq₂
-    simp [eq₁, eq₂] at h
+    simp [h', eq₁, eq₂] at h
     exact ⟨l, m, r, groups, eqstring, c, by simp [←h]⟩
 
 end IsSearchRegex

--- a/correctness/RegexCorrectness/Regex/Basic.lean
+++ b/correctness/RegexCorrectness/Regex/Basic.lean
@@ -8,7 +8,7 @@ set_option autoImplicit false
 
 open Regex.Data (Expr Span)
 open String (Pos Iterator)
-open Regex.NFA (EquivMaterializedUpdate materializeRegexGroups materializeUpdates)
+open Regex.Strategy (EquivMaterializedUpdate materializeRegexGroups materializeUpdates)
 
 namespace Regex
 

--- a/correctness/RegexCorrectness/Regex/Captures.lean
+++ b/correctness/RegexCorrectness/Regex/Captures.lean
@@ -28,15 +28,13 @@ def Valid (self : Captures) : Prop :=
   self.regex.IsSearchRegex ∧ self.currentPos.ValidPlus self.haystack
 
 theorem captures_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self'))
-  (v : self.Valid) (bt : ¬self.regex.useBacktracker) :
+  (v : self.Valid) :
   self'.Valid ∧ captured.Spec v.1 self.haystack := by
   unfold next? at h
   split at h
   next le =>
-    simp [Regex.captureNextBuf, bt] at h
-    generalize h' : VM.captureNextBuf self.regex.nfa self.regex.wf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩ = matched at h
-    match matched with
-    | none => simp at h
+    match h' : self.regex.captureNextBuf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩ with
+    | none => simp [h'] at h
     | some matched =>
       have pos_valid := v.2.valid_of_le le
       have : 1 ≤ self.regex.maxTag := v.1.le_maxTag
@@ -44,7 +42,7 @@ theorem captures_of_next?_some {self self' : Captures} {captured} (h : self.next
         v.1.captures_of_captureNext h' pos_valid (by omega)
       simp at eqstring
 
-      simp at h
+      simp [h'] at h
       set captured' := CapturedGroups.mk matched.toArray
       have hcaptured (i : Nat) : captured'.get i = materializeRegexGroups groups i := by
         have eqsize : matched.toArray.size = self.regex.maxTag + 1 :=
@@ -116,17 +114,15 @@ theorem captures_of_next?_some {self self' : Captures} {captured} (h : self.next
         exact ⟨⟨v.1, String.Pos.validPlus_of_next_valid pos_valid⟩, l, m, r, groups, by simp [eqstring], c, captured₀, hcaptured⟩
   next => simp at h
 
-theorem regex_eq_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self')) (bt : ¬self.regex.useBacktracker) :
+theorem regex_eq_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self')) :
   self'.regex = self.regex := by
   unfold next? at h
   split at h
   next =>
-    simp [Regex.captureNextBuf, bt] at h
-    set captured' := VM.captureNextBuf self.regex.nfa self.regex.wf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩
-    match h' : captured' with
-    | none => simp at h
+    match h' : self.regex.captureNextBuf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩ with
+    | none => simp [h'] at h
     | some buffer =>
-      simp at h
+      simp [h'] at h
       match h'' : CapturedGroups.get ⟨buffer.toArray⟩ 0 with
       | none => simp [h''] at h
       | some _ =>
@@ -140,17 +136,15 @@ theorem regex_eq_of_next?_some {self self' : Captures} {captured} (h : self.next
           simp [←h]
   next => simp at h
 
-theorem haystack_eq_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self')) (bt : ¬self.regex.useBacktracker) :
+theorem haystack_eq_of_next?_some {self self' : Captures} {captured} (h : self.next? = .some (captured, self')) :
   self'.haystack = self.haystack := by
   unfold next? at h
   split at h
   next =>
-    simp [Regex.captureNextBuf, bt] at h
-    set captured' := VM.captureNextBuf self.regex.nfa self.regex.wf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩
-    match h' : captured' with
-    | none => simp at h
+    match h' : self.regex.captureNextBuf (self.regex.maxTag + 1) ⟨self.haystack, self.currentPos⟩ with
+    | none => simp [h'] at h
     | some buffer =>
-      simp at h
+      simp [h'] at h
       match h'' : CapturedGroups.get ⟨buffer.toArray⟩ 0 with
       | none => simp [h''] at h
       | some _ =>

--- a/correctness/RegexCorrectness/Regex/Captures.lean
+++ b/correctness/RegexCorrectness/Regex/Captures.lean
@@ -4,6 +4,7 @@ import RegexCorrectness.Regex.Basic
 set_option autoImplicit false
 
 open String (Pos)
+open Regex.Strategy (materializeRegexGroups)
 
 /--
 `CapturedGroups` conforms to the spec if and only if:
@@ -19,7 +20,7 @@ def Regex.CapturedGroups.Spec {re : Regex} (s : re.IsSearchRegex) (haystack : St
     haystack = ⟨l ++ m ++ r⟩ ∧
     s.expr.Captures ⟨l, [], m ++ r⟩ ⟨l, m.reverse, r⟩ groups ∧
     self.get 0 = .some (⟨String.utf8Len l⟩, ⟨String.utf8Len l + String.utf8Len m⟩) ∧
-    ∀ i, self.get i = NFA.materializeRegexGroups groups i
+    ∀ i, self.get i = materializeRegexGroups groups i
 
 namespace Regex.Captures
 
@@ -45,7 +46,7 @@ theorem captures_of_next?_some {self self' : Captures} {captured} (h : self.next
 
       simp at h
       set captured' := CapturedGroups.mk matched.toArray
-      have hcaptured (i : Nat) : captured'.get i = NFA.materializeRegexGroups groups i := by
+      have hcaptured (i : Nat) : captured'.get i = materializeRegexGroups groups i := by
         have eqsize : matched.toArray.size = self.regex.maxTag + 1 :=
           matched.size_toArray
         if h₁ : 2 * i + 1 < self.regex.maxTag + 1 then
@@ -78,14 +79,14 @@ theorem captures_of_next?_some {self self' : Captures} {captured} (h : self.next
                 eq₂ ▸ getElem?_pos matched.toArray (2 * i + 1) (by omega)
               simp [CapturedGroups.get, eq₁', eq₂', hgroup₁, hgroup₂, captured']
         else
-          match h₂ : NFA.materializeRegexGroups groups i with
+          match h₂ : materializeRegexGroups groups i with
           | none =>
             have : matched.toArray[2 * i + 1]? = .none :=
               getElem?_neg matched.toArray (2 * i + 1) (by omega)
             simp [CapturedGroups.get, this, captured']
           | some _ =>
-            have : (NFA.materializeRegexGroups groups i).isSome := by simp [h₂]
-            have := NFA.mem_tags_of_materializeRegexGroups_some c this
+            have : (materializeRegexGroups groups i).isSome := by simp [h₂]
+            have := Strategy.mem_tags_of_materializeRegexGroups_some c this
             have := v.1.maxTag_eq ▸ NFA.lt_of_mem_tags_compile v.1.nfa_eq.symm this
             simp at h₁
             omega

--- a/correctness/RegexCorrectness/Regex/Matches.lean
+++ b/correctness/RegexCorrectness/Regex/Matches.lean
@@ -26,18 +26,16 @@ def Valid (self : Matches) : Prop :=
   self.regex.IsSearchRegex ∧ self.currentPos.ValidPlus self.haystack
 
 theorem captures_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self'))
-  (v : self.Valid) (bt : ¬self.regex.useBacktracker) :
+  (v : self.Valid) :
   self'.Valid ∧ Spec v.1 self.haystack positions := by
   unfold next? at h
   split at h
   next le =>
     have pos_valid := v.2.valid_of_le le
-    simp [Regex.searchNext, bt] at h
-    generalize h' : VM.searchNext self.regex.nfa self.regex.wf ⟨self.haystack, self.currentPos⟩ = matched at h
-    match matched with
-    | none => simp at h
+    match h' : self.regex.searchNext ⟨self.haystack, self.currentPos⟩ with
+    | none => simp [h'] at h
     | some matched =>
-      simp at h
+      simp [h'] at h
       have ⟨l, m, r, groups, eqstring, c, eq₁, eq₂⟩ := v.1.searchNext_some h' pos_valid
       simp at eqstring
       split at h
@@ -55,31 +53,27 @@ theorem captures_of_next?_some {self self' : Matches} {positions} (h : self.next
         exact ⟨⟨v.1, String.Pos.validPlus_of_next_valid pos_valid⟩, l, m, r, groups, by simp [eqstring], c, eq₁, eq₂⟩
   next => simp at h
 
-theorem regex_eq_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self')) (bt : ¬self.regex.useBacktracker) :
+theorem regex_eq_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self')) :
   self'.regex = self.regex := by
   unfold next? at h
   split at h
   next =>
-    simp [Regex.searchNext, bt] at h
-    set matched := VM.searchNext self.regex.nfa self.regex.wf ⟨self.haystack, self.currentPos⟩
-    match h' : matched with
-    | none => simp at h
+    match h' : self.regex.searchNext ⟨self.haystack, self.currentPos⟩ with
+    | none => simp [h'] at h
     | some matched =>
-      simp at h
+      simp [h'] at h
       split at h <;> simp at h <;> simp [←h]
   next => simp at h
 
-theorem haystack_eq_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self')) (bt : ¬self.regex.useBacktracker) :
+theorem haystack_eq_of_next?_some {self self' : Matches} {positions} (h : self.next? = .some (positions, self')) :
   self'.haystack = self.haystack := by
   unfold next? at h
   split at h
   next =>
-    simp [Regex.searchNext, bt] at h
-    set matched := VM.searchNext self.regex.nfa self.regex.wf ⟨self.haystack, self.currentPos⟩
-    match h' : matched with
-    | none => simp at h
+    match h' : self.regex.searchNext ⟨self.haystack, self.currentPos⟩ with
+    | none => simp [h'] at h
     | some matched =>
-      simp at h
+      simp [h'] at h
       split at h <;> simp at h <;> simp [←h]
   next => simp at h
 

--- a/correctness/RegexCorrectness/Regex/Utilities.lean
+++ b/correctness/RegexCorrectness/Regex/Utilities.lean
@@ -11,31 +11,31 @@ namespace Regex
 variable {re : Regex} {haystack : String}
 
 theorem captures_of_find_some {positions} (h : re.find haystack = .some positions)
-  (s : re.IsSearchRegex) (bt : ¬re.useBacktracker) :
+  (s : re.IsSearchRegex) :
   Matches.Spec s haystack positions := by
   simp [Regex.find] at h
   have ⟨_, h⟩ := h
   have v := Captures.valid_captures haystack s
-  exact (Matches.captures_of_next?_some h v bt).2
+  exact (Matches.captures_of_next?_some h v).2
 
 theorem captures_of_mem_findAll.go {m : Matches} {accum : Array (Pos × Pos)}
-  (v : m.Valid) (bt : ¬m.regex.useBacktracker) (inv : ∀ positions ∈ accum, Matches.Spec v.1 m.haystack positions) :
+  (v : m.Valid) (inv : ∀ positions ∈ accum, Matches.Spec v.1 m.haystack positions) :
   ∀ positions ∈ findAll.go m accum, Matches.Spec v.1 m.haystack positions := by
   induction m, accum using findAll.go.induct with
   | case1 m accum positions m' next_some? ih =>
     -- next match is found
     rw [findAll.go, next_some?]
     simp
-    have regex_eq := Matches.regex_eq_of_next?_some next_some? bt
-    have haystack_eq := Matches.haystack_eq_of_next?_some next_some? bt
+    have regex_eq := Matches.regex_eq_of_next?_some next_some?
+    have haystack_eq := Matches.haystack_eq_of_next?_some next_some?
     simp [regex_eq, haystack_eq] at ih
 
-    have ⟨v', spec⟩ := Matches.captures_of_next?_some next_some? v bt
+    have ⟨v', spec⟩ := Matches.captures_of_next?_some next_some? v
     have inv' (p₁ p₂ : Pos) (mem : (p₁, p₂) ∈ accum ∨ (p₁, p₂) = positions) : Matches.Spec v.1 m.haystack (p₁, p₂) := by
       cases mem with
       | inl mem => exact inv (p₁, p₂) mem
       | inr eq => exact eq ▸ spec
-    exact ih v' (by simp [bt]) inv'
+    exact ih v' inv'
   | case2 m accum next_none? =>
     -- next match is not found
     rw [findAll.go, next_none?]
@@ -43,38 +43,38 @@ theorem captures_of_mem_findAll.go {m : Matches} {accum : Array (Pos × Pos)}
     exact inv
 
 theorem captures_of_mem_findAll {positions} (mem : positions ∈ re.findAll haystack)
-  (s : re.IsSearchRegex) (bt : ¬re.useBacktracker) :
+  (s : re.IsSearchRegex) :
   Matches.Spec s haystack positions := by
   simp [Regex.findAll] at mem
   have v := Matches.vaild_matches haystack s
-  exact captures_of_mem_findAll.go v bt (by simp) positions mem
+  exact captures_of_mem_findAll.go v (by simp) positions mem
 
 theorem captures_of_capture_some {captured} (h : re.capture haystack = .some captured)
-  (s : re.IsSearchRegex) (bt : ¬re.useBacktracker) :
+  (s : re.IsSearchRegex) :
   captured.Spec s haystack := by
   simp [Regex.capture] at h
   have ⟨_, h⟩ := h
   have v := Captures.valid_captures haystack s
-  exact (Captures.captures_of_next?_some h v bt).2
+  exact (Captures.captures_of_next?_some h v).2
 
 theorem captures_of_mem_captureAll.go {captures : Captures} {accum : Array CapturedGroups}
-  (v : captures.Valid) (bt : ¬captures.regex.useBacktracker) (inv : ∀ captured ∈ accum, captured.Spec v.1 captures.haystack) :
+  (v : captures.Valid) (inv : ∀ captured ∈ accum, captured.Spec v.1 captures.haystack) :
   ∀ captured ∈ captureAll.go captures accum, captured.Spec v.1 captures.haystack := by
   induction captures, accum using captureAll.go.induct with
   | case1 captures accum groups captures' next?_some ih =>
     -- next capture is found
     rw [captureAll.go, next?_some]
     simp
-    have regex_eq := Captures.regex_eq_of_next?_some next?_some bt
-    have haystack_eq := Captures.haystack_eq_of_next?_some next?_some bt
+    have regex_eq := Captures.regex_eq_of_next?_some next?_some
+    have haystack_eq := Captures.haystack_eq_of_next?_some next?_some
     simp [regex_eq, haystack_eq] at ih
 
-    have ⟨v', spec⟩ := Captures.captures_of_next?_some next?_some v bt
+    have ⟨v', spec⟩ := Captures.captures_of_next?_some next?_some v
     have inv' (captured : CapturedGroups) (mem : captured ∈ accum ∨ captured = groups) : captured.Spec v.1 captures.haystack := by
       cases mem with
       | inl mem => exact inv captured mem
       | inr eq => exact eq ▸ spec
-    exact ih v' (by simp [bt]) inv'
+    exact ih v' inv'
   | case2 captures accum next?_none =>
     -- next capture is not found
     rw [captureAll.go, next?_none]
@@ -82,10 +82,10 @@ theorem captures_of_mem_captureAll.go {captures : Captures} {accum : Array Captu
     exact inv
 
 theorem captures_of_mem_captureAll {captured} (mem : captured ∈ re.captureAll haystack)
-  (s : re.IsSearchRegex) (bt : ¬re.useBacktracker) :
+  (s : re.IsSearchRegex) :
   captured.Spec s haystack := by
   simp [Regex.captureAll] at mem
   have v := Captures.valid_captures haystack s
-  exact captures_of_mem_captureAll.go v bt (by simp) captured mem
+  exact captures_of_mem_captureAll.go v (by simp) captured mem
 
 end Regex

--- a/correctness/RegexCorrectness/Strategy.lean
+++ b/correctness/RegexCorrectness/Strategy.lean
@@ -1,0 +1,2 @@
+import RegexCorrectness.Strategy.Materialize
+import RegexCorrectness.Strategy.Refinement

--- a/correctness/RegexCorrectness/Strategy/Materialize.lean
+++ b/correctness/RegexCorrectness/Strategy/Materialize.lean
@@ -1,0 +1,3 @@
+import RegexCorrectness.Strategy.Materialize.Basic
+import RegexCorrectness.Strategy.Materialize.Lemmas
+import RegexCorrectness.Strategy.Materialize.Naturality

--- a/correctness/RegexCorrectness/Strategy/Materialize/Basic.lean
+++ b/correctness/RegexCorrectness/Strategy/Materialize/Basic.lean
@@ -1,12 +1,11 @@
 import RegexCorrectness.Data.Expr.Semantics.CaptureGroups
-import RegexCorrectness.NFA.Semantics.Equivalence
 
 set_option autoImplicit false
 
 open Regex.Data (CaptureGroups)
 open String (Pos)
 
-namespace Regex.NFA
+namespace Regex.Strategy
 
 /--
 `materializeRegexGroups groups` constructs a mapping that associates each capture group's tag
@@ -41,4 +40,4 @@ def EquivMaterializedUpdate {n} (groups : Nat → Option (Pos × Pos)) (updates 
     ((h₁ : 2 * tag < n) → ((groups tag).map (·.1) = updates[2 * tag])) ∧
     ((h₂ : 2 * tag + 1 < n) → ((groups tag).map (·.2) = updates[2 * tag + 1]))
 
-end Regex.NFA
+end Regex.Strategy

--- a/correctness/RegexCorrectness/Strategy/Materialize/Lemmas.lean
+++ b/correctness/RegexCorrectness/Strategy/Materialize/Lemmas.lean
@@ -1,4 +1,4 @@
-import RegexCorrectness.VM.Correspondence.Materialize.Basic
+import RegexCorrectness.Strategy.Materialize.Basic
 import RegexCorrectness.Data.Expr.Semantics
 import Init.Data.Vector.Lemmas
 
@@ -6,7 +6,7 @@ set_option autoImplicit false
 
 open String (Pos)
 
-namespace Regex.NFA
+namespace Regex.Strategy
 
 @[simp]
 theorem materializeRegexGroups_empty : materializeRegexGroups .empty = fun _ => .none := rfl
@@ -146,4 +146,4 @@ theorem materializeUpdates_append_getElem {n updates₁ updates₂} {offset : Na
     rw [materializeUpdatesAux_getElem h]
   rfl
 
-end Regex.NFA
+end Regex.Strategy

--- a/correctness/RegexCorrectness/Strategy/Materialize/Naturality.lean
+++ b/correctness/RegexCorrectness/Strategy/Materialize/Naturality.lean
@@ -1,10 +1,11 @@
 import RegexCorrectness.Data.Expr.Semantics
 import RegexCorrectness.NFA.Semantics.Equivalence
-import RegexCorrectness.VM.Correspondence.Materialize.Lemmas
+import RegexCorrectness.Strategy.Materialize.Lemmas
 
 set_option autoImplicit false
 
 open Regex.Data (Expr)
+open Regex.Strategy
 open String (Pos)
 
 namespace Regex.NFA
@@ -111,6 +112,5 @@ where
         have := (eqv₂ tag).2 h₂
         simp [h] at this
         simp [←this, (eqv₁ tag).2 h₂]
-
 
 end Regex.NFA

--- a/correctness/RegexCorrectness/Strategy/Refinement.lean
+++ b/correctness/RegexCorrectness/Strategy/Refinement.lean
@@ -1,0 +1,48 @@
+import Regex.Strategy
+import RegexCorrectness.Strategy.Materialize
+
+set_option autoImplicit false
+
+open String (Pos)
+
+namespace Regex.Strategy
+
+variable {nfa : NFA} {bufferSize : Nat} {matched' : Option (List (Nat × Pos))} {matched : Option (Buffer bufferSize)}
+
+def refineUpdate (update : List (Nat × Pos)) (buffer : Buffer bufferSize) : Prop :=
+  materializeUpdates bufferSize update = buffer
+
+@[simp]
+theorem refineUpdate.empty {bufferSize : Nat} : refineUpdate HistoryStrategy.empty (BufferStrategy bufferSize).empty := rfl
+
+def refineUpdateOpt : Option (List (Nat × Pos)) → Option (Buffer bufferSize) → Prop
+  | .none, .none => True
+  | .some update, .some buffer => refineUpdate update buffer
+  | _, _ => False
+
+theorem refineUpdateOpt.isSome_iff (h : refineUpdateOpt matched' matched) :
+  matched'.isSome ↔ matched.isSome := by
+  match matched', matched with
+  | .none, .none => simp
+  | .some _, .some _ => simp
+  | .none, .some _ | .some _, .none => simp [refineUpdateOpt] at h
+
+theorem refineUpdateOpt.isNone_iff (h : refineUpdateOpt matched' matched) :
+  matched'.isNone ↔ matched.isNone := by
+  match matched', matched with
+  | .none, .none => simp
+  | .some _, .some _ => simp
+  | .none, .some _ | .some _, .none => simp [refineUpdateOpt] at h
+
+theorem refineUpdateOpt.orElse {update₁ update₂ : Option (List (Nat × Pos))} {buffer₁ buffer₂ : Option (Buffer bufferSize)}
+  (h₁ : refineUpdateOpt update₁ buffer₁) (h₂ : refineUpdateOpt update₂ buffer₂) :
+  refineUpdateOpt (update₁ <|> update₂) (buffer₁ <|> buffer₂) := by
+  match update₁, buffer₁ with
+  | .some _, .some _ => simp [h₁]
+  | .none, .none => simp [h₂]
+  | .none, .some _ | .some _, .none => simp [refineUpdateOpt] at h₁
+
+def refineUpdates (updates : Vector (List (Nat × Pos)) nfa.nodes.size) (buffers : Vector (Buffer bufferSize) nfa.nodes.size) : Prop :=
+  ∀ (i : Fin nfa.nodes.size), refineUpdate updates[i] buffers[i]
+
+end Regex.Strategy

--- a/correctness/RegexCorrectness/VM/Correspondence.lean
+++ b/correctness/RegexCorrectness/VM/Correspondence.lean
@@ -1,3 +1,2 @@
-import RegexCorrectness.VM.Correspondence.Materialize
 import RegexCorrectness.VM.Correspondence.Refinement
 import RegexCorrectness.VM.Correspondence.Correctness

--- a/correctness/RegexCorrectness/VM/Correspondence/Correctness.lean
+++ b/correctness/RegexCorrectness/VM/Correspondence/Correctness.lean
@@ -1,12 +1,11 @@
 import RegexCorrectness.VM.Search
-import RegexCorrectness.VM.Correspondence.Materialize
 import RegexCorrectness.VM.Correspondence.Refinement
 
 set_option autoImplicit false
 
 open Regex.Data (Span)
 open Regex (NFA)
-open Regex.NFA (EquivMaterializedUpdate materializeRegexGroups materializeUpdates)
+open Regex.Strategy (EquivMaterializedUpdate materializeRegexGroups materializeUpdates refineUpdateOpt)
 
 namespace Regex.VM
 

--- a/correctness/RegexCorrectness/VM/Correspondence/Materialize.lean
+++ b/correctness/RegexCorrectness/VM/Correspondence/Materialize.lean
@@ -1,3 +1,0 @@
-import RegexCorrectness.VM.Correspondence.Materialize.Basic
-import RegexCorrectness.VM.Correspondence.Materialize.Lemmas
-import RegexCorrectness.VM.Correspondence.Materialize.Naturality

--- a/correctness/RegexCorrectness/VM/Correspondence/Refinement/Refinement.lean
+++ b/correctness/RegexCorrectness/VM/Correspondence/Refinement/Refinement.lean
@@ -1,12 +1,11 @@
 import RegexCorrectness.VM.Search
-import RegexCorrectness.VM.Correspondence.Materialize
--- import RegexCorrectness.VM.Correspondence.Refinement.Simp
+import RegexCorrectness.Strategy.Refinement
 
 set_option autoImplicit false
 
 open Regex.Data (SparseSet)
 open Regex (NFA)
-open Regex.NFA (materializeUpdates)
+open Regex.Strategy (refineUpdateOpt refineUpdates materializeUpdates)
 open String (Pos Iterator)
 
 /-
@@ -21,42 +20,6 @@ variable {nfa : NFA} {wf : nfa.WellFormed} {bufferSize : Nat} {it : Iterator}
   {matched : Option (Buffer bufferSize)} {matched' : Option (List (Nat × Pos))}
   {next : SearchState (BufferStrategy bufferSize) nfa} {next' : SearchState HistoryStrategy nfa}
   {stack : εStack (BufferStrategy bufferSize) nfa} {stack' : εStack HistoryStrategy nfa}
-
-def refineUpdate (update : List (Nat × Pos)) (buffer : Buffer bufferSize) : Prop :=
-  materializeUpdates bufferSize update = buffer
-
-@[simp]
-theorem refineUpdate.empty {bufferSize : Nat} : refineUpdate HistoryStrategy.empty (BufferStrategy bufferSize).empty := rfl
-
-def refineUpdateOpt : Option (List (Nat × Pos)) → Option (Buffer bufferSize) → Prop
-  | .none, .none => True
-  | .some update, .some buffer => refineUpdate update buffer
-  | _, _ => False
-
-theorem refineUpdateOpt.isSome_iff (h : refineUpdateOpt matched' matched) :
-  matched'.isSome ↔ matched.isSome := by
-  match matched', matched with
-  | .none, .none => simp
-  | .some _, .some _ => simp
-  | .none, .some _ | .some _, .none => simp [refineUpdateOpt] at h
-
-theorem refineUpdateOpt.isNone_iff (h : refineUpdateOpt matched' matched) :
-  matched'.isNone ↔ matched.isNone := by
-  match matched', matched with
-  | .none, .none => simp
-  | .some _, .some _ => simp
-  | .none, .some _ | .some _, .none => simp [refineUpdateOpt] at h
-
-theorem refineUpdateOpt.orElse {update₁ update₂ : Option (List (Nat × Pos))} {buffer₁ buffer₂ : Option (Buffer bufferSize)}
-  (h₁ : refineUpdateOpt update₁ buffer₁) (h₂ : refineUpdateOpt update₂ buffer₂) :
-  refineUpdateOpt (update₁ <|> update₂) (buffer₁ <|> buffer₂) := by
-  match update₁, buffer₁ with
-  | .some _, .some _ => simp [h₁]
-  | .none, .none => simp [h₂]
-  | .none, .some _ | .some _, .none => simp [refineUpdateOpt] at h₁
-
-def refineUpdates (updates : Vector (List (Nat × Pos)) nfa.nodes.size) (buffers : Vector (Buffer bufferSize) nfa.nodes.size) : Prop :=
-  ∀ (i : Fin nfa.nodes.size), refineUpdate updates[i] buffers[i]
 
 def SearchState.refines (state' : SearchState HistoryStrategy nfa) (state : SearchState (BufferStrategy bufferSize) nfa) : Prop :=
   state'.states = state.states ∧ refineUpdates state'.updates state.updates

--- a/correctness/RegexCorrectness/VM/Correspondence/Refinement/Refinement.lean
+++ b/correctness/RegexCorrectness/VM/Correspondence/Refinement/Refinement.lean
@@ -46,8 +46,8 @@ theorem εStack.refines_cons {update state' tail' stack} :
     exact eq ▸ .cons h₁ h₂ rest
 
 theorem εClosure.refines {result result'}
-  (h : @εClosure (BufferStrategy bufferSize) nfa wf it matched next stack = result)
-  (h' : @εClosure HistoryStrategy nfa wf it matched' next' stack' = result')
+  (h : εClosure (BufferStrategy bufferSize) nfa wf it matched next stack = result)
+  (h' : εClosure HistoryStrategy nfa wf it matched' next' stack' = result')
   (refMatched : refineUpdateOpt matched' matched)
   (refState : next'.refines next)
   (refStack : stack'.refines stack) :

--- a/regex/Regex/Backtracker/Basic.lean
+++ b/regex/Regex/Backtracker/Basic.lean
@@ -1,51 +1,14 @@
-import Regex.Data.String
+import Regex.Data.BoundedIterator
 import Regex.NFA
 import Regex.Strategy
 import Regex.Backtracker.BitMatrix
 
 open String (Iterator Pos)
+open Regex.Data (BoundedIterator)
 
 set_option autoImplicit false
 
 namespace Regex.Backtracker
-
-structure BoundedIterator (startIdx : Nat) where
-  it : Iterator
-  ge : startIdx ≤ it.pos.byteIdx
-  le : it.pos ≤ it.toString.endPos
-
-namespace BoundedIterator
-
-def maxIdx {startIdx : Nat} (bit : BoundedIterator startIdx) : Nat := bit.it.toString.endPos.byteIdx
-
-def pos {startIdx : Nat} (bit : BoundedIterator startIdx) : String.Pos := bit.it.pos
-
-def index {startIdx : Nat} (bit : BoundedIterator startIdx) : Fin (bit.maxIdx + 1 - startIdx) :=
-  have lt : bit.it.pos.byteIdx - startIdx < bit.maxIdx + 1 - startIdx := by
-    exact Nat.sub_lt_sub_right bit.ge (Nat.lt_of_le_of_lt bit.le (Nat.lt_succ_self _))
-  ⟨bit.it.pos.byteIdx - startIdx, lt⟩
-
-def index' {startIdx maxIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.maxIdx = maxIdx) : Fin (maxIdx + 1 - startIdx) :=
-  bit.index.cast (by simp [h])
-
-def hasNext {startIdx : Nat} (bit : BoundedIterator startIdx) : Bool := bit.it.hasNext
-
-def next {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : BoundedIterator startIdx :=
-  let it' := bit.it.next' h
-  have ge' : startIdx ≤ it'.pos.byteIdx := Nat.le_of_lt (Nat.lt_of_le_of_lt bit.ge bit.it.lt_next)
-  have le' : it'.pos ≤ it'.toString.endPos := bit.it.next_le_endPos h
-  ⟨it', ge', le'⟩
-
-def curr {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : Char := bit.it.curr' h
-
-theorem next_maxIdx {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : (bit.next h).maxIdx = bit.maxIdx := rfl
-
-def remainingBytes {startIdx : Nat} (bit : BoundedIterator startIdx) : Nat := bit.it.remainingBytes
-
-theorem next_remainingBytes_lt {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : (bit.next h).remainingBytes < bit.remainingBytes := by
-  simp [next, remainingBytes]
-
-end BoundedIterator
 
 structure StackEntry (σ : Strategy) (nfa : NFA) (startIdx maxIdx : Nat) where
   update : σ.Update

--- a/regex/Regex/Backtracker/Basic.lean
+++ b/regex/Regex/Backtracker/Basic.lean
@@ -88,11 +88,6 @@ where
   termination_by bit.remainingBytes
 
 def captureNextBuf (nfa : NFA) (wf : nfa.WellFormed) (bufferSize : Nat) (it : Iterator) : Option (Buffer bufferSize) :=
-  let _ := BufferStrategy bufferSize
   captureNext (BufferStrategy bufferSize) nfa wf it
-
-def searchNext (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator) : Option (Pos × Pos) := do
-  let slots ← captureNextBuf nfa wf 2 it
-  pure (← slots[0], ← slots[1])
 
 end Regex.Backtracker

--- a/regex/Regex/Data/BoundedIterator.lean
+++ b/regex/Regex/Data/BoundedIterator.lean
@@ -1,0 +1,49 @@
+import Regex.Data.String
+
+set_option autoImplicit false
+
+open String (Iterator)
+
+namespace Regex.Data
+
+structure BoundedIterator (startIdx : Nat) where
+  it : Iterator
+  ge : startIdx ≤ it.pos.byteIdx
+  le : it.pos ≤ it.toString.endPos
+
+namespace BoundedIterator
+
+def maxIdx {startIdx : Nat} (bit : BoundedIterator startIdx) : Nat := bit.it.toString.endPos.byteIdx
+
+def pos {startIdx : Nat} (bit : BoundedIterator startIdx) : String.Pos := bit.it.pos
+
+def index {startIdx : Nat} (bit : BoundedIterator startIdx) : Fin (bit.maxIdx + 1 - startIdx) :=
+  have lt : bit.it.pos.byteIdx - startIdx < bit.maxIdx + 1 - startIdx := by
+    exact Nat.sub_lt_sub_right bit.ge (Nat.lt_of_le_of_lt bit.le (Nat.lt_succ_self _))
+  ⟨bit.it.pos.byteIdx - startIdx, lt⟩
+
+def index' {startIdx maxIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.maxIdx = maxIdx) : Fin (maxIdx + 1 - startIdx) :=
+  bit.index.cast (by simp [h])
+
+def hasNext {startIdx : Nat} (bit : BoundedIterator startIdx) : Bool := bit.it.hasNext
+
+def next {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : BoundedIterator startIdx :=
+  let it' := bit.it.next' h
+  have ge' : startIdx ≤ it'.pos.byteIdx := Nat.le_of_lt (Nat.lt_of_le_of_lt bit.ge bit.it.lt_next)
+  have le' : it'.pos ≤ it'.toString.endPos := bit.it.next_le_endPos h
+  ⟨it', ge', le'⟩
+
+def curr {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : Char := bit.it.curr' h
+
+theorem next_maxIdx {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : (bit.next h).maxIdx = bit.maxIdx := rfl
+
+def remainingBytes {startIdx : Nat} (bit : BoundedIterator startIdx) : Nat := bit.it.remainingBytes
+
+theorem next_remainingBytes_lt {startIdx : Nat} (bit : BoundedIterator startIdx) (h : bit.hasNext) : (bit.next h).remainingBytes < bit.remainingBytes := by
+  simp [next, remainingBytes]
+
+def Valid {startIdx : Nat} (bit : BoundedIterator startIdx) : Prop := String.Pos.isValid bit.it.toString bit.it.pos
+
+end BoundedIterator
+
+end Regex.Data

--- a/regex/Regex/Data/String.lean
+++ b/regex/Regex/Data/String.lean
@@ -1,3 +1,4 @@
+-- FIXME: many of the theorems are no longer needed as we moved to a simpler termination argument for Backtracker.captureNext.go.
 namespace Char
 
 theorem default_utf8Size : (default : Char).utf8Size = 1 := rfl

--- a/regex/Regex/Data/String.lean
+++ b/regex/Regex/Data/String.lean
@@ -1,4 +1,3 @@
--- FIXME: many of the theorems are no longer needed as we moved to a simpler termination argument for Backtracker.captureNext.go.
 namespace Char
 
 theorem default_utf8Size : (default : Char).utf8Size = 1 := rfl

--- a/regex/Regex/Regex/Basic.lean
+++ b/regex/Regex/Regex/Basic.lean
@@ -20,11 +20,9 @@ def captureNextBuf (self : Regex) (bufferSize : Nat) (it : Iterator) : Option (B
   else
     VM.captureNextBuf self.nfa self.wf bufferSize it
 
-def searchNext (self : Regex) (it : Iterator) : Option (Pos × Pos) := do
-  if self.useBacktracker then
-    Backtracker.searchNext self.nfa self.wf it
-  else
-    VM.searchNext self.nfa self.wf it
+def searchNext (self : Regex) (it : Iterator) : Option (Pos × Pos) :=  do
+  let slots ← captureNextBuf self 2 it
+  pure (← slots[0], ← slots[1])
 
 def parse (s : String) : Except Regex.Syntax.Parser.Error Regex := do
   let expr ← Regex.Syntax.Parser.parse s

--- a/regex/Regex/VM/Basic.lean
+++ b/regex/Regex/VM/Basic.lean
@@ -147,11 +147,6 @@ where
           go it.next (stepped.1 <|> matched) stepped.2 ⟨current.states.clear, current.updates⟩
 
 def captureNextBuf (nfa : NFA) (wf : nfa.WellFormed) (bufferSize : Nat) (it : Iterator) : Option (Buffer bufferSize) :=
-  let _ := BufferStrategy bufferSize
   captureNext (BufferStrategy bufferSize) nfa wf it
-
-def searchNext (nfa : NFA) (wf : nfa.WellFormed) (it : String.Iterator) : Option (Pos × Pos) := do
-  let slots ← captureNextBuf nfa wf 2 it
-  pure (← slots[0], ← slots[1])
 
 end Regex.VM


### PR DESCRIPTION
The PR ports the soundness proof of the NFA simulation to the bounded backtracking engine. It reuses the theory of the equivalence between a regex match and the compiled NFA's acceptance and verifies that the backtracking engine returns a match only when the NFA accepts the input. The PR also refactors the refinement relations so that the backtracker proof can reuse it.

Closes #63.