### PR TITLE
Backtracker should continue the search when it encounters a fail node

### DIFF
--- a/correctness/RegexCorrectness/Backtracker/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Basic.lean
@@ -28,7 +28,9 @@ theorem captureNextAux.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed)
       (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
     ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     nfa[state] = NFA.Node.fail →
+    motive visited' stack' →
     motive visited (⟨update, state, it⟩ :: stack'))
   (epsilon :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
@@ -158,8 +160,8 @@ theorem captureNextAux.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed)
   captureNextAux.induct σ nfa wf startIdx maxIdx motive base visited
     (fun visited update state it stack' mem _ hn =>
       done visited update state it stack' mem hn)
-    (fun visited update state it stack' mem _ hn =>
-      fail visited update state it stack' mem hn)
+    (fun visited update state it stack' mem _ hn ih =>
+      fail visited update state it stack' mem hn ih)
     (fun visited update state it stack' mem _ state' hn isLt ih =>
       epsilon visited update state it stack' mem ⟨state', isLt⟩ hn ih)
     (fun visited update state it stack' mem _ state₁ state₂ hn isLt ih =>
@@ -212,7 +214,7 @@ theorem captureNextAux_done {update state it stack'} (mem : ¬visited.get state 
   split <;> simp_all
 
 theorem captureNextAux_fail {update state it stack'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .fail) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') = (.none, visited.set state it.index) := by
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') = captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) stack' := by
   conv =>
     lhs
     unfold captureNextAux

--- a/correctness/RegexCorrectness/Backtracker/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Basic.lean
@@ -2,7 +2,7 @@ import Regex.Backtracker
 
 set_option autoImplicit false
 
-open Regex.Data (BoundedIterator)
+open Regex.Data (BitMatrix BoundedIterator)
 
 namespace Regex.Backtracker
 

--- a/correctness/RegexCorrectness/Backtracker/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Basic.lean
@@ -11,177 +11,177 @@ theorem captureNextAux.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed)
   (base : ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)), motive visited [])
   (visited :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    visited.get state (it.index' eq) →
+    visited.get state it.index →
     motive visited stack' →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited (⟨update, state, it⟩ :: stack'))
   (done :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
+    ¬visited.get state it.index →
     nfa[state] = NFA.Node.done →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited (⟨update, state, it⟩ :: stack'))
   (fail :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
+    ¬visited.get state it.index →
     nfa[state] = NFA.Node.fail →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited (⟨update, state, it⟩ :: stack'))
   (epsilon :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.epsilon state' →
-    motive visited' (⟨update, state', it, eq⟩ :: stack') →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited' (⟨update, state', it⟩ :: stack') →
+    motive visited (⟨update, state, it⟩ :: stack'))
   (split :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (state₁ state₂ : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.split state₁ state₂ →
-    motive visited' (⟨update, state₁, it, eq⟩ :: ⟨update, state₂, it, eq⟩ :: stack') →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited' (⟨update, state₁, it⟩ :: ⟨update, state₂, it⟩ :: stack') →
+    motive visited (⟨update, state, it⟩ :: stack'))
   (save :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (offset : Nat) (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.save offset state' →
     let update' := σ.write update offset it.pos;
-    motive visited' (⟨update', state', it, eq⟩ :: stack') →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited' (⟨update', state', it⟩ :: stack') →
+    motive visited (⟨update, state, it⟩ :: stack'))
   (anchor_pos :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (a : Data.Anchor) (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.anchor a state' →
     Data.Anchor.test it.it a →
-    motive visited' (⟨update, state', it, eq⟩ :: stack') →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited' (⟨update, state', it⟩ :: stack') →
+    motive visited (⟨update, state, it⟩ :: stack'))
   (anchor_neg :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (a : Data.Anchor) (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.anchor a state' →
     ¬Data.Anchor.test it.it a →
     motive visited' stack' →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited (⟨update, state, it⟩ :: stack'))
   (char_pos :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (c : Char) (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.char c state' →
     (h : it.hasNext) →
     it.curr h = c →
-    motive visited' (⟨update, state', it.next h, eq⟩ :: stack') →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited' (⟨update, state', it.next h⟩ :: stack') →
+    motive visited (⟨update, state, it⟩ :: stack'))
   (char_neg :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (c : Char) (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.char c state' →
     (h : it.hasNext) →
     ¬it.curr h = c →
     motive visited' stack' →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited (⟨update, state, it⟩ :: stack'))
   (char_end :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (c : Char) (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.char c state' →
     ¬it.hasNext →
     motive visited' stack' →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited (⟨update, state, it⟩ :: stack'))
   (sparse_pos :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (cs : Data.Classes) (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.sparse cs state' →
     (h : it.hasNext) →
     it.curr h ∈ cs →
-    motive visited' (⟨update, state', it.next h, eq⟩ :: stack') →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited' (⟨update, state', it.next h⟩ :: stack') →
+    motive visited (⟨update, state, it⟩ :: stack'))
   (sparse_neg :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (cs : Data.Classes) (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.sparse cs state' →
     (h : it.hasNext) →
     ¬it.curr h ∈ cs →
     motive visited' stack' →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited (⟨update, state, it⟩ :: stack'))
   (sparse_end :
     ∀ (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update)
-      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx) (eq : it.maxIdx = maxIdx)
+      (state : Fin nfa.nodes.size) (it : BoundedIterator startIdx maxIdx)
       (stack' : List (StackEntry σ nfa startIdx maxIdx)),
-    ¬visited.get state (it.index' eq) →
-    let visited' := visited.set state (it.index' eq);
+    ¬visited.get state it.index →
+    let visited' := visited.set state it.index;
     ∀ (cs : Data.Classes) (state' : Fin nfa.nodes.size),
     nfa[state] = NFA.Node.sparse cs state' →
     ¬it.hasNext →
     motive visited' stack' →
-    motive visited (⟨update, state, it, eq⟩ :: stack'))
+    motive visited (⟨update, state, it⟩ :: stack'))
   (matrix : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (stack : List (StackEntry σ nfa startIdx maxIdx)) :
   motive matrix stack :=
   captureNextAux.induct σ nfa wf startIdx maxIdx motive base visited
-    (fun visited update state it eq stack' mem _ hn =>
-      done visited update state it eq stack' mem hn)
-    (fun visited update state it eq stack' mem _ hn =>
-      fail visited update state it eq stack' mem hn)
-    (fun visited update state it eq stack' mem _ state' hn isLt ih =>
-      epsilon visited update state it eq stack' mem ⟨state', isLt⟩ hn ih)
-    (fun visited update state it eq stack' mem _ state₁ state₂ hn isLt ih =>
-      split visited update state it eq stack' mem ⟨state₁, isLt.1⟩ ⟨state₂, isLt.2⟩ hn ih)
-    (fun visited update state it eq stack' mem _ offset state' hn isLt ih =>
-      save visited update state it eq stack' mem offset ⟨state', isLt⟩ hn ih)
-    (fun visited update state it eq stack' mem _ a state' hn isLt ih =>
-      anchor_pos visited update state it eq stack' mem a ⟨state', isLt⟩ hn ih)
-    (fun visited update state it eq stack' mem _ a state' hn isLt ih =>
-      anchor_neg visited update state it eq stack' mem a ⟨state', isLt⟩ hn ih)
-    (fun visited update state it eq stack' mem _ state' isLt h hn ih =>
-      char_pos visited update state it eq stack' mem (it.curr h) ⟨state', isLt⟩ hn h rfl ih)
-    (fun visited update state it eq stack' mem _ c state' hn isLt h ne ih =>
-      char_neg visited update state it eq stack' mem c ⟨state', isLt⟩ hn h ne ih)
-    (fun visited update state it eq stack' mem _ c state' hn isLt h ih =>
-      char_end visited update state it eq stack' mem c ⟨state', isLt⟩ hn h ih)
-    (fun visited update state it eq stack' mem _ cs state' hn isLt h ih =>
-      sparse_pos visited update state it eq stack' mem cs ⟨state', isLt⟩ hn h ih)
-    (fun visited update state it eq stack' mem _ cs state' hn isLt h ih =>
-      sparse_neg visited update state it eq stack' mem cs ⟨state', isLt⟩ hn h ih)
-    (fun visited update state it eq stack' mem _ cs state' hn isLt h ih =>
-      sparse_end visited update state it eq stack' mem cs ⟨state', isLt⟩ hn h ih)
+    (fun visited update state it stack' mem _ hn =>
+      done visited update state it stack' mem hn)
+    (fun visited update state it stack' mem _ hn =>
+      fail visited update state it stack' mem hn)
+    (fun visited update state it stack' mem _ state' hn isLt ih =>
+      epsilon visited update state it stack' mem ⟨state', isLt⟩ hn ih)
+    (fun visited update state it stack' mem _ state₁ state₂ hn isLt ih =>
+      split visited update state it stack' mem ⟨state₁, isLt.1⟩ ⟨state₂, isLt.2⟩ hn ih)
+    (fun visited update state it stack' mem _ offset state' hn isLt ih =>
+      save visited update state it stack' mem offset ⟨state', isLt⟩ hn ih)
+    (fun visited update state it stack' mem _ a state' hn isLt ih =>
+      anchor_pos visited update state it stack' mem a ⟨state', isLt⟩ hn ih)
+    (fun visited update state it stack' mem _ a state' hn isLt ih =>
+      anchor_neg visited update state it stack' mem a ⟨state', isLt⟩ hn ih)
+    (fun visited update state it stack' mem _ state' isLt h hn ih =>
+      char_pos visited update state it stack' mem (it.curr h) ⟨state', isLt⟩ hn h rfl ih)
+    (fun visited update state it stack' mem _ c state' hn isLt h ne ih =>
+      char_neg visited update state it stack' mem c ⟨state', isLt⟩ hn h ne ih)
+    (fun visited update state it stack' mem _ c state' hn isLt h ih =>
+      char_end visited update state it stack' mem c ⟨state', isLt⟩ hn h ih)
+    (fun visited update state it stack' mem _ cs state' hn isLt h ih =>
+      sparse_pos visited update state it stack' mem cs ⟨state', isLt⟩ hn h ih)
+    (fun visited update state it stack' mem _ cs state' hn isLt h ih =>
+      sparse_neg visited update state it stack' mem cs ⟨state', isLt⟩ hn h ih)
+    (fun visited update state it stack' mem _ cs state' hn isLt h ih =>
+      sparse_end visited update state it stack' mem cs ⟨state', isLt⟩ hn h ih)
     matrix stack
 
 /-
@@ -195,15 +195,15 @@ theorem captureNextAux_base :
   captureNextAux σ nfa wf startIdx maxIdx visited [] = (.none, visited) := by
   simp [captureNextAux]
 
-theorem captureNextAux_visited {update state it eq stack'} (mem : visited.get state (it.index' eq)) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') = captureNextAux σ nfa wf startIdx maxIdx visited stack' := by
+theorem captureNextAux_visited {update state it stack'} (mem : visited.get state it.index) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') = captureNextAux σ nfa wf startIdx maxIdx visited stack' := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
 
-theorem captureNextAux_done {update state it eq stack'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .done) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') = (.some update, visited.set state (it.index' eq)) := by
+theorem captureNextAux_done {update state it stack'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .done) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') = (.some update, visited.set state it.index) := by
   simp at hn
   conv =>
     lhs
@@ -211,107 +211,107 @@ theorem captureNextAux_done {update state it eq stack'} (mem : ¬visited.get sta
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_fail {update state it eq stack'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .fail) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') = (.none, visited.set state (it.index' eq)) := by
+theorem captureNextAux_fail {update state it stack'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .fail) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') = (.none, visited.set state it.index) := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_epsilon {update state it eq stack' state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .epsilon state') :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it, eq⟩ :: stack') := by
+theorem captureNextAux_epsilon {update state it stack' state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .epsilon state') :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) (⟨update, state', it⟩ :: stack') := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_split {update state it eq stack' state₁ state₂} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .split state₁ state₂) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state₁, it, eq⟩ :: ⟨update, state₂, it, eq⟩ :: stack') := by
+theorem captureNextAux_split {update state it stack' state₁ state₂} (mem : ¬visited.get state it.index) (hn : nfa[state] = .split state₁ state₂) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) (⟨update, state₁, it⟩ :: ⟨update, state₂, it⟩ :: stack') := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_save {update state it eq stack' offset state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .save offset state') :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨σ.write update offset it.pos, state', it, eq⟩ :: stack') := by
+theorem captureNextAux_save {update state it stack' offset state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .save offset state') :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) (⟨σ.write update offset it.pos, state', it⟩ :: stack') := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_anchor_pos {update state it eq stack' a state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .anchor a state') (h : Data.Anchor.test it.it a) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it, eq⟩ :: stack') := by
+theorem captureNextAux_anchor_pos {update state it stack' a state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .anchor a state') (h : Data.Anchor.test it.it a) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) (⟨update, state', it⟩ :: stack') := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_anchor_neg {update state it eq stack' a state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .anchor a state') (h : ¬Data.Anchor.test it.it a) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+theorem captureNextAux_anchor_neg {update state it stack' a state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .anchor a state') (h : ¬Data.Anchor.test it.it a) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) stack' := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_char_pos {update state it eq stack' c state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .char c state') (h : it.hasNext) (hc : it.curr h = c) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it.next h, eq⟩ :: stack') := by
+theorem captureNextAux_char_pos {update state it stack' c state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .char c state') (h : it.hasNext) (hc : it.curr h = c) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) (⟨update, state', it.next h⟩ :: stack') := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_char_neg {update state it eq stack' c state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .char c state') (h : it.hasNext) (hc : ¬it.curr h = c) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+theorem captureNextAux_char_neg {update state it stack' c state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .char c state') (h : it.hasNext) (hc : ¬it.curr h = c) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) stack' := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_char_end {update state it eq stack' c state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .char c state') (h : ¬it.hasNext) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+theorem captureNextAux_char_end {update state it stack' c state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .char c state') (h : ¬it.hasNext) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) stack' := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_sparse_pos {update state it eq stack' cs state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .sparse cs state') (h : it.hasNext) (hc : it.curr h ∈ cs) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) (⟨update, state', it.next h, eq⟩ :: stack') := by
+theorem captureNextAux_sparse_pos {update state it stack' cs state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .sparse cs state') (h : it.hasNext) (hc : it.curr h ∈ cs) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) (⟨update, state', it.next h⟩ :: stack') := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_sparse_neg {update state it eq stack' cs state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .sparse cs state') (h : it.hasNext) (hc : ¬it.curr h ∈ cs) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+theorem captureNextAux_sparse_neg {update state it stack' cs state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .sparse cs state') (h : it.hasNext) (hc : ¬it.curr h ∈ cs) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) stack' := by
   conv =>
     lhs
     unfold captureNextAux
     simp [mem]
   split <;> simp_all
 
-theorem captureNextAux_sparse_end {update state it eq stack' cs state'} (mem : ¬visited.get state (it.index' eq)) (hn : nfa[state] = .sparse cs state') (h : ¬it.hasNext) :
-  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it, eq⟩ :: stack') =
-  captureNextAux σ nfa wf startIdx maxIdx (visited.set state (it.index' eq)) stack' := by
+theorem captureNextAux_sparse_end {update state it stack' cs state'} (mem : ¬visited.get state it.index) (hn : nfa[state] = .sparse cs state') (h : ¬it.hasNext) :
+  captureNextAux σ nfa wf startIdx maxIdx visited (⟨update, state, it⟩ :: stack') =
+  captureNextAux σ nfa wf startIdx maxIdx (visited.set state it.index) stack' := by
   conv =>
     lhs
     unfold captureNextAux
@@ -320,23 +320,23 @@ theorem captureNextAux_sparse_end {update state it eq stack' cs state'} (mem : �
 
 end
 
-theorem captureNext.go.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (startIdx : Nat)
-  (motive : (bit : BoundedIterator startIdx) → BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx) → Prop)
-  (found : ∀ (bit : BoundedIterator startIdx) (visited : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)) (update : σ.Update) (visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)),
-    captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.some update, visited') →
+theorem captureNext.go.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (startIdx maxIdx : Nat)
+  (motive : (bit : BoundedIterator startIdx maxIdx) → BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx) → Prop)
+  (found : ∀ (bit : BoundedIterator startIdx maxIdx) (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (update : σ.Update) (visited' : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)),
+    captureNextAux σ nfa wf startIdx maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit⟩] = (.some update, visited') →
     motive bit visited)
-  (not_found_next : ∀ (bit : BoundedIterator startIdx) (visited visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)),
-    captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.none, visited') →
+  (not_found_next : ∀ (bit : BoundedIterator startIdx maxIdx) (visited visited' : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)),
+    captureNextAux σ nfa wf startIdx maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit⟩] = (.none, visited') →
     (h : bit.hasNext) →
     (ih : motive (bit.next h) visited') →
     motive bit visited)
-  (not_found_end : ∀ (bit : BoundedIterator startIdx) (visited visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)),
-    captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.none, visited') →
+  (not_found_end : ∀ (bit : BoundedIterator startIdx maxIdx) (visited visited' : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)),
+    captureNextAux σ nfa wf startIdx maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit⟩] = (.none, visited') →
     ¬bit.hasNext →
     motive bit visited)
-  (bit : BoundedIterator startIdx) (visited : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)) :
+  (bit : BoundedIterator startIdx maxIdx) (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) :
   motive bit visited :=
-  captureNext.go.induct σ nfa wf startIdx motive
+  captureNext.go.induct σ nfa wf startIdx maxIdx motive
     found
     (fun bit visited visited' hres h _ ih => not_found_next bit visited visited' hres h ih)
     not_found_end
@@ -347,22 +347,22 @@ Simplification lemmas for `captureNext.go`.
 -/
 section
 
-variable {σ nfa wf startIdx bit visited}
+variable {σ nfa wf startIdx maxIdx bit visited}
 
-theorem captureNext.go_found {update visited'} (h : captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.some update, visited')) :
-  captureNext.go σ nfa wf startIdx bit visited = (.some update, visited') := by
+theorem captureNext.go_found {update visited'} (h : captureNextAux σ nfa wf startIdx maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit⟩] = (.some update, visited')) :
+  captureNext.go σ nfa wf startIdx maxIdx bit visited = (.some update, visited') := by
   unfold captureNext.go
   split <;> simp_all
 
-theorem captureNext.go_not_found_next {visited'} (h : captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.none, visited')) (h' : bit.hasNext) :
-  captureNext.go σ nfa wf startIdx bit visited = captureNext.go σ nfa wf startIdx (bit.next h') visited' := by
+theorem captureNext.go_not_found_next {visited'} (h : captureNextAux σ nfa wf startIdx maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit⟩] = (.none, visited')) (h' : bit.hasNext) :
+  captureNext.go σ nfa wf startIdx maxIdx bit visited = captureNext.go σ nfa wf startIdx maxIdx (bit.next h') visited' := by
   conv =>
     lhs
     unfold captureNext.go
   split <;> simp_all
 
-theorem captureNext.go_not_found_end {visited'} (h : captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] = (.none, visited')) (h' : ¬bit.hasNext) :
-  captureNext.go σ nfa wf startIdx bit visited = (.none, visited') := by
+theorem captureNext.go_not_found_end {visited'} (h : captureNextAux σ nfa wf startIdx maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit⟩] = (.none, visited')) (h' : ¬bit.hasNext) :
+  captureNext.go σ nfa wf startIdx maxIdx bit visited = (.none, visited') := by
   unfold captureNext.go
   split <;> simp_all
 
@@ -376,7 +376,7 @@ section
 variable {σ nfa wf it}
 
 theorem captureNext_le (le : it.pos ≤ it.toString.endPos) :
-  captureNext σ nfa wf it = (captureNext.go σ nfa wf it.pos.byteIdx ⟨it, Nat.le_refl _, le⟩ (BitMatrix.zero _ _)).1 := by
+  captureNext σ nfa wf it = (captureNext.go σ nfa wf it.pos.byteIdx it.toString.endPos.byteIdx ⟨it, Nat.le_refl _, le, rfl⟩ (BitMatrix.zero _ _)).1 := by
   simp [captureNext, le]
 
 theorem captureNext_not_le (h : ¬it.pos ≤ it.toString.endPos) :

--- a/correctness/RegexCorrectness/Backtracker/Compile.lean
+++ b/correctness/RegexCorrectness/Backtracker/Compile.lean
@@ -6,7 +6,7 @@ set_option autoImplicit false
 
 open String (Pos)
 open Regex.NFA (EquivUpdate)
-open Regex.Data (BoundedIterator)
+open Regex.Data (BitMatrix BoundedIterator)
 
 namespace Regex.Backtracker
 

--- a/correctness/RegexCorrectness/Backtracker/Compile.lean
+++ b/correctness/RegexCorrectness/Backtracker/Compile.lean
@@ -10,15 +10,15 @@ open Regex.Data (BoundedIterator)
 
 namespace Regex.Backtracker
 
-theorem captureNext.go.path_done_of_some {nfa wf startIdx bit update} {visited visited' : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)}
-  (v : bit.Valid) (hres : captureNext.go HistoryStrategy nfa wf startIdx bit visited = (.some update, visited')) :
+theorem captureNext.go.path_done_of_some {nfa wf startIdx maxIdx bit update} {visited visited' : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)}
+  (v : bit.Valid) (hres : captureNext.go HistoryStrategy nfa wf startIdx maxIdx bit visited = (.some update, visited')) :
   ∃ state it it', it'.toString = bit.it.toString ∧ nfa[state] = .done ∧ Path nfa wf it it' state update := by
   induction bit, visited using captureNext.go.induct' HistoryStrategy nfa wf startIdx with
   | found bit visited update' visited' haux =>
     simp [captureNext.go_found haux] at hres
     simp [hres] at haux
     have ⟨l, r, vf⟩ := (bit.valid_of_valid v).validFor
-    have inv₀ : captureNextAux.UpperInv wf bit.it [⟨[], ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] := by
+    have inv₀ : captureNextAux.UpperInv wf bit.it [⟨[], ⟨nfa.start, wf.start_lt⟩, bit⟩] := by
       refine ⟨?_⟩
       simp
       exact .init (bit.valid_of_valid v)
@@ -33,10 +33,10 @@ theorem captureNext.path_done_of_some {nfa wf it update} (hres : captureNext His
   ∃ state it' it'', it''.toString = it.toString ∧ nfa[state] = .done ∧ Path nfa wf it' it'' state update := by
   if le : it.pos ≤ it.toString.endPos then
     simp [captureNext_le le] at hres
-    let result := go HistoryStrategy nfa wf it.pos.byteIdx ⟨it, (Nat.le_refl _), le⟩ (BitMatrix.zero _ _)
+    let result := go HistoryStrategy nfa wf it.pos.byteIdx it.toString.endPos.byteIdx ⟨it, (Nat.le_refl _), le, rfl⟩ (BitMatrix.zero _ _)
     change result.1 = .some update at hres
     have : result = (.some update, result.2) := by simp [Prod.ext_iff, hres]
-    exact captureNext.go.path_done_of_some (BoundedIterator.valid_of_it_valid _ v) this
+    exact captureNext.go.path_done_of_some (BoundedIterator.valid_of_it_valid v) this
   else
     simp [captureNext_not_le le] at hres
 

--- a/correctness/RegexCorrectness/Backtracker/Refinement.lean
+++ b/correctness/RegexCorrectness/Backtracker/Refinement.lean
@@ -4,7 +4,7 @@ import RegexCorrectness.Strategy
 set_option autoImplicit false
 
 open Regex (NFA)
-open Regex.Data (BoundedIterator)
+open Regex.Data (BitMatrix BoundedIterator)
 open Regex.Strategy (refineUpdate refineUpdateOpt refineUpdates materializeUpdates)
 open String (Pos)
 namespace Regex.Backtracker
@@ -52,11 +52,13 @@ theorem captureNextAux.refines (nfa wf startIdx maxIdx bufferSize visited) {stac
     | cons entryH entryB stackH stackB refEntry refStack =>
       rw [refEntry.simpL]
       simp [captureNextAux_done mem hn, Refines, refineUpdateOpt, refEntry.1]
-  | fail visited update state' it stackH mem hn =>
+  | fail visited update state' it stackH mem visited' hn =>
+    rename_i ih
     cases refStack with
     | cons entryH entryB stackH stackB refEntry refStack =>
       rw [refEntry.simpL]
-      simp [captureNextAux_fail mem hn, Refines, refineUpdateOpt]
+      simp [captureNextAux_fail mem hn]
+      exact ih refStack
   | epsilon visited update state it stackH mem visited' state' hn =>
     rename_i ih
     cases refStack with

--- a/correctness/RegexCorrectness/Backtracker/Traversal.lean
+++ b/correctness/RegexCorrectness/Backtracker/Traversal.lean
@@ -18,100 +18,100 @@ theorem mem_of_mem_visited {s i} (hmem : visited.get s i) :
   (captureNextAux σ nfa wf startIdx maxIdx visited stack).2.get s i := by
   induction visited, stack using captureNextAux.induct' σ nfa wf startIdx maxIdx with
   | base visited => simp [captureNextAux_base, hmem]
-  | visited visited update state it eq stack' mem ih => simp [captureNextAux_visited mem, ih hmem]
-  | done visited update state it eq stack' mem hn => simp [captureNextAux_done mem hn, BitMatrix.get_set, hmem]
-  | fail visited update state it eq stack' mem hn => simp [captureNextAux_fail mem hn, BitMatrix.get_set, hmem]
-  | epsilon visited update state it eq stack' mem visited' state' hn ih =>
+  | visited visited update state it stack' mem ih => simp [captureNextAux_visited mem, ih hmem]
+  | done visited update state it stack' mem hn => simp [captureNextAux_done mem hn, BitMatrix.get_set, hmem]
+  | fail visited update state it stack' mem hn => simp [captureNextAux_fail mem hn, BitMatrix.get_set, hmem]
+  | epsilon visited update state it stack' mem visited' state' hn ih =>
     rw [captureNextAux_epsilon mem hn]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | split visited update state it eq stack' mem visited' state₁ state₂ hn ih =>
+  | split visited update state it stack' mem visited' state₁ state₂ hn ih =>
     rw [captureNextAux_split mem hn]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | save visited update state it eq stack' mem visited' offset state' hn update' ih =>
+  | save visited update state it stack' mem visited' offset state' hn update' ih =>
     rw [captureNextAux_save mem hn]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | anchor_pos visited update state it eq stack' mem visited' a state' hn ht ih =>
+  | anchor_pos visited update state it stack' mem visited' a state' hn ht ih =>
     rw [captureNextAux_anchor_pos mem hn ht]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | anchor_neg visited update state it eq stack' mem visited' a state' hn ht ih =>
+  | anchor_neg visited update state it stack' mem visited' a state' hn ht ih =>
     rw [captureNextAux_anchor_neg mem hn ht]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | char_pos visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+  | char_pos visited update state it stack' mem visited' c state' hn hnext hc ih =>
     rw [captureNextAux_char_pos mem hn hnext hc]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | char_neg visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+  | char_neg visited update state it stack' mem visited' c state' hn hnext hc ih =>
     rw [captureNextAux_char_neg mem hn hnext hc]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | char_end visited update state it eq stack' mem visited' c state' hn hnext ih =>
+  | char_end visited update state it stack' mem visited' c state' hn hnext ih =>
     rw [captureNextAux_char_end mem hn hnext]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | sparse_pos visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+  | sparse_pos visited update state it stack' mem visited' cs state' hn hnext hc ih =>
     rw [captureNextAux_sparse_pos mem hn hnext hc]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | sparse_neg visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+  | sparse_neg visited update state it stack' mem visited' cs state' hn hnext hc ih =>
     rw [captureNextAux_sparse_neg mem hn hnext hc]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
-  | sparse_end visited update state it eq stack' mem visited' cs state' hn hnext ih =>
+  | sparse_end visited update state it stack' mem visited' cs state' hn hnext ih =>
     rw [captureNextAux_sparse_end mem hn hnext]
     exact ih (by simp [visited', BitMatrix.get_set, hmem])
 
 theorem mem_of_mem_top_stack {entry stack'} (hstack : entry :: stack' = stack) :
-  (captureNextAux σ nfa wf startIdx maxIdx visited stack).2.get entry.state (entry.it.index' entry.eq) := by
+  (captureNextAux σ nfa wf startIdx maxIdx visited stack).2.get entry.state entry.it.index := by
   induction visited, stack using captureNextAux.induct' σ nfa wf startIdx maxIdx with
   | base visited => simp at hstack
-  | visited visited update state it eq stack' mem ih =>
+  | visited visited update state it stack' mem ih =>
     simp [captureNextAux_visited mem]
     simp at hstack
     exact mem_of_mem_visited (by simp [hstack, mem])
-  | done visited update state it eq stack' mem hn =>
+  | done visited update state it stack' mem hn =>
     simp [captureNextAux_done mem hn]
     simp at hstack
     simp [hstack, BitMatrix.get_set]
-  | fail visited update state it eq stack' mem hn =>
+  | fail visited update state it stack' mem hn =>
     simp [captureNextAux_fail mem hn]
     simp at hstack
     simp [hstack, BitMatrix.get_set]
-  | epsilon visited update state it eq stack'' mem visited' state' hn ih =>
+  | epsilon visited update state it stack'' mem visited' state' hn ih =>
     rw [captureNextAux_epsilon mem hn]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | split visited update state it eq stack'' mem visited' state₁ state₂ hn ih =>
+  | split visited update state it stack'' mem visited' state₁ state₂ hn ih =>
     rw [captureNextAux_split mem hn]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | save visited update state it eq stack' mem visited' offset state' hn update' ih =>
+  | save visited update state it stack' mem visited' offset state' hn update' ih =>
     rw [captureNextAux_save mem hn]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | anchor_pos visited update state it eq stack' mem visited' a state' hn ht ih =>
+  | anchor_pos visited update state it stack' mem visited' a state' hn ht ih =>
     rw [captureNextAux_anchor_pos mem hn ht]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | anchor_neg visited update state it eq stack' mem visited' a state' hn ht ih =>
+  | anchor_neg visited update state it stack' mem visited' a state' hn ht ih =>
     rw [captureNextAux_anchor_neg mem hn ht]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | char_pos visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+  | char_pos visited update state it stack' mem visited' c state' hn hnext hc ih =>
     rw [captureNextAux_char_pos mem hn hnext hc]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | char_neg visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+  | char_neg visited update state it stack' mem visited' c state' hn hnext hc ih =>
     rw [captureNextAux_char_neg mem hn hnext hc]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | char_end visited update state it eq stack' mem visited' c state' hn hnext ih =>
+  | char_end visited update state it stack' mem visited' c state' hn hnext ih =>
     rw [captureNextAux_char_end mem hn hnext]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | sparse_pos visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+  | sparse_pos visited update state it stack' mem visited' cs state' hn hnext hc ih =>
     rw [captureNextAux_sparse_pos mem hn hnext hc]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | sparse_neg visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+  | sparse_neg visited update state it stack' mem visited' cs state' hn hnext hc ih =>
     rw [captureNextAux_sparse_neg mem hn hnext hc]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
-  | sparse_end visited update state it eq stack' mem visited' cs state' hn hnext ih =>
+  | sparse_end visited update state it stack' mem visited' cs state' hn hnext ih =>
     rw [captureNextAux_sparse_end mem hn hnext]
     simp at hstack
     exact mem_of_mem_visited (by simp [BitMatrix.get_set, hstack, mem])
@@ -147,96 +147,96 @@ theorem path_done_of_some {it₀} (hres : captureNextAux HistoryStrategy nfa wf 
   ∃ state it', nfa[state] = .done ∧ Path nfa wf it₀ it' state update' := by
   induction visited, stack using captureNextAux.induct' HistoryStrategy nfa wf startIdx with
   | base visited => simp [captureNextAux_base] at hres
-  | visited visited update state it eq stack' mem ih =>
+  | visited visited update state it stack' mem ih =>
     simp [captureNextAux_visited mem] at hres
     have inv' : UpperInv wf it₀ stack' := by
       have reachable entry (mem : entry ∈ stack') : Path nfa wf it₀ entry.it.it entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | done visited update state it eq stack' mem hn =>
+  | done visited update state it stack' mem hn =>
     simp [captureNextAux_done mem hn] at hres
-    have path := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+    have path := inv.reachable ⟨update, state, it⟩ (by simp)
     exact ⟨state, it.it, hn, hres.1 ▸ path⟩
-  | fail visited update state it eq stack' mem hn => simp [captureNextAux_fail mem hn] at hres
-  | epsilon visited update state it eq stack' mem visited' state' hn ih =>
+  | fail visited update state it stack' mem hn => simp [captureNextAux_fail mem hn] at hres
+  | epsilon visited update state it stack' mem visited' state' hn ih =>
     rw [captureNextAux_epsilon mem hn] at hres
-    have inv' : UpperInv wf it₀ (⟨update, state', it, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update, state', it, eq⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
+    have inv' : UpperInv wf it₀ (⟨update, state', it⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
           simp [eq']
-          have path := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          have path := inv.reachable ⟨update, state, it⟩ (by simp)
           simp at path
           exact path.more (.epsilon (Nat.zero_le _) state.isLt hn path.validR) (by simp)
         | inr mem => exact inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | split visited update state it eq stack' mem visited' state₁ state₂ hn ih =>
+  | split visited update state it stack' mem visited' state₁ state₂ hn ih =>
     rw [captureNextAux_split mem hn] at hres
-    let stack'' := ⟨update, state₁, it, eq⟩ :: ⟨update, state₂, it, eq⟩ :: stack'
+    let stack'' := ⟨update, state₁, it⟩ :: ⟨update, state₂, it⟩ :: stack'
     have inv' : UpperInv wf it₀ stack'' := by
       have reachable entry (mem : entry ∈ stack'') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
         simp [stack''] at mem
         match mem with
         | .inl eq₁ =>
           simp [eq₁]
-          have path := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          have path := inv.reachable ⟨update, state, it⟩ (by simp)
           simp at path
           exact path.more (.splitLeft (Nat.zero_le _) state.isLt hn path.validR) (by simp)
         | .inr (.inl eq₂) =>
           simp [eq₂]
-          have path := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          have path := inv.reachable ⟨update, state, it⟩ (by simp)
           simp at path
           exact path.more (.splitRight (Nat.zero_le _) state.isLt hn path.validR) (by simp)
         | .inr (.inr mem) => exact inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | save visited update state it eq stack' mem visited' offset state' hn update' ih =>
+  | save visited update state it stack' mem visited' offset state' hn update' ih =>
     rw [captureNextAux_save mem hn] at hres
-    have inv' : UpperInv wf it₀ (⟨update', state', it, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update', state', it, eq⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
+    have inv' : UpperInv wf it₀ (⟨update', state', it⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update', state', it⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
           simp [eq']
-          have path := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          have path := inv.reachable ⟨update, state, it⟩ (by simp)
           simp at path
           exact path.more (.save (Nat.zero_le _) state.isLt hn path.validR) (by simp [update', HistoryStrategy, BoundedIterator.pos])
         | inr mem => exact inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | anchor_pos visited update state it eq stack' mem visited' a state' hn ht ih =>
+  | anchor_pos visited update state it stack' mem visited' a state' hn ht ih =>
     rw [captureNextAux_anchor_pos mem hn ht] at hres
-    have inv' : UpperInv wf it₀ (⟨update, state', it, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update, state', it, eq⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
+    have inv' : UpperInv wf it₀ (⟨update, state', it⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
           simp [eq']
-          have path := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          have path := inv.reachable ⟨update, state, it⟩ (by simp)
           simp at path
           exact path.more (.anchor (Nat.zero_le _) state.isLt hn path.validR ht) (by simp)
         | inr mem => exact inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | anchor_neg visited update state it eq stack' mem visited' a state' hn ht ih =>
+  | anchor_neg visited update state it stack' mem visited' a state' hn ht ih =>
     rw [captureNextAux_anchor_neg mem hn ht] at hres
     have inv' : UpperInv wf it₀ stack' := by
       have reachable entry (mem : entry ∈ stack') : Path nfa wf it₀ entry.it.it entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | char_pos visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+  | char_pos visited update state it stack' mem visited' c state' hn hnext hc ih =>
     rw [captureNextAux_char_pos mem hn hnext hc] at hres
-    have inv' : UpperInv wf it₀ (⟨update, state', it.next hnext, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext, eq⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
+    have inv' : UpperInv wf it₀ (⟨update, state', it.next hnext⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
           simp [eq']
-          have path := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          have path := inv.reachable ⟨update, state, it⟩ (by simp)
           simp at path
           have v : it.Valid := it.valid_of_it_valid path.validR
           have ⟨l, r, vf⟩ := v.validFor_of_hasNext hnext
@@ -244,29 +244,29 @@ theorem path_done_of_some {it₀} (hres : captureNextAux HistoryStrategy nfa wf 
         | inr mem => exact inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | char_neg visited update state it eq stack' mem visited' c state' hn hnext hc ih =>
+  | char_neg visited update state it stack' mem visited' c state' hn hnext hc ih =>
     rw [captureNextAux_char_neg mem hn hnext hc] at hres
     have inv' : UpperInv wf it₀ stack' := by
       have reachable entry (mem : entry ∈ stack') : Path nfa wf it₀ entry.it.it entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | char_end visited update state it eq stack' mem visited' c state' hn hnext ih =>
+  | char_end visited update state it stack' mem visited' c state' hn hnext ih =>
     rw [captureNextAux_char_end mem hn hnext] at hres
     have inv' : UpperInv wf it₀ stack' := by
       have reachable entry (mem : entry ∈ stack') : Path nfa wf it₀ entry.it.it entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | sparse_pos visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+  | sparse_pos visited update state it stack' mem visited' cs state' hn hnext hc ih =>
     rw [captureNextAux_sparse_pos mem hn hnext hc] at hres
-    have inv' : UpperInv wf it₀ (⟨update, state', it.next hnext, eq⟩ :: stack') := by
-      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext, eq⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
+    have inv' : UpperInv wf it₀ (⟨update, state', it.next hnext⟩ :: stack') := by
+      have reachable entry (mem : entry ∈ ⟨update, state', it.next hnext⟩ :: stack') : Path nfa wf it₀ entry.it.it entry.state entry.update := by
         simp at mem
         cases mem with
         | inl eq' =>
           simp [eq']
-          have path := inv.reachable ⟨update, state, it, eq⟩ (by simp)
+          have path := inv.reachable ⟨update, state, it⟩ (by simp)
           simp at path
           have v : it.Valid := it.valid_of_it_valid path.validR
           have ⟨l, r, vf⟩ := v.validFor_of_hasNext hnext
@@ -274,14 +274,14 @@ theorem path_done_of_some {it₀} (hres : captureNextAux HistoryStrategy nfa wf 
         | inr mem => exact inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | sparse_neg visited update state it eq stack' mem visited' cs state' hn hnext hc ih =>
+  | sparse_neg visited update state it stack' mem visited' cs state' hn hnext hc ih =>
     rw [captureNextAux_sparse_neg mem hn hnext hc] at hres
     have inv' : UpperInv wf it₀ stack' := by
       have reachable entry (mem : entry ∈ stack') : Path nfa wf it₀ entry.it.it entry.state entry.update :=
         inv.reachable entry (by simp [mem])
       exact ⟨reachable⟩
     exact ih hres inv'
-  | sparse_end visited update state it eq stack' mem visited' cs state' hn hnext ih =>
+  | sparse_end visited update state it stack' mem visited' cs state' hn hnext ih =>
     rw [captureNextAux_sparse_end mem hn hnext] at hres
     have inv' : UpperInv wf it₀ stack' := by
       have reachable entry (mem : entry ∈ stack') : Path nfa wf it₀ entry.it.it entry.state entry.update :=

--- a/correctness/RegexCorrectness/Backtracker/Traversal.lean
+++ b/correctness/RegexCorrectness/Backtracker/Traversal.lean
@@ -5,8 +5,8 @@ import RegexCorrectness.Backtracker.Path
 
 set_option autoImplicit false
 
-open Regex.Data (BoundedIterator)
-open String (Iterator)
+open Regex.Data (BitMatrix BoundedIterator)
+open String (Pos Iterator)
 
 namespace Regex.Backtracker.captureNextAux
 

--- a/correctness/RegexCorrectness/Data/BoundedIterator.lean
+++ b/correctness/RegexCorrectness/Data/BoundedIterator.lean
@@ -7,43 +7,45 @@ open String (Iterator)
 
 namespace Regex.Data.BoundedIterator
 
-theorem valid_of_it_valid {startIdx} (bit : BoundedIterator startIdx) (v : bit.it.Valid) : bit.Valid := v.isValid
+variable {startIdx maxIdx : Nat}
 
-theorem valid_of_valid {startIdx} (bit : BoundedIterator startIdx) (v : bit.Valid) : bit.it.Valid := Iterator.Valid.of_isValid v
+theorem valid_of_it_valid {bit : BoundedIterator startIdx maxIdx} (v : bit.it.Valid) : bit.Valid := v.isValid
 
-theorem next_valid {startIdx} (bit : BoundedIterator startIdx) (h : bit.hasNext) (v : bit.Valid) : (bit.next h).Valid := by
+theorem valid_of_valid {bit : BoundedIterator startIdx maxIdx} (v : bit.Valid) : bit.it.Valid := Iterator.Valid.of_isValid v
+
+theorem next_valid {bit : BoundedIterator startIdx maxIdx} (h : bit.hasNext) (v : bit.Valid) : (bit.next h).Valid := by
   apply valid_of_it_valid
   simp [next, String.Iterator.next'_eq_next]
   exact (bit.valid_of_valid v).next h
 
-def ValidFor {startIdx} (l r : List Char) (bit : BoundedIterator startIdx) : Prop := bit.it.ValidFor l r
+def ValidFor (l r : List Char) (bit : BoundedIterator startIdx maxIdx) : Prop := bit.it.ValidFor l r
 
 namespace ValidFor
 
-theorem hasNext {startIdx l r} {bit : BoundedIterator startIdx} (vf : ValidFor l r bit) : bit.hasNext ↔ r ≠ [] := by
+theorem hasNext {l r} {bit : BoundedIterator startIdx maxIdx} (vf : ValidFor l r bit) : bit.hasNext ↔ r ≠ [] := by
   unfold ValidFor at vf
   exact vf.hasNext
 
-theorem next {startIdx l c r} {bit : BoundedIterator startIdx} (vf : ValidFor l (c :: r) bit) : ValidFor (c :: l) r (bit.next (by simp [vf.hasNext])) := by
+theorem next {l c r} {bit : BoundedIterator startIdx maxIdx} (vf : ValidFor l (c :: r) bit) : ValidFor (c :: l) r (bit.next (by simp [vf.hasNext])) := by
   unfold ValidFor at vf
   exact vf.next
 
-theorem next' {startIdx l r} {bit : BoundedIterator startIdx} (h : bit.hasNext) (vf : ValidFor l r bit) : ∃ c r', ValidFor (c :: l) r' (bit.next h) := by
+theorem next' {l r} {bit : BoundedIterator startIdx maxIdx} (h : bit.hasNext) (vf : ValidFor l r bit) : ∃ c r', ValidFor (c :: l) r' (bit.next h) := by
   match r with
   | [] => simp [vf.hasNext] at h
   | c :: r' => exact ⟨c, r', vf.next⟩
 
-theorem curr {startIdx l c r} {bit : BoundedIterator startIdx} (vf : ValidFor l (c :: r) bit) : bit.curr (by simp [vf.hasNext]) = c := by
+theorem curr {l c r} {bit : BoundedIterator startIdx maxIdx} (vf : ValidFor l (c :: r) bit) : bit.curr (by simp [vf.hasNext]) = c := by
   simp [BoundedIterator.curr, bit.it.curr'_eq_curr, String.Iterator.ValidFor.curr vf]
 
 end ValidFor
 
 namespace Valid
 
-theorem validFor {startIdx} {bit : BoundedIterator startIdx} (v : bit.Valid) : ∃ l r, ValidFor l r bit :=
+theorem validFor {bit : BoundedIterator startIdx maxIdx} (v : bit.Valid) : ∃ l r, ValidFor l r bit :=
   (bit.valid_of_valid v).validFor
 
-theorem validFor_of_hasNext {startIdx} {bit : BoundedIterator startIdx} (h : bit.hasNext) (v : bit.Valid) :
+theorem validFor_of_hasNext {bit : BoundedIterator startIdx maxIdx} (h : bit.hasNext) (v : bit.Valid) :
   ∃ l r, ValidFor l (bit.curr h :: r) bit := by
   have ⟨l, r, vf⟩ := validFor v
   match h' : r with

--- a/regex/Regex/Backtracker/Basic.lean
+++ b/regex/Regex/Backtracker/Basic.lean
@@ -1,10 +1,10 @@
+import Regex.Data.BitMatrix
 import Regex.Data.BoundedIterator
 import Regex.NFA
 import Regex.Strategy
-import Regex.Backtracker.BitMatrix
 
 open String (Iterator Pos)
-open Regex.Data (BoundedIterator)
+open Regex.Data (BitMatrix BoundedIterator)
 
 set_option autoImplicit false
 

--- a/regex/Regex/Backtracker/Basic.lean
+++ b/regex/Regex/Backtracker/Basic.lean
@@ -13,45 +13,44 @@ namespace Regex.Backtracker
 structure StackEntry (σ : Strategy) (nfa : NFA) (startIdx maxIdx : Nat) where
   update : σ.Update
   state : Fin nfa.nodes.size
-  it : BoundedIterator startIdx
-  eq : it.maxIdx = maxIdx
+  it : BoundedIterator startIdx maxIdx
 
 def captureNextAux (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (startIdx maxIdx : Nat)
   (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) (stack : List (StackEntry σ nfa startIdx maxIdx)) :
   (Option σ.Update × BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) :=
   match stack with
   | [] => (.none, visited)
-  | ⟨update, state, it, eq⟩ :: stack' =>
-    if h : visited.get state (it.index' eq) then
+  | ⟨update, state, it⟩ :: stack' =>
+    if h : visited.get state it.index then
       captureNextAux σ nfa wf startIdx maxIdx visited stack'
     else
-      let visited' := visited.set state (it.index' eq)
+      let visited' := visited.set state it.index
       have : nfa.nodes.size * (maxIdx + 1 - startIdx) + 1 - visited'.popcount < nfa.nodes.size * (maxIdx + 1 - startIdx) + 1 - visited.popcount :=
-        BitMatrix.popcount_decreasing visited state (it.index' eq) h
+        BitMatrix.popcount_decreasing visited state it.index h
       match hn : nfa[state] with
       | .done => (.some update, visited')
       | .fail => (.none, visited')
       | .epsilon state' =>
         have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
-        captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it, eq⟩ :: stack')
+        captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it⟩ :: stack')
       | .split state₁ state₂ =>
         have isLt : state₁ < nfa.nodes.size ∧ state₂ < nfa.nodes.size := wf.inBounds' state hn
-        captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state₁, isLt.1⟩, it, eq⟩ :: ⟨update, ⟨state₂, isLt.2⟩, it, eq⟩ :: stack')
+        captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state₁, isLt.1⟩, it⟩ :: ⟨update, ⟨state₂, isLt.2⟩, it⟩ :: stack')
       | .save offset state' =>
         have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
         let update' := σ.write update offset it.pos
-        captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update', ⟨state', isLt⟩, it, eq⟩ :: stack')
+        captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update', ⟨state', isLt⟩, it⟩ :: stack')
       | .anchor a state' =>
         have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
         if a.test it.it then
-          captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it, eq⟩ :: stack')
+          captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it⟩ :: stack')
         else
           captureNextAux σ nfa wf startIdx maxIdx visited' stack'
       | .char c state' =>
         have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
         if h : it.hasNext then
           if it.curr h = c then
-            captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it.next h, eq ▸ it.next_maxIdx h⟩ :: stack')
+            captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it.next h⟩ :: stack')
           else
             captureNextAux σ nfa wf startIdx maxIdx visited' stack'
         else
@@ -60,7 +59,7 @@ def captureNextAux (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (startIdx m
         have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
         if h : it.hasNext then
           if it.curr h ∈ cs then
-            captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it.next h, eq ▸ it.next_maxIdx h⟩ :: stack')
+            captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it.next h⟩ :: stack')
           else
             captureNextAux σ nfa wf startIdx maxIdx visited' stack'
         else
@@ -69,20 +68,21 @@ termination_by (nfa.nodes.size * (maxIdx + 1 - startIdx) + 1 - visited.popcount,
 
 def captureNext (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator) : Option σ.Update :=
   let startIdx := it.pos.byteIdx
+  let maxIdx := it.toString.endPos.byteIdx
   if le : it.pos ≤ it.toString.endPos then
-    let bit : BoundedIterator startIdx := ⟨it, Nat.le_refl _, le⟩
-    (go startIdx bit (BitMatrix.zero _ _)).1
+    let bit : BoundedIterator startIdx maxIdx := ⟨it, Nat.le_refl _, le, rfl⟩
+    (go startIdx maxIdx bit (BitMatrix.zero _ _)).1
   else
     .none
 where
-  go (startIdx : Nat) (bit : BoundedIterator startIdx) (visited : BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx)) :
-  Option σ.Update × BitMatrix nfa.nodes.size (bit.maxIdx + 1 - startIdx) :=
-  match captureNextAux σ nfa wf startIdx bit.maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit, rfl⟩] with
+  go (startIdx maxIdx : Nat) (bit : BoundedIterator startIdx maxIdx) (visited : BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx)) :
+  Option σ.Update × BitMatrix nfa.nodes.size (maxIdx + 1 - startIdx) :=
+  match captureNextAux σ nfa wf startIdx maxIdx visited [⟨σ.empty, ⟨nfa.start, wf.start_lt⟩, bit⟩] with
   | (.some update, visited') => (.some update, visited')
   | (.none, visited') =>
     if h : bit.hasNext then
       have : (bit.next h).remainingBytes < bit.remainingBytes := bit.next_remainingBytes_lt h
-      go startIdx (bit.next h) visited'
+      go startIdx maxIdx (bit.next h) visited'
     else
       (.none, visited')
   termination_by bit.remainingBytes

--- a/regex/Regex/Backtracker/Basic.lean
+++ b/regex/Regex/Backtracker/Basic.lean
@@ -29,7 +29,7 @@ def captureNextAux (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (startIdx m
         BitMatrix.popcount_decreasing visited state it.index h
       match hn : nfa[state] with
       | .done => (.some update, visited')
-      | .fail => (.none, visited')
+      | .fail => captureNextAux σ nfa wf startIdx maxIdx visited' stack'
       | .epsilon state' =>
         have isLt : state' < nfa.nodes.size := wf.inBounds' state hn
         captureNextAux σ nfa wf startIdx maxIdx visited' (⟨update, ⟨state', isLt⟩, it⟩ :: stack')

--- a/regex/Regex/Data/BitMatrix.lean
+++ b/regex/Regex/Data/BitMatrix.lean
@@ -1,12 +1,16 @@
 import Regex.Data.BitVec
 
-namespace Regex.Backtracker
+set_option autoImplicit false
+
+namespace Regex.Data
 
 structure BitMatrix (w h : Nat) where
   bv : BitVec (w * h)
 deriving Repr
 
 namespace BitMatrix
+
+variable {w h : Nat}
 
 instance : ToString (BitMatrix w h) := ⟨fun m => toString m.bv⟩
 
@@ -74,6 +78,9 @@ theorem get_set {m : BitMatrix w h} (x x' : Fin w) (y y' : Fin h) : (m.set x y).
   else
     simp [h, get_set_ne x x' y y' (by omega)]
 
+theorem get_set_of_get {m : BitMatrix w h} {x x' : Fin w} {y y' : Fin h} (h : m.get x y) : (m.set x' y').get x y := by
+  simp [get_set, h]
+
 def popcount (m : BitMatrix w h) : Nat := m.bv.popcount
 
 theorem popcount_le {m : BitMatrix w h} : popcount m ≤ w * h := BitVec.popcount_le m.bv
@@ -83,4 +90,4 @@ theorem popcount_decreasing (m : BitMatrix w h) (x : Fin w) (y : Fin h) (hget : 
 
 end BitMatrix
 
-end Regex.Backtracker
+end Regex.Data


### PR DESCRIPTION
Previous proof didn't catch this issue as the bug reports less `.some` from the backtracker, but the proof mentions only the case the result is `.some`.

The bug was found during the completeness proof, and the PR includes some reorganization along with it.