### PR TITLE
Refactor εClosure

### DIFF
--- a/correctness/RegexCorrectness/Backtracker/Traversal/Invariants.lean
+++ b/correctness/RegexCorrectness/Backtracker/Traversal/Invariants.lean
@@ -44,23 +44,6 @@ theorem mem_stack_top (entry stack') (hstack : entry :: stack' = stack) :
 
 end
 
-/-
-Here, we consider a minimal invariant enough to prove the "soundness" of the backtracker; a capture group found by the backtracker indeed corresponds to a match by the regex.
-Therefore, we are only concenred about that the states in the stack are reachable from the start node starting from a particular position.
-
-NOTE: if we want to show that the backtracker is complete (i.e., if the regex matches a string, then the backtracker will find a capture group), we need new invariants
-about the visited set so that we can reason about the case the backtracker returns `.none`.
-
-Current candidates are:
-
-1. Closure under transition: ∀ (state, pos) ∈ visited, nfa.Step 0 state pos state' pos' → (state', pos') ∈ visited ∨ ∃ entry ∈ stack, entry.state = state' ∧ entry.it.poss = pos'
-  * At the end of the traversal, we can use this invariant to show that the visited set is a reflexive-transitive closure of the step relation.
-2. Upper bound of the visited set: ∀ (state, pos) ∈ visited, (state, pos) ∈ visisted₀ ∨ ∃ it, Path nfa wf it₀ it state update
-  * We'll strengthen `UpperInv` to give an upper bound of the visited set.
-  * Combined with the closure property, we can show that the traversal adds just the states reachable from the starting node at a particular position.
-3. The visited set doesn't contain the `.done` state.
-  * This implies that if the traversal returns `.none`, then there is no match starting from the particular position.
--/
 section
 
 variable {nfa : NFA} {wf : nfa.WellFormed} {startIdx maxIdx : Nat}

--- a/correctness/RegexCorrectness/Strategy/Refinement.lean
+++ b/correctness/RegexCorrectness/Strategy/Refinement.lean
@@ -45,4 +45,14 @@ theorem refineUpdateOpt.orElse {update₁ update₂ : Option (List (Nat × Pos))
 def refineUpdates (updates : Vector (List (Nat × Pos)) nfa.nodes.size) (buffers : Vector (Buffer bufferSize) nfa.nodes.size) : Prop :=
   ∀ (i : Fin nfa.nodes.size), refineUpdate updates[i] buffers[i]
 
+theorem refineUpdates.set_set {updates : Vector (List (Nat × Pos)) nfa.nodes.size} {buffers : Vector (Buffer bufferSize) nfa.nodes.size}
+  {i : Fin nfa.nodes.size} {update : List (Nat × Pos)} {buffer : Buffer bufferSize}
+  (h₁ : refineUpdates updates buffers) (h₂ : refineUpdate update buffer) :
+  refineUpdates (updates.set i update) (buffers.set i buffer) := by
+  intro j
+  if h : i.val = j.val then
+    simpa [h] using h₂
+  else
+    simpa [h] using h₁ j
+
 end Regex.Strategy

--- a/correctness/RegexCorrectness/VM/CharStep/Lemmas.lean
+++ b/correctness/RegexCorrectness/VM/CharStep/Lemmas.lean
@@ -94,12 +94,12 @@ theorem mem_next_of_stepChar {i j k update}
     rw [CharStep.char hn] at step
     have ⟨l, r, eqj, vf⟩ := step
     simp [vf.curr] at h
-    exact mem_next_of_εClosure h lb (by simpa [←eqj] using cls)
+    exact εClosure.mem_next h lb (by simpa [←eqj] using cls)
   next cs j' hn =>
     rw [CharStep.sparse hn] at step
     have ⟨l, c, r, eqj, vf, hc⟩ := step
     simp [vf.curr, hc] at h
-    exact mem_next_of_εClosure h lb (by simpa [←eqj] using cls)
+    exact εClosure.mem_next h lb (by simpa [←eqj] using cls)
   next ne₁ ne₂ =>
     have := step.char_or_sparse
     simp_all
@@ -110,7 +110,7 @@ theorem stepChar.write_updates_of_mem_next {i k}
   k ∈ next.states ∨ ∃ j update',
     nfa.CharStep it i j ∧
     nfa.εClosure' it.next j k update' ∧
-    (WriteUpdate k → next'.updates[k] = currentUpdates.get i ++ update') := by
+    (εClosure.writeUpdate nfa[k] → next'.updates[k] = currentUpdates.get i ++ update') := by
   simp [stepChar] at h
   split at h
   next c j hn =>
@@ -200,8 +200,7 @@ theorem eachStepChar.inv_of_stepChar {idx} (hlt : idx < current.states.count)
     have equ := stepChar.eq_updates_of_mem_next h mem
     exact equ ▸ inv
   | .inr ⟨j, update', step, cls, write'⟩ =>
-    simp [step.write_update] at write
-    have write'' : WriteUpdate k → next'.updates[k] = update ++ update' := write ▸ write'
+    have write'' : εClosure.writeUpdate nfa[k] → next'.updates[k] = update ++ update' := (write step.write_update) ▸ write'
     exact ⟨update ++ update', .more path step cls, write''⟩
 
 theorem eachStepChar.go.inv {idx hle} (h : eachStepChar.go HistoryStrategy nfa wf it current idx hle next = (matched', next'))

--- a/correctness/RegexCorrectness/VM/Path/EpsilonClosure.lean
+++ b/correctness/RegexCorrectness/VM/Path/EpsilonClosure.lean
@@ -15,47 +15,35 @@ section
 
 variable {nfa : NFA} {it i j update}
 
-@[simp]
 theorem εStep'.done (hn : nfa[i] = .done) :
   nfa.εStep' it i j update ↔ False := by
   apply Step.iff_done hn
 
-@[simp]
 theorem εStep'.fail (hn : nfa[i] = .fail) :
   nfa.εStep' it i j update ↔ False := by
   apply Step.iff_fail hn
 
-@[simp]
-theorem εStep'.epsilon {next} (hn : nfa[i] = .epsilon next) :
+theorem εStep'.epsilon {next : Nat} (hn : nfa[i] = .epsilon next) :
   nfa.εStep' it i j update ↔ j = next ∧ update = .none ∧ it.Valid := by
   simp [εStep', Step.iff_epsilon hn]
-  omega
 
-@[simp]
-theorem εStep'.anchor {anchor next} (hn : nfa[i] = .anchor anchor next) :
+theorem εStep'.anchor {anchor} {next : Nat} (hn : nfa[i] = .anchor anchor next) :
   nfa.εStep' it i j update ↔ j = next ∧ update = .none ∧ it.Valid ∧ anchor.test it := by
   simp [εStep', Step.iff_anchor hn]
-  omega
 
-@[simp]
-theorem εStep'.split {next₁ next₂} (hn : nfa[i] = .split next₁ next₂) :
+theorem εStep'.split {next₁ next₂ : Nat} (hn : nfa[i] = .split next₁ next₂) :
   nfa.εStep' it i j update ↔ (j = next₁ ∨ j = next₂) ∧ update = .none ∧ it.Valid := by
   simp [εStep', Step.iff_split hn]
-  omega
 
-@[simp]
-theorem εStep'.save {offset next} (hn : nfa[i] = .save offset next) :
+theorem εStep'.save {offset} {next : Nat} (hn : nfa[i] = .save offset next) :
   nfa.εStep' it i j update ↔ j = next ∧ update = .some (offset, it.pos) ∧ it.Valid := by
   simp [εStep', Step.iff_save hn]
-  omega
 
-@[simp]
-theorem εStep'.char {c next} (hn : nfa[i] = .char c next) :
+theorem εStep'.char {c} {next : Nat} (hn : nfa[i] = .char c next) :
   nfa.εStep' it i j update ↔ False := by
   simp [εStep', Step.iff_char hn]
 
-@[simp]
-theorem εStep'.sparse {cs next} (hn : nfa[i] = .sparse cs next) :
+theorem εStep'.sparse {cs} {next : Nat} (hn : nfa[i] = .sparse cs next) :
   nfa.εStep' it i j update ↔ False := by
   simp [εStep', Step.iff_sparse hn]
 

--- a/correctness/RegexCorrectness/VM/Search/Lemmas.lean
+++ b/correctness/RegexCorrectness/VM/Search/Lemmas.lean
@@ -35,7 +35,7 @@ theorem captureNext.go.inv {nfa wf it₀ it matched current next matched'}
       intro isSome''
       have ⟨state', mem', hn, hupdate⟩ := eachStepChar.done_of_matched_some h₂ isSome''
       have ⟨update, path, write⟩ := next'_inv state' mem'
-      simp [WriteUpdate, hn] at write
+      simp [εClosure.writeUpdate, hn] at write
       simp at hupdate
       simp [←write, hupdate] at path
       exact ⟨state', it.next, by rw [it.next_toString, string_eq], hn, path⟩
@@ -50,7 +50,7 @@ theorem captureNext.go.inv {nfa wf it₀ it matched current next matched'}
         simp
         have ⟨state', mem', hn, hupdate⟩ := eachStepChar.done_of_matched_some h' (by simp)
         have ⟨update, path, write⟩ := next'_inv state' mem'
-        simp [WriteUpdate, hn] at write
+        simp [εClosure.writeUpdate, hn] at write
         simp at hupdate
         simp [←write, hupdate] at path
         intro _
@@ -78,7 +78,7 @@ theorem captureNext.path_done_of_matched {nfa wf it₀ matched'}
     intro isSome
     have ⟨state, mem, hn, hupdate⟩ := εClosure.matched_inv h' (by simp) isSome
     have ⟨update, path, write⟩ := curr_inv state mem
-    simp [WriteUpdate, hn, hupdate] at write
+    simp [εClosure.writeUpdate, hn, hupdate] at write
     exact ⟨state, it₀, rfl, hn, write ▸ path⟩
 
   exact captureNext.go.inv h v rfl curr_inv (by simp) matched_inv isSome'

--- a/regex/Regex/VM/Basic.lean
+++ b/regex/Regex/VM/Basic.lean
@@ -22,6 +22,9 @@ abbrev εStack (σ : Strategy) (nfa : NFA) := List (σ.Update × Fin nfa.nodes.s
 
 namespace εClosure
 
+/--
+As an optimization, we write the updates to the buffer only when the state is done, a character, or a sparse state.
+-/
 @[inline]
 def writeUpdate (node : NFA.Node) : Bool :=
   match node with
@@ -66,11 +69,7 @@ def εClosure (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
         let node := nfa[state]
         let matched' := if node = .done then matched <|> update else matched
         let states' := states.insert state
-        let updates' :=
-          if εClosure.writeUpdate node then
-            updates.set state update
-          else
-            updates
+        let updates' := if εClosure.writeUpdate node then updates.set state update else updates
         let stack'' := εClosure.pushNext σ nfa it node (wf.inBounds state) update stack'
         εClosure σ nfa wf it matched' ⟨states', updates'⟩ stack''
 termination_by (next.states.measure, stack)


### PR DESCRIPTION
This PR applies the same decoupling technique as the backtracker to the `εClosure` function of NFA simulation. The idea is to separate the state updates from the recursion structure and update each state independently. In particular, the stack management is factored out as `pushNext`, which helps confine the branching on the NFA nodes.