### PR TITLE
Move epsilon expansion after eachStepChar

### DIFF
--- a/correctness/RegexCorrectness/Data/String.lean
+++ b/correctness/RegexCorrectness/Data/String.lean
@@ -177,7 +177,46 @@ theorem exists_cons_of_not_atEnd {l r} {it : Iterator} (v : it.ValidFor l r) (h 
   subst this
   exact ⟨r', rfl⟩
 
+theorem pos_atEnd {l} {it : Iterator} (v : it.ValidFor l []) : it.pos = it.toString.endPos := by
+  simp [v.out']
+
 end String.Iterator.ValidFor
+
+namespace String.Iterator
+
+theorem eq_of_valid_of_next_eq {it₁ it₂ : Iterator} (v₁ : it₁.Valid) (v₂ : it₂.Valid) (h : it₁.next = it₂.next) : it₁ = it₂ := by
+  have eqs₁₂ : it₁.toString = it₂.toString := by
+    have : it₁.next.toString = it₂.next.toString := by rw [h]
+    simpa [Iterator.next_toString] using this
+  have ⟨l₁, r₁, vf₁⟩ := v₁.validFor
+  have ⟨l₂, r₂, vf₂⟩ := v₂.validFor
+  match r₁, r₂ with
+  | [], [] =>
+    have eqs₁ : it₁.toString = ⟨l₁.reverse⟩ := vf₁.toString
+    have eqs₂ : it₂.toString = ⟨l₂.reverse⟩ := vf₂.toString
+    have eqs : l₁ = l₂ := by
+      rw [eqs₁, eqs₂] at eqs₁₂
+      simpa using eqs₁₂
+    exact vf₁.eq_it (eqs ▸ vf₂)
+  | c₁ :: r₁, c₂ :: r₂ =>
+    have vf₁' := vf₁.next
+    have vf₂' := vf₂.next
+    have eq := vf₁'.eq (h ▸ vf₂')
+    simp at eq
+    simp [eq] at vf₁
+    exact vf₁.eq_it vf₂
+  | [], c₂ :: r₂ =>
+    have pos₁ : it₁.pos = it₁.toString.endPos := vf₁.pos_atEnd
+    have pos₂ : it₂.next.pos ≤ it₂.toString.endPos := vf₂.next.valid.le_endPos
+    rw [←eqs₁₂, ←h, ←pos₁] at pos₂
+    exact ((Nat.not_le_of_lt it₁.lt_next) pos₂).elim
+  | c₁ :: r₁, [] =>
+    have pos₁ : it₁.next.pos ≤ it₁.toString.endPos := vf₁.next.valid.le_endPos
+    have pos₂ : it₂.pos = it₂.toString.endPos := vf₂.pos_atEnd
+    rw [eqs₁₂, h, ←pos₂] at pos₁
+    exact ((Nat.not_le_of_lt it₂.lt_next) pos₁).elim
+
+end String.Iterator
 
 namespace String.Pos
 

--- a/correctness/RegexCorrectness/Strategy/Refinement.lean
+++ b/correctness/RegexCorrectness/Strategy/Refinement.lean
@@ -27,8 +27,8 @@ theorem refineUpdateOpt.isSome_iff (h : refineUpdateOpt matched' matched) :
   | .some _, .some _ => simp
   | .none, .some _ | .some _, .none => simp [refineUpdateOpt] at h
 
-theorem refineUpdateOpt.isNone_iff (h : refineUpdateOpt matched' matched) :
-  matched'.isNone ↔ matched.isNone := by
+theorem refineUpdateOpt.none_iff (h : refineUpdateOpt matched' matched) :
+  (matched' = .none) ↔ (matched = .none) := by
   match matched', matched with
   | .none, .none => simp
   | .some _, .some _ => simp

--- a/correctness/RegexCorrectness/VM/CharStep/Lemmas.lean
+++ b/correctness/RegexCorrectness/VM/CharStep/Lemmas.lean
@@ -11,8 +11,6 @@ open String (Pos Iterator)
 
 namespace Regex.VM
 
-local instance : Strategy := HistoryStrategy
-
 variable {nfa : NFA} {wf : nfa.WellFormed} {it : Iterator}
   {current : SearchState HistoryStrategy nfa} {currentUpdates : Vector (List (Nat × Pos)) nfa.nodes.size}
   {next : SearchState HistoryStrategy nfa} {state : Fin nfa.nodes.size}

--- a/correctness/RegexCorrectness/VM/Path/VMPath.lean
+++ b/correctness/RegexCorrectness/VM/Path/VMPath.lean
@@ -57,6 +57,8 @@ end Regex.NFA
 namespace Regex.VM
 
 /--
+The invariant for the soundness theorem.
+
 All states in `next.state` have a corresponding path from `nfa.start` to the state ending at `it`,
 and their updates are written to `next.updates` when necessary.
 -/

--- a/correctness/RegexCorrectness/VM/Search/Basic.lean
+++ b/correctness/RegexCorrectness/VM/Search/Basic.lean
@@ -16,18 +16,24 @@ theorem captureNext.go.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed)
     it.atEnd →
     motive it matched current next)
   (found : ∀ it matched current next,
-    ¬it.atEnd → current.states.isEmpty → matched.isSome →
+    ¬it.atEnd →
+    current.states.isEmpty →
+    matched.isSome →
     motive it matched current next)
-  (ind_not_found : ∀ it matched current next _matched current' matched' next',
-    ¬it.atEnd → matched.isNone →
-    εClosure σ nfa wf it .none current [(σ.empty, ⟨nfa.start, wf.start_lt⟩)] = (_matched, current') →
-    eachStepChar σ nfa wf it current' next = (matched', next') →
-    motive it.next matched' next' ⟨current'.states.clear, current'.updates⟩ →
+  (ind_not_found : ∀ it matched current next,
+    let stepped := eachStepChar σ nfa wf it current next
+    let expanded := εClosure σ nfa wf it.next .none stepped.2 [(σ.empty, ⟨nfa.start, wf.start_lt⟩)]
+    ¬it.atEnd →
+    matched = .none →
+    stepped.1 = .none →
+    motive it.next expanded.1 expanded.2 ⟨current.states.clear, current.updates⟩ →
     motive it matched current next)
-  (ind_found : ∀ it matched current next matched' next',
-    ¬it.atEnd → ¬current.states.isEmpty → matched.isSome →
-    eachStepChar σ nfa wf it current next = (matched', next') →
-    motive it.next (matched' <|> matched) next' ⟨current.states.clear, current.updates⟩ →
+  (ind_found : ∀ it matched current next,
+    let stepped := eachStepChar σ nfa wf it current next
+    ¬it.atEnd →
+    (matched.isSome → ¬current.states.isEmpty) →
+    matched.isSome ∨ stepped.1.isSome →
+    motive it.next (stepped.1 <|> matched) stepped.2 ⟨current.states.clear, current.updates⟩ →
     motive it matched current next)
   (it : Iterator) (matched : Option σ.Update) (current next : SearchState σ nfa) :
   motive it matched current next :=
@@ -35,15 +41,22 @@ theorem captureNext.go.induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed)
     (fun it matched current next atEnd => not_found it matched current next atEnd)
     (fun it matched current next atEnd h =>
       found it matched current next atEnd (by simp at h; exact h.1) (by simp at h; exact h.2))
-    (fun it matched current next atEnd h isNone ih =>
-      let expanded := εClosure σ nfa wf it .none current [(σ.empty, ⟨nfa.start, wf.start_lt⟩)]
-      let stepped := eachStepChar σ nfa wf it expanded.2 next
-      ind_not_found it matched current next expanded.1 expanded.2 stepped.1 stepped.2
-        atEnd isNone rfl rfl ih)
-    (fun it matched current next atEnd h isSome ih =>
+    (fun it matched current next atEnd h₁ h₂ ih => by
       let stepped := eachStepChar σ nfa wf it current next
-      ind_found it matched current next stepped.1 stepped.2
-        atEnd (by simp at isSome; simp [isSome] at h; simp [h]) (by cases matched <;> simp at isSome; simp) rfl ih)
+      let expanded := εClosure σ nfa wf it .none stepped.2 [(σ.empty, ⟨nfa.start, wf.start_lt⟩)]
+      rw [Option.isNone_iff_eq_none, Option.orElse_eq_none] at h₂
+      exact ind_not_found it matched current next atEnd h₂.2 h₂.1 ih)
+    (fun it matched current next atEnd h₁ h₂ ih => by
+      let stepped := eachStepChar σ nfa wf it current next
+      rw [Bool.and_comm] at h₁
+      simp at h₁
+      have h₂' : matched.isSome ∨ stepped.1.isSome := by
+        match matched with
+        | .none =>
+          simp only [Option.orElse_none, Option.isNone_iff_eq_none, ←Option.not_isSome_iff_eq_none, Decidable.not_not] at h₂
+          exact .inr h₂
+        | .some _ => exact .inl (by simp)
+      exact ind_found it matched current next atEnd (by simpa using h₁) h₂' ih)
     it matched current next
 
 section
@@ -60,29 +73,34 @@ theorem captureNext.go_found {σ nfa wf it matched current next}
   simp [captureNext.go, atEnd, isEmpty, isSome]
 
 @[simp]
-theorem captureNext.go_ind_not_found {σ nfa wf it matched current next _matched current' matched' next'}
-  (atEnd : ¬it.atEnd) (isNone : matched.isNone)
-  (h₁ : εClosure σ nfa wf it .none current [(σ.empty, ⟨nfa.start, wf.start_lt⟩)] = (_matched, current'))
-  (h₂ : eachStepChar σ nfa wf it current' next = (matched', next')) :
-  captureNext.go σ nfa wf it matched current next = captureNext.go σ nfa wf it.next matched' next' ⟨current'.states.clear, current'.updates⟩ := by
-  have isSome : ¬matched.isSome := by
-    cases matched <;> simp_all
+theorem captureNext.go_ind_not_found {σ nfa wf it matched current next} (stepped expanded)
+  (eq₁ : stepped = eachStepChar σ nfa wf it current next)
+  (eq₂ : expanded = εClosure σ nfa wf it.next .none stepped.2 [(σ.empty, ⟨nfa.start, wf.start_lt⟩)])
+  (atEnd : ¬it.atEnd) (isNone₁ : matched = .none) (isNone₂ : stepped.1 = .none) :
+  captureNext.go σ nfa wf it matched current next =
+  captureNext.go σ nfa wf it.next expanded.1 expanded.2 ⟨current.states.clear, current.updates⟩ := by
   conv =>
     lhs
     unfold captureNext.go
-    simp [atEnd, isSome, isNone, h₁, h₂]
+    simp [atEnd, isNone₁, isNone₂, ←eq₁, ←eq₂]
 
 @[simp]
-theorem captureNext.go_ind_found {σ nfa wf it matched current next matched' next'}
-  (atEnd : ¬it.atEnd) (isEmpty : ¬current.states.isEmpty) (isSome : matched.isSome)
-  (h : eachStepChar σ nfa wf it current next = (matched', next')) :
-  captureNext.go σ nfa wf it matched current next = captureNext.go σ nfa wf it.next (matched' <|> matched) next' ⟨current.states.clear, current.updates⟩ := by
-  have isNone : ¬matched.isNone := by
-    cases matched <;> simp_all
+theorem captureNext.go_ind_found {σ nfa wf it matched current next} (stepped)
+  (eq : stepped = eachStepChar σ nfa wf it current next)
+  (atEnd : ¬it.atEnd) (hemp : matched.isSome → ¬current.states.isEmpty) (isSome : matched.isSome ∨ stepped.1.isSome) :
+  captureNext.go σ nfa wf it matched current next =
+  captureNext.go σ nfa wf it.next (stepped.1 <|> matched) stepped.2 ⟨current.states.clear, current.updates⟩ := by
+  have h' : (current.states.isEmpty && matched.isSome) = false := by
+    rw [Bool.and_comm]
+    simpa using hemp
+  have h'' : (stepped.1 <|> matched).isNone = false := by
+    simp [Option.isSome_iff_ne_none]
+    intro eq₁ eq₂
+    simp [eq₁, eq₂] at isSome
   conv =>
     lhs
     unfold captureNext.go
-    simp [atEnd, isEmpty, isSome, isNone, h]
+    simp [atEnd, h', h'', ←eq]
 
 end
 

--- a/regex/Regex/VM/Basic.lean
+++ b/regex/Regex/VM/Basic.lean
@@ -140,13 +140,13 @@ where
       if current.states.isEmpty && matched.isSome then
         matched
       else
-        if matched.isNone then
-          let expanded := εClosure σ nfa wf it none current [(σ.empty, ⟨nfa.start, wf.start_lt⟩)]
-          let stepped := eachStepChar σ nfa wf it expanded.2 next
-          go it.next stepped.1 stepped.2 ⟨expanded.2.states.clear, expanded.2.updates⟩
+        let stepped := eachStepChar σ nfa wf it current next
+        let matched' := stepped.1 <|> matched
+        if matched'.isNone then
+          let expanded := εClosure σ nfa wf it.next .none stepped.2 [(σ.empty, ⟨nfa.start, wf.start_lt⟩)]
+          go it.next expanded.1 expanded.2 ⟨current.states.clear, current.updates⟩
         else
-          let stepped := eachStepChar σ nfa wf it current next
-          go it.next (stepped.1 <|> matched) stepped.2 ⟨current.states.clear, current.updates⟩
+          go it.next matched' stepped.2 ⟨current.states.clear, current.updates⟩
 
 def captureNextBuf (nfa : NFA) (wf : nfa.WellFormed) (bufferSize : Nat) (it : Iterator) : Option (Buffer bufferSize) :=
   captureNext (BufferStrategy bufferSize) nfa wf it

--- a/regex/tests/CorpusTest.csv
+++ b/regex/tests/CorpusTest.csv
@@ -301,7 +301,7 @@ multiline/repeat13-no-multi-crlf-cr,error,"expected '(?R)$*' to compile, but it 
 multiline/repeat14,error,"expected '(?m)$+' to compile, but it did not: unexpected character: ?"
 multiline/repeat14-crlf,error,"expected '(?Rm)$+' to compile, but it did not: unexpected character: ?"
 multiline/repeat14-crlf-cr,error,"expected '(?Rm)$+' to compile, but it did not: unexpected character: ?"
-multiline/repeat14-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 4, end := 4 }] }], got #[]"
+multiline/repeat14-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 4, end := 4 }] }], got #[#[(some (4, 4))], #[(some (4, 4))]]"
 multiline/repeat14-no-multi-crlf,error,"expected '(?R)$+' to compile, but it did not: unexpected character: ?"
 multiline/repeat14-no-multi-crlf-cr,error,"expected '(?R)$+' to compile, but it did not: unexpected character: ?"
 multiline/repeat15,error,"expected '(?m)(?:$\n)+' to compile, but it did not: unexpected character: ?"
@@ -325,7 +325,7 @@ multiline/repeat17-no-multi-crlf-cr,error,"expected '(?R)(?:$\r^)+' to compile, 
 multiline/repeat18,error,"expected '(?m)(?:^|$)+' to compile, but it did not: unexpected character: ?"
 multiline/repeat18-crlf,error,"expected '(?Rm)(?:^|$)+' to compile, but it did not: unexpected character: ?"
 multiline/repeat18-crlf-cr,error,"expected '(?Rm)(?:^|$)+' to compile, but it did not: unexpected character: ?"
-multiline/repeat18-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 7, end := 7 }] }], got #[#[(some (0, 0))]]"
+multiline/repeat18-no-multi,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 0 }] }, { id := 0, spans := #[some { start := 7, end := 7 }] }], got #[#[(some (0, 0))], #[(some (7, 7))], #[(some (7, 7))]]"
 multiline/repeat18-no-multi-crlf,error,"expected '(?R)(?:^|$)+' to compile, but it did not: unexpected character: ?"
 multiline/repeat18-no-multi-crlf-cr,error,"expected '(?R)(?:^|$)+' to compile, but it did not: unexpected character: ?"
 multiline/match-line-100,error,"expected '(?m)^.+$' to compile, but it did not: unexpected character: ?"
@@ -400,7 +400,7 @@ regression/negated-char-class-100,error,"expected '(?i)[^x]' to compile, but it 
 regression/negated-char-class-200,error,"expected '(?i)[^x]' to compile, but it did not: unexpected character: ?"
 regression/ascii-word-underscore,error,"expected '[[:word:]]' to compile, but it did not: expected EOF"
 regression/captures-repeat,error,"expected '([a-f]){2}(?P<foo>[x-z])' to compile, but it did not: unexpected character: ?"
-regression/alt-in-alt-100,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 1 }] }, { id := 0, spans := #[some { start := 2, end := 2 }] }], got #[#[(some (0, 1))]]"
+regression/alt-in-alt-100,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 1 }] }, { id := 0, spans := #[some { start := 2, end := 2 }] }], got #[#[(some (0, 1))], #[(some (2, 2))], #[(some (2, 2))]]"
 regression/alt-in-alt-200,error,"expected #[{ id := 0, spans := #[some { start := 0, end := 3 }] }], but got #[#[(some (0, 5))]]"
 regression/leftmost-first-prefix,ok,
 regression/many-alternates,ok,


### PR DESCRIPTION
The PR shuffles around the ε-closure expansion and char step of the NFA simulation. The new implementation provides a better invariants since all paths are captured in the `SearchState` at the start of `captureNext.go`.

There are a few changes in the regression tests, but they are not regressions (no `ok -> fail` transitions), and the results seem "more correct".