### PR TITLE
chore: Adjust README example to work w/ copy paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Returns captured groups: group 0 = whole match, group 1 = "aaa", group 2 = "bb":
 some {
   haystack := "aaabb",
   buffer := #[
-    some { byteIdx := 0 }, some { byteIdx := 5 }, some { byteIdx := 0 },
-    some { byteIdx := 3 }, some { byteIdx := 3 }, some { byteIdx := 5 }
+    some { byteIdx := 0 }, some { byteIdx := 5 },
+    some { byteIdx := 0 }, some { byteIdx := 3 },
+    some { byteIdx := 3 }, some { byteIdx := 5 }
   ]
 }
 -/

--- a/README.md
+++ b/README.md
@@ -39,16 +39,35 @@ to your `lakefile.lean`.
 import Regex
 
 -- Create a regex at compile-time using re! syntax
-let regex := re! r"\d{4}-\d{2}-\d{2}"
+def dateRegexExample := re! r"\d{4}-\d{2}-\d{2}"
 
--- Find matches
-let allMatches := regex.findAll "2025-05-24: Something happened\\n2025-05-26: Another thing happened"
--- Returns positions of matches
+-- Find and return matches (and their positions as components of each `Substring`)
+def allMatches := dateRegexExample.findAll
+  "2025-05-24: Something happened\\n2025-05-26: Another thing happened"
+
+-- #["2025-05-24".toSubstring, "2025-05-26".toSubstring]
+#eval allMatches
+
+-- #[{ byteIdx := 0 }, { byteIdx := 32 }]
+#eval allMatches.map (·.startPos)
 
 -- Capture groups
-let groupRegex := re! r"(a+)(b*)"
-let captures := groupRegex.capture "aaabb"
--- Returns captured groups: group 0 = whole match, group 1 = "aaa", group 2 = "bb"
+def groupRegexExample := re! r"(a+)(b*)"
+
+def captures := groupRegexExample.capture "aaabb"
+
+/-
+Returns captured groups: group 0 = whole match, group 1 = "aaa", group 2 = "bb":
+
+some {
+  haystack := "aaabb",
+  buffer := #[
+    some { byteIdx := 0 }, some { byteIdx := 5 }, some { byteIdx := 0 },
+    some { byteIdx := 3 }, some { byteIdx := 3 }, some { byteIdx := 5 }
+  ]
+}
+-/
+#eval captures
 ```
 
 For more details, please check [the API reference](https://pandaman64.github.io/lean-regex/Regex.html).

--- a/regex/Regex.lean
+++ b/regex/Regex.lean
@@ -42,16 +42,36 @@ to your `lakefile.lean`.
 import Regex
 
 -- Create a regex at compile-time using re! syntax
-let regex := re! r"\d{4}-\d{2}-\d{2}"
+def dateRegexExample := re! r"\d{4}-\d{2}-\d{2}"
 
--- Find matches
-let allMatches := regex.findAll "2025-05-24: Something happened\\n2025-05-26: Another thing happened"
--- Returns positions of matches
+-- Find and return matches (and their positions as components of each `Substring`)
+def allMatches := dateRegexExample.findAll
+  "2025-05-24: Something happened\\n2025-05-26: Another thing happened"
+
+-- #["2025-05-24".toSubstring, "2025-05-26".toSubstring]
+#eval allMatches
+
+-- #[{ byteIdx := 0 }, { byteIdx := 32 }]
+#eval allMatches.map (·.startPos)
 
 -- Capture groups
-let groupRegex := re! r"(a+)(b*)"
-let captures := groupRegex.capture "aaabb"
--- Returns captured groups: group 0 = whole match, group 1 = "aaa", group 2 = "bb"
+def groupRegexExample := re! r"(a+)(b*)"
+
+def captures := groupRegexExample.capture "aaabb"
+
+/-
+Returns captured groups: group 0 = whole match, group 1 = "aaa", group 2 = "bb":
+
+some {
+  haystack := "aaabb",
+  buffer := #[
+    some { byteIdx := 0 }, some { byteIdx := 5 },
+    some { byteIdx := 0 }, some { byteIdx := 3 },
+    some { byteIdx := 3 }, some { byteIdx := 5 }
+  ]
+}
+-/
+#eval captures
 ```
 
 ## API Overview


### PR DESCRIPTION
The example in the README begins with an `import` statement, which would seem to invite readers to copy and paste the code block in their editor just to see if everything's working. Since it uses `let` where a declaration is expected, it doesn't actually work as written.

This just changes the `let`s to `def`s to make it work when copied and pasted verbatim.