### PR TITLE
Add transform functionality

### DIFF
--- a/regex/Regex/Regex/Captures.lean
+++ b/regex/Regex/Regex/Captures.lean
@@ -78,6 +78,15 @@ def Captures.next? (self : Captures) : Option (CapturedGroups × Captures) := do
   else
     throw ()
 
+theorem Captures.zeroth_group_some_of_next?_some {self next : Captures} {groups : CapturedGroups}
+    (h : self.next? = (groups,next)) : groups.get 0 |>.isSome := by
+  unfold next? at h
+  split at h <;> simp [Option.bind_eq_some_iff] at h
+  have ⟨_, _, h⟩ := h
+  have ⟨_, h, ⟨h', _⟩⟩ := h
+  rw [h'] at h
+  exact Option.isSome_of_mem h
+
 /--
 Gets the number of remaining characters to process in the haystack string.
 

--- a/regex/Regex/Regex/Utilities.lean
+++ b/regex/Regex/Regex/Utilities.lean
@@ -32,6 +32,41 @@ where
   termination_by m.remaining
 
 /--
+Transforms the first match of a regex pattern using its capture groups.
+
+* `regex`: The compiled regex pattern to use for matching
+* `haystack`: The input string to search in
+* `transformer`: The rule yielding the string to replace the match with
+* Returns: The modified string, or the original string if no match is found
+-/
+def transform (regex : Regex) (haystack : String) (transformer : CapturedGroups → String) : String :=
+    match (regex.captures haystack).next? with
+  | some (g,_) =>
+    let s := g.get 0 |>.get! -- TODO: show that this always succeeds and use get
+    haystack.extract 0 s.startPos ++ transformer g ++ haystack.extract s.stopPos haystack.endPos
+  | none => haystack
+
+/--
+Transforms all matches of a regex pattern using its capture groups.
+
+* `regex`: The compiled regex pattern to use for matching
+* `haystack`: The input string to search in
+* `transformer`: The rule yielding the string to replace the match with
+* Returns: The modified string, or the original string if no matches are found
+-/
+def transformAll (regex : Regex) (haystack : String) (transformer : CapturedGroups → String) : String :=
+  go (regex.captures haystack) "" 0
+where
+  go (c : Captures) (accum : String) (endPos : Pos) : String :=
+    match _h : c.next? with
+    | some (g, c') =>
+      let s := g.get 0 |>.get! -- TODO: show that this always succeeds and use get
+      go c' (accum ++ haystack.extract endPos s.startPos ++ transformer g) s.stopPos
+    | none =>
+      accum ++ haystack.extract endPos haystack.endPos
+  termination_by c.remaining
+
+/--
 Replaces the first match of a regex pattern with a replacement string.
 
 * `regex`: The compiled regex pattern to use for matching

--- a/regex/Regex/Regex/Utilities.lean
+++ b/regex/Regex/Regex/Utilities.lean
@@ -40,9 +40,9 @@ Transforms the first match of a regex pattern using its capture groups.
 * Returns: The modified string, or the original string if no match is found
 -/
 def transform (regex : Regex) (haystack : String) (transformer : CapturedGroups → String) : String :=
-    match (regex.captures haystack).next? with
+    match h : (regex.captures haystack).next? with
   | some (g,_) =>
-    let s := g.get 0 |>.get! -- TODO: show that this always succeeds and use get
+    let s := g.get 0 |>.get (Captures.zeroth_group_some_of_next?_some h)
     haystack.extract 0 s.startPos ++ transformer g ++ haystack.extract s.stopPos haystack.endPos
   | none => haystack
 
@@ -58,9 +58,9 @@ def transformAll (regex : Regex) (haystack : String) (transformer : CapturedGrou
   go (regex.captures haystack) "" 0
 where
   go (c : Captures) (accum : String) (endPos : Pos) : String :=
-    match _h : c.next? with
+    match h : c.next? with
     | some (g, c') =>
-      let s := g.get 0 |>.get! -- TODO: show that this always succeeds and use get
+      let s := g.get 0 |>.get (Captures.zeroth_group_some_of_next?_some h)
       go c' (accum ++ haystack.extract endPos s.startPos ++ transformer g) s.stopPos
     | none =>
       accum ++ haystack.extract endPos haystack.endPos

--- a/regex/tests/Test.lean
+++ b/regex/tests/Test.lean
@@ -1,4 +1,5 @@
 import Regex.Regex.Utilities
+import Regex.Regex.Captures
 import Regex.Regex.Elab
 import Regex.Backtracker
 
@@ -261,3 +262,36 @@ namespace Split
 #guard (re! " +").splitTest "    a  b c" = #["", "a", "b", "c"]
 
 end Split
+
+namespace Transform
+
+open Regex
+
+def parenthesesRegex := re! r"\((\d+)\)"
+
+def parenthesesToBraces (captures : CapturedGroups) : String :=
+  let digits := captures.get 1 |>.map Substring.toString |>.getD ""
+  "{" ++ digits ++ "}"
+
+#guard parenthesesRegex.transform "" parenthesesToBraces = ""
+#guard parenthesesRegex.transformAll "" parenthesesToBraces = ""
+#guard parenthesesRegex.transform "(123) and ((4))" parenthesesToBraces = "{123} and ((4))"
+#guard parenthesesRegex.transformAll "(123) and ((4))" parenthesesToBraces = "{123} and ({4})"
+
+def countRegex := re! r"(a+)(b*)|(c+)"
+
+def countString (name : String) (input : Option Substring) : String :=
+  input.map (Substring.toString)
+    |>.map (fun s => toString s.length ++ name)
+    |>.getD ""
+
+def countTransform (captures : CapturedGroups) : String :=
+  let as := captures.get 1 |> countString "a"
+  let bs := captures.get 2 |> countString "b"
+  let cs := captures.get 3 |> countString "c"
+  as ++ bs ++ cs
+
+#guard countRegex.transform "a aa aab c cc" countTransform = "1a0b aa aab c cc"
+#guard countRegex.transformAll "a aa aab c cc" countTransform = "1a0b 2a0b 2a1b 1c 2c"
+
+end Transform


### PR DESCRIPTION
This is work in progress for #102. The basic functionality has been implemented.

Next, I will try to experiment a bit with `replace` using `transform` and look at the performance.
(I probably won't have time to so in the coming week.)

As always, some questions:
1. Out of curiosity: how brittle are proofs such as the one I wrote in 48e6a26 under refactors of the original function? (It seems so "low-level".)
2. The following is related, but might be too high level; let me know what you think. Two basic iterators for stateful transformations:
```lean
import Regex
open Regex 
open String (Pos)

def Regex.transformAllWithState' (regex : Regex) (haystack : String) (init : α) (transformer : α → CapturedGroups → α × String) : α × String :=
  go (regex.captures haystack) init "" 0
where
  go (c : Captures) (state : α) (accum : String) (endPos : Pos) : α × String :=
    match h : c.next? with
    | some (g, c') =>
      let s := g.get 0 |>.get (Captures.zeroth_group_some_of_next?_some h)
      let (state', transform) := transformer state g
      go c' state' (accum ++ haystack.extract endPos s.startPos ++ transform) s.stopPos
    | none =>
      (state, accum ++ haystack.extract endPos haystack.endPos)
  termination_by c.remaining

def Regex.transformAllWithState (regex : Regex) (haystack : String) (init : α) (transformer : α → CapturedGroups → α × String) : String :=
  Regex.transformAllWithState' regex haystack init transformer |>.snd

-- EXAMPLE: count and mark matches
def counter (n : Nat) (captures : CapturedGroups) : Nat × String :=
  let m := captures.get 0 |>.map Substring.toString |>.getD ""
  (n+1, s!"<match {n+1}: {m}>")

-- "<match 1: a> <match 2: a> <match 3: aa> <match 4: aaa> <match 5: a>"
#eval (re! "a+").transformAllWithState "a a aa aaa a" 0 counter

-- "There are 5 matches: <match 1: a> <match 2: a> <match 3: aa> <match 4: aaa> <match 5: a>"
#eval
  let (state,string) := (re! "a+").transformAllWithState' "a a aa aaa a" 0 counter
  s!"There are {state} matches: '{string}'"
```