### PR TITLE
Add a non-membership proof to insert

### DIFF
--- a/correctness/RegexCorrectness/Data/SparseSet.lean
+++ b/correctness/RegexCorrectness/Data/SparseSet.lean
@@ -2,42 +2,15 @@ import Regex.Data.SparseSet
 
 namespace Regex.Data.SparseSet
 
-theorem mem_insert_of_mem {s : SparseSet n} {i j : Fin n} : i ∈ s → i ∈ s.insert j := by
-  intro h
-  unfold SparseSet.insert
-  split
-  next => exact h
-  next hmem =>
-    simp [mem]
-    if heq : j.val = i.val then
-      simp [heq]
-      exact Fin.eq_of_val_eq heq
-    else
-      simp [mem] at h
-      simp [heq]
-      have : s.count ≠ s.sparse[i.val].val := Nat.ne_of_gt h.left
-      simp [this, h]
-      exact Nat.lt_trans h.left (Nat.lt_succ_self _)
+theorem mem_insert_of_mem {s : SparseSet n} {i j : Fin n} (h : j ∉ s) (hmem : i ∈ s) : i ∈ s.insert j h := by
+  have ne : i ≠ j := fun eq => h (eq ▸ hmem)
+  simp [mem] at hmem
+  simp [insert, mem, Vector.getElem_set_ne (h := Fin.val_ne_of_ne ne.symm)]
+  grind
 
-theorem eq_or_mem_of_mem_insert {s : SparseSet n} {i j : Fin n} : i ∈ s.insert j → i = j ∨ i ∈ s := by
-  intro h
-  if heq : i = j then
-    exact Or.inl heq
-  else
-    suffices i ∈ s from Or.inr this
-    unfold SparseSet.insert at h
-    split at h
-    next => exact h
-    next hmem =>
-      have ne : j.val ≠ i.val := Ne.symm (Fin.val_ne_of_ne heq)
-      simp [mem, Vector.getElem_set, ne] at h
-      split at h
-      case isTrue heq' => simp [h] at heq
-      case isFalse heq' =>
-        have : s.sparse[i.val] < s.count := by
-          have : s.sparse[i.val] ≤ s.count := Nat.le_of_lt_succ h.left
-          exact Nat.lt_of_le_of_ne this (Ne.symm heq')
-        simp [mem, this, h]
+theorem eq_or_mem_of_mem_insert {s : SparseSet n} {i j : Fin n} {h : j ∉ s} : i ∈ s.insert j h → i = j ∨ i ∈ s := by
+  simp [insert, mem]
+  grind only [Vector.getElem_set, cases Or]
 
 theorem subset_self {s : SparseSet n} : s ⊆ s := by
   simp [HasSubset.Subset, Subset]
@@ -45,9 +18,9 @@ theorem subset_self {s : SparseSet n} : s ⊆ s := by
 theorem mem_of_mem_of_subset {s₁ s₂ : SparseSet n} {i : Fin n} (mem : i ∈ s₁) (sub : s₁ ⊆ s₂) : i ∈ s₂ :=
   sub i mem
 
-theorem subset_insert {s : SparseSet n} : s ⊆ s.insert i := by
+theorem subset_insert {s : SparseSet n} {h : i ∉ s} : s ⊆ s.insert i h := by
   intro j hj
-  exact mem_insert_of_mem hj
+  exact mem_insert_of_mem h hj
 
 theorem subset_trans {s₁ s₂ s₃ : SparseSet n} (h₁ : s₁ ⊆ s₂) (h₂ : s₂ ⊆ s₃) : s₁ ⊆ s₃ := by
   intro i hi

--- a/correctness/RegexCorrectness/VM/EpsilonClosure/Basic.lean
+++ b/correctness/RegexCorrectness/VM/EpsilonClosure/Basic.lean
@@ -136,18 +136,18 @@ theorem induct' (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator
     state ∈ next.states →
     motive matched next stack' →
     motive matched next ((update, state) :: stack'))
-  (not_visited : ∀ (matched : Option σ.Update) (next : SearchState σ nfa) (update : σ.Update) (state : Fin nfa.nodes.size) (stack' : εStack σ nfa),
-    state ∉ next.states →
+  (not_visited : ∀ (matched : Option σ.Update) (next : SearchState σ nfa) (update : σ.Update) (state : Fin nfa.nodes.size) (stack' : εStack σ nfa)
+    (hmem : state ∉ next.states),
     let node := nfa[state]
     let matched' := if node = Node.done then matched <|> some update else matched
-    let states' := next.states.insert state
+    let states' := next.states.insert state hmem
     let updates' := if writeUpdate node = true then next.updates.set state update else next.updates
     motive matched' ⟨states', updates'⟩ (pushNext σ nfa it node (wf.inBounds state) update stack') →
     motive matched next ((update, state) :: stack')) :
   ∀ (matched : Option σ.Update) (next : SearchState σ nfa) (stack : εStack σ nfa), motive matched next stack :=
   fun matched next stack =>
     induct σ nfa wf it motive base visited
-      (fun matched update state stack' states updates hmem ih =>
+      (fun matched update state stack' states updates hmem _ ih =>
         not_visited matched ⟨states, updates⟩ update state stack' hmem ih)
       matched next stack
 
@@ -171,7 +171,7 @@ theorem visited (hmem : state ∈ next.states) :
 theorem not_visited (hmem : state ∉ next.states) :
   letI node := nfa[state]
   letI matched' := if node = Node.done then matched <|> some update else matched
-  letI states' := next.states.insert state
+  letI states' := next.states.insert state hmem
   letI updates' := if writeUpdate node = true then next.updates.set state update else next.updates
   εClosure σ nfa wf it matched next ((update, state) :: stack') =
   εClosure σ nfa wf it matched' ⟨states', updates'⟩ (pushNext σ nfa it node (wf.inBounds state) update stack') := by

--- a/regex/Regex/VM/Basic.lean
+++ b/regex/Regex/VM/Basic.lean
@@ -61,16 +61,17 @@ def εClosure (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
   match stack with
   | [] => (matched, next)
   | (update, state) :: stack' =>
-    if _ : state ∈ next.states then
+    if mem : state ∈ next.states then
       εClosure σ nfa wf it matched next stack'
     else
       match h : next with
       | ⟨states, updates⟩ =>
         let node := nfa[state]
         let matched' := if node = .done then matched <|> update else matched
-        let states' := states.insert state
+        let states' := states.insert state mem
         let updates' := if εClosure.writeUpdate node then updates.set state update else updates
         let stack'' := εClosure.pushNext σ nfa it node (wf.inBounds state) update stack'
+        have : states'.measure < states.measure := SparseSet.lt_measure_insert' mem
         εClosure σ nfa wf it matched' ⟨states', updates'⟩ stack''
 termination_by (next.states.measure, stack)
 


### PR DESCRIPTION
The actual usage of `SparseSet.insert` satisfies non-membershipness already, so we pass the hypothesis to eliminate a branch.

It seems that the new Lean4 compiler introduces a few additional `lean_dec`s when having that branch. I hope this works around [the regression](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Slowdown.20in.20v4.2E22.2E0-rc3/with/528451790).