### PR TITLE
Issue 102 cleanup

### DIFF
--- a/regex/Regex.lean
+++ b/regex/Regex.lean
@@ -100,6 +100,25 @@ Note the empty substring due to the match "a" at the beginning of the input:
 -/
 #eval utilityRegexExample.split haystack
 
+def transformRegexExample := re! r"(a+)(b*)|(c+)"
+
+def countString (name : String) (input : Option Substring) : String :=
+  input.map (Substring.toString)
+    |>.map (fun s => toString s.length ++ name)
+    |>.getD ""
+
+def countTransform (captures : CapturedGroups) : String :=
+  let as := captures.get 1 |> countString "a"
+  let bs := captures.get 2 |> countString "b"
+  let cs := captures.get 3 |> countString "c"
+  as ++ bs ++ cs
+
+-- "1a0b 2a0b 2a1b 1c 2c"
+#eval transformRegexExample.transformAll "a aa aab c cc" countTransform
+
+-- Transforming matches into a fixed string is also available using `.replace` and `.replaceAll`.
+#guard transformRegexExample.transformAll "a aa aab c cc" (fun _ => ".")
+     = transformRegexExample.replaceAll   "a aa aab c cc" "."
 ```
 
 ## API Overview
@@ -121,6 +140,8 @@ Regex operations include:
 - `Regex.captureAll`: Capture all matches with their capture groups
 - `Regex.replace`: Replace the first match with a replacement string
 - `Regex.replaceAll`: Replace all matches with a replacement string
+- `Regex.transform`: Transform the first match using a rule based on its captured groups
+- `Regex.transformAll`: Transform all matches using a rule based on their captured groups
 - `Regex.test`: Test if a regex matches a string
 - `Regex.count`: Count the number of regex matches in a string
 - `Regex.split`: Split a string using regex matches as breakpoints

--- a/regex/Regex/Regex/Utilities.lean
+++ b/regex/Regex/Regex/Utilities.lean
@@ -75,10 +75,7 @@ Replaces the first match of a regex pattern with a replacement string.
 * Returns: The modified string, or the original string if no match is found
 -/
 def replace (regex : Regex) (haystack : String) (replacement : String) : String :=
-  match regex.find haystack with
-  | some s =>
-    haystack.extract 0 s.startPos ++ replacement ++ haystack.extract s.stopPos haystack.endPos
-  | none => haystack
+  transform regex haystack (fun _ => replacement)
 
 /--
 Replaces all matches of a regex pattern with a replacement string.
@@ -89,15 +86,7 @@ Replaces all matches of a regex pattern with a replacement string.
 * Returns: The modified string, or the original string if no matches are found
 -/
 def replaceAll (regex : Regex) (haystack : String) (replacement : String) : String :=
-  go (regex.matches haystack) "" 0
-where
-  go (m : Matches) (accum : String) (endPos : Pos) : String :=
-    match _h : m.next? with
-    | some (s, m') =>
-      go m' (accum ++ haystack.extract endPos s.startPos ++ replacement) s.stopPos
-    | none =>
-      accum ++ haystack.extract endPos haystack.endPos
-  termination_by m.remaining
+  transformAll regex haystack (fun _ => replacement)
 
 /--
 Captures the first match of a regex pattern in a string, including capture groups.


### PR DESCRIPTION
I've added some documentation about the `transform*` capabilities (see #106), but only in the API reference for now, as to not make the README too long.

I've also rewritten the `replace*` functions; now they use `transform*`. In my limited tests, this is about 1-3% slower (max).

(PS: Feel free to ping me when the Lean iterator API is stable, and you want to use it in this library for a stateful conversion.)