### PR TITLE
Use utility method count in benchmark

### DIFF
--- a/regex/scripts/Bench.lean
+++ b/regex/scripts/Bench.lean
@@ -6,7 +6,7 @@ def printUsage : IO Unit := do
 
 @[noinline]
 def findCount (re : Regex) (content : String) : IO Nat :=
-  pure (re.findAll content |>.size)
+  re.count content |> pure
 
 def benchmark (re : Regex) (content : String) (iterations : Nat) : IO Unit := do
   let mut totalTime := 0


### PR DESCRIPTION
I saw #113 and noted that the utility method `count` could be used, which makes the code a tiny bit cleaner. 

(Btw: how did you find out that the optimizer pulled out `findCount`?)