### PR TITLE
Prefilter for multiple starting characters

### DIFF
--- a/correctness/RegexCorrectness/Data/Expr/Optimization.lean
+++ b/correctness/RegexCorrectness/Data/Expr/Optimization.lean
@@ -17,7 +17,7 @@ theorem curr_of_captures_of_firstChars_some {it it' groups e n cs} (c : Expr.Cap
   | alternateLeft c₁ ih =>
     intro cs h
     simp [firstChars, Option.bind_eq_some_iff] at h
-    have ⟨_,hcs₁,_,_,hcs⟩ := h
+    have ⟨_, hcs₁, _, _, hcs⟩ := h
     rw [← hcs]
     simp only [Array.contains_eq_mem, Array.mem_append, Bool.decide_or, Bool.or_eq_true,
       decide_eq_true_eq]
@@ -26,7 +26,7 @@ theorem curr_of_captures_of_firstChars_some {it it' groups e n cs} (c : Expr.Cap
   | alternateRight _ ih =>
     intro cs h
     simp [firstChars, Option.bind_eq_some_iff] at h
-    have ⟨_,_,_,hcs₂,hcs⟩ := h
+    have ⟨_, _, _, hcs₂, hcs⟩ := h
     rw [← hcs]
     simp only [Array.contains_eq_mem, Array.mem_append, Bool.decide_or, Bool.or_eq_true,
       decide_eq_true_eq]

--- a/correctness/RegexCorrectness/Data/Expr/Optimization.lean
+++ b/correctness/RegexCorrectness/Data/Expr/Optimization.lean
@@ -1,5 +1,6 @@
 import Regex.Data.Expr
 import RegexCorrectness.Data.Expr.Semantics
+import RegexCorrectness.Data.HashSet
 
 namespace Regex.Data.Expr
 
@@ -7,6 +8,7 @@ theorem empty_of_captures_of_nullOnly {it it' groups e} (c : Expr.Captures it it
   it' = it := by
   induction c <;> grind [nullOnly]
 
+open Std in
 theorem curr_of_captures_of_firstChars_some {it it' groups e n cs} (c : Expr.Captures it it' groups e) (h : e.firstChars n = .some cs) :
   cs.contains it.curr := by
   revert cs
@@ -19,19 +21,17 @@ theorem curr_of_captures_of_firstChars_some {it it' groups e n cs} (c : Expr.Cap
     simp [firstChars, Option.bind_eq_some_iff] at h
     have ⟨_, hcs₁, _, _, hcs⟩ := h
     rw [← hcs]
-    simp only [Array.contains_eq_mem, Array.mem_append, Bool.decide_or, Bool.or_eq_true,
-      decide_eq_true_eq]
+    simp only [HashSet.contains_iff_mem, HashSet.mem_union_iff]
     left
-    exact Array.contains_iff.mp (ih hcs₁)
+    exact ih hcs₁
   | alternateRight _ ih =>
     intro cs h
     simp [firstChars, Option.bind_eq_some_iff] at h
     have ⟨_, _, _, hcs₂, hcs⟩ := h
     rw [← hcs]
-    simp only [Array.contains_eq_mem, Array.mem_append, Bool.decide_or, Bool.or_eq_true,
-      decide_eq_true_eq]
+    simp only [HashSet.contains_iff_mem, HashSet.mem_union_iff]
     right
-    exact Array.contains_iff.mp (ih hcs₂)
+    exact ih hcs₂
   | concat c₁ _ ih₁ ih₂ =>
     intro cs h
     simp [firstChars] at h

--- a/correctness/RegexCorrectness/Data/Expr/Optimization.lean
+++ b/correctness/RegexCorrectness/Data/Expr/Optimization.lean
@@ -7,22 +7,37 @@ theorem empty_of_captures_of_nullOnly {it it' groups e} (c : Expr.Captures it it
   it' = it := by
   induction c <;> grind [nullOnly]
 
-theorem curr_of_captures_of_firstChar_some {it it' groups e ch} (c : Expr.Captures it it' groups e) (h : e.firstChar = .some ch) :
-  it.curr = ch := by
+theorem curr_of_captures_of_firstChars_some {it it' groups e n cs} (c : Expr.Captures it it' groups e) (h : e.firstChars n = .some cs) :
+  cs.contains it.curr := by
+  revert cs
   induction c with
-  | sparse | epsilon | anchor | starEpsilon | starConcat  => simp [firstChar] at h
-  | char vf => simp_all [vf.curr, firstChar]
-  | group _ ih => exact ih h
-  | alternateLeft _ ih =>
-    simp [firstChar, Option.bind_eq_some_iff] at h
-    exact ih h.1
+  | sparse | epsilon | anchor | starEpsilon | starConcat => simp [firstChars]
+  | char vf => simp_all [vf.curr, firstChars, Option.bind_eq_some_iff]
+  | group _ _ => simp_all [firstChars, Option.bind_eq_some_iff]
+  | alternateLeft c₁ ih =>
+    intro cs h
+    simp [firstChars, Option.bind_eq_some_iff] at h
+    have ⟨_,hcs₁,_,_,hcs⟩ := h
+    rw [← hcs]
+    simp only [Array.contains_eq_mem, Array.mem_append, Bool.decide_or, Bool.or_eq_true,
+      decide_eq_true_eq]
+    left
+    exact Array.contains_iff.mp (ih hcs₁)
   | alternateRight _ ih =>
-    simp [firstChar, Option.bind_eq_some_iff] at h
-    exact ih h.2
+    intro cs h
+    simp [firstChars, Option.bind_eq_some_iff] at h
+    have ⟨_,_,_,hcs₂,hcs⟩ := h
+    rw [← hcs]
+    simp only [Array.contains_eq_mem, Array.mem_append, Bool.decide_or, Bool.or_eq_true,
+      decide_eq_true_eq]
+    right
+    exact Array.contains_iff.mp (ih hcs₂)
   | concat c₁ _ ih₁ ih₂ =>
-    simp [firstChar] at h
+    intro cs h
+    simp [firstChars] at h
     split at h
-    next h' => exact empty_of_captures_of_nullOnly c₁ h' ▸ ih₂ h
-    next => exact ih₁ h
+    all_goals simp [Option.bind_eq_some_iff] at h
+    next h' => exact empty_of_captures_of_nullOnly c₁ h' ▸ ih₂ h.1
+    next => exact ih₁ h.1
 
 end Regex.Data.Expr

--- a/correctness/RegexCorrectness/Data/HashSet.lean
+++ b/correctness/RegexCorrectness/Data/HashSet.lean
@@ -18,7 +18,4 @@ theorem mem_union_iff {a : α} (m₁ m₂ : HashSet α) :
       rw [BEq.comm]
       grind
 
-theorem contains_toArray_iff {a : α} (m : HashSet α) :
-    m.contains a ↔ m.toArray.contains a := sorry
-
 end Std.HashSet

--- a/correctness/RegexCorrectness/Data/HashSet.lean
+++ b/correctness/RegexCorrectness/Data/HashSet.lean
@@ -1,0 +1,15 @@
+import Std.Data.HashSet
+
+universe u
+
+variable {α : Type u} [BEq α] [Hashable α]
+
+namespace Std.HashSet
+
+theorem mem_union_iff {a : α} (m₁ m₂ : HashSet α) :
+    a ∈ m₁.union m₂ ↔ a ∈ m₁ ∨ a ∈ m₂ := sorry
+
+theorem contains_toArray_iff {a : α} (m : HashSet α) :
+    m.contains a ↔ m.toArray.contains a := sorry
+
+end Std.HashSet

--- a/correctness/RegexCorrectness/Data/HashSet.lean
+++ b/correctness/RegexCorrectness/Data/HashSet.lean
@@ -2,12 +2,21 @@ import Std.Data.HashSet
 
 universe u
 
-variable {α : Type u} [BEq α] [Hashable α]
+variable {α : Type u} [BEq α] [Hashable α] [EquivBEq α] [LawfulHashable α]
 
 namespace Std.HashSet
 
 theorem mem_union_iff {a : α} (m₁ m₂ : HashSet α) :
-    a ∈ m₁.union m₂ ↔ a ∈ m₁ ∨ a ∈ m₂ := sorry
+    a ∈ m₁.union m₂ ↔ a ∈ m₁ ∨ a ∈ m₂ := by
+    simp [union, fold_eq_foldl_toList]
+    rw [mem_iff_contains (m:= m₂), ← contains_toList]
+    generalize m₂.toList = l
+    induction l generalizing m₁ with
+    | nil => simp
+    | cons hd tl ih =>
+      simp [ih]
+      rw [BEq.comm]
+      grind
 
 theorem contains_toArray_iff {a : α} (m : HashSet α) :
     m.contains a ↔ m.toArray.contains a := sorry

--- a/correctness/RegexCorrectness/Regex/OptimizationInfo.lean
+++ b/correctness/RegexCorrectness/Regex/OptimizationInfo.lean
@@ -37,7 +37,8 @@ theorem findStart_completeness {it it' it'' : Iterator} {opt : OptimizationInfo}
     simp [eq, fromExpr] at h
     have ⟨_, h₁, h₂⟩ := h
     have : cs.contains it'.curr := by
-      rw [← h₂, ← HashSet.contains_toArray_iff]
+      rw [← h₂]
+      simp only [HashSet.contains_toArray]
       exact Expr.curr_of_captures_of_firstChars_some c h₁
     contradiction
   next => exact Nat.not_lt_of_ge ge

--- a/correctness/RegexCorrectness/Regex/OptimizationInfo.lean
+++ b/correctness/RegexCorrectness/Regex/OptimizationInfo.lean
@@ -29,13 +29,12 @@ theorem findStart_completeness {it it' it'' : Iterator} {opt : OptimizationInfo}
   False := by
   revert lt
   fun_cases findStart opt it
-  next ch h =>
+  next cs h =>
     intro lt
-    have ne := Iterator.find_completeness v it' c.validL eqs ge lt
-    simp at ne
+    have : ¬(cs.contains it'.curr) := Iterator.find_completeness v it' c.validL eqs ge lt
     simp [eq, fromExpr] at h
-    have eq : it'.curr = ch := Expr.curr_of_captures_of_firstChar_some c h
-    exact ne eq
+    have : cs.contains it'.curr := Expr.curr_of_captures_of_firstChars_some c h
+    contradiction
   next => exact Nat.not_lt_of_ge ge
 
 end Regex.OptimizationInfo

--- a/correctness/RegexCorrectness/Regex/OptimizationInfo.lean
+++ b/correctness/RegexCorrectness/Regex/OptimizationInfo.lean
@@ -2,9 +2,11 @@ import Regex.Regex.OptimizationInfo
 import RegexCorrectness.Data.Expr.Semantics
 import RegexCorrectness.Data.Expr.Optimization
 import RegexCorrectness.Data.String
+import RegexCorrectness.Data.HashSet
 
 open Regex.Data (Expr CaptureGroups)
 open String (Iterator)
+open Std
 
 namespace Regex.OptimizationInfo
 
@@ -33,7 +35,10 @@ theorem findStart_completeness {it it' it'' : Iterator} {opt : OptimizationInfo}
     intro lt
     have : ¬(cs.contains it'.curr) := Iterator.find_completeness v it' c.validL eqs ge lt
     simp [eq, fromExpr] at h
-    have : cs.contains it'.curr := Expr.curr_of_captures_of_firstChars_some c h
+    have ⟨_, h₁, h₂⟩ := h
+    have : cs.contains it'.curr := by
+      rw [← h₂, ← HashSet.contains_toArray_iff]
+      exact Expr.curr_of_captures_of_firstChars_some c h₁
     contradiction
   next => exact Nat.not_lt_of_ge ge
 

--- a/regex/Regex/Data/Expr/Optimization.lean
+++ b/regex/Regex/Data/Expr/Optimization.lean
@@ -24,7 +24,7 @@ def firstChars (maxSize : Nat) (expr : Expr) : Option (HashSet Char) := do
       let cs₁ ← e₁.firstChars maxSize
       let cs₂ ← e₂.firstChars maxSize
       return cs₁.union cs₂
-    | .star _ => .none
+    | .star _ _ => .none
   guard (cs.size ≤ maxSize)
   return cs
 

--- a/regex/Regex/Data/Expr/Optimization.lean
+++ b/regex/Regex/Data/Expr/Optimization.lean
@@ -1,5 +1,7 @@
 import Regex.Data.Expr.Basic
 
+open Std
+
 namespace Regex.Data.Expr
 
 def nullOnly (expr : Expr) : Bool :=
@@ -11,20 +13,18 @@ def nullOnly (expr : Expr) : Bool :=
   | .alternate e₁ e₂ => e₁.nullOnly && e₂.nullOnly
   | .star _ e => e.nullOnly
 
-def firstChars (maxSize : Nat) (expr : Expr) : Option (Array Char) := do
+def firstChars (maxSize : Nat) (expr : Expr) : Option (HashSet Char) := do
   let cs ← match expr with
     | .empty | .epsilon | .anchor _ => .none
-    | .char c => .some #[c]
+    | .char c => .some {c}
     | .classes _ => .none -- TODO: take .single class into account
     | .group _ e => e.firstChars maxSize
     | .concat e₁ e₂ => if e₁.nullOnly then e₂.firstChars maxSize else e₁.firstChars maxSize
     | .alternate e₁ e₂ => do
       let cs₁ ← e₁.firstChars maxSize
       let cs₂ ← e₂.firstChars maxSize
-      -- TODO: make sure there are no duplicates
-      -- Array.foldl (Array.binInsert (· < ·)) cs₁ cs₂
-      return cs₁ ++ cs₂
-    | .star _ _ => .none
+      return cs₁.union cs₂
+    | .star _ => .none
   guard (cs.size ≤ maxSize)
   return cs
 

--- a/regex/Regex/Regex/OptimizationInfo.lean
+++ b/regex/Regex/Regex/OptimizationInfo.lean
@@ -8,21 +8,21 @@ namespace Regex
 
 structure OptimizationInfo where
   /--
-  When `firstChar` is `.some c`, all matching strings must start with `c`.
+  When `firstChars` is `.some chars`, all matching strings must start with one of the characters in `chars`.
 
-  The regex engine will optimize the search to skip positions that do not start with `c`.
+  The regex engine will optimize the search to skip positions that do not start with any character in `chars`.
   -/
-  firstChar : Option Char
+  firstChars : Option (Array Char)
 deriving Repr, Inhabited, DecidableEq, Lean.ToExpr
 
 namespace OptimizationInfo
 
 def fromExpr (expr : Expr) : OptimizationInfo :=
-  { firstChar := expr.firstChar }
+  { firstChars := expr.firstChars (maxSize := 8) }
 
 def findStart (self : OptimizationInfo) (it : Iterator) : Iterator :=
-  match self.firstChar with
-  | .some c => it.find (· = c)
+  match self.firstChars with
+  | .some cs => it.find (cs.contains ·)
   | .none => it
 
 end OptimizationInfo

--- a/regex/Regex/Regex/OptimizationInfo.lean
+++ b/regex/Regex/Regex/OptimizationInfo.lean
@@ -18,7 +18,7 @@ deriving Repr, Inhabited, DecidableEq, Lean.ToExpr
 namespace OptimizationInfo
 
 def fromExpr (expr : Expr) : OptimizationInfo :=
-  { firstChars := expr.firstChars (maxSize := 8) }
+  { firstChars := expr.firstChars (maxSize := 8) |>.map Std.HashSet.toArray }
 
 def findStart (self : OptimizationInfo) (it : Iterator) : Iterator :=
   match self.firstChars with


### PR DESCRIPTION
This is a first step to resolve #118, but it is not yet ready to be merged.

After some iterations, the basic structure is finished. There is still room for improvement, and I'll be working on this in the coming week. In particular, the following still needs to be done:

- [ ] **Use the`.single` character class as well.** 
When classes are used, the prefilter is currently not activated.
- [x] **Guarantee that the resulting array does not contain duplicates.** 
This needs to be done in the `.classes` and `.alternate` case, and will make the prefilter more efficient. In fact, currently there are regressions with respect to the one character prefilter: regexes with lots of alternatives with the same starting character will not activate the prefilter, since the array of starting characters will be too large.
For `.alternate`, the current code simply concatenates the `firstChars` of both options. I will need a good way to merge arrays which removes duplicates and for which the necessary theorems exist. I could not find this in the standard library yet. Worst case, I'll try to write this myself.
- [ ] **Proof golfing.**
The proof of `curr_of_captures_of_firstChars_some` can probably be cleaned up a bit. For this, the final implementation of `firstChars` should be finished.

Feel free to give some feedback!