### PR TITLE
Add NFA visualization support based on ProofWidgets and Penrose

### DIFF
--- a/correctness/RegexCorrectness/Display/NFADisplay.lean
+++ b/correctness/RegexCorrectness/Display/NFADisplay.lean
@@ -1,0 +1,121 @@
+import ProofWidgets.Component.PenroseDiagram
+import ProofWidgets.Component.HtmlDisplay
+import Regex.Regex
+import Regex.Data.Anchor
+import Regex.Data.Classes
+import Regex.Syntax.Parser
+
+open Lean Meta ProofWidgets Jsx Regex.Syntax.Parser
+open scoped Jsx in
+
+def epsilon : String := "\\epsilon"
+
+def isNeighbor (i j : Nat) : String :=
+  if i - j == 1 then "TRUE" else "FALSE"
+
+def escapeLabel (label : String) : String :=
+  label.replace "_" "\\_"
+
+def labelElement (elemLabel label : String) : String :=
+  if label = "$" then
+    s!"Label {elemLabel} \"{label}\"\n"
+  else if label = "^" then
+    s!"Label {elemLabel} ${label}\\wedge$\n"
+  else if label = epsilon then
+    s!"Label {elemLabel} ${label}$\n"
+  else
+    s!"Label {elemLabel} $\\text\{{escapeLabel label}}$\n"
+
+def createNode (i : Nat) : String :=
+  s!"Let n{i} := Node(\"{i}\")\n"
+
+def labelNode (i : Nat) (label : String) : String :=
+  labelElement s!"n{i}" label
+
+def declareStartNode (i : Nat) : String :=
+  s!"StartNode(n{i})\n"
+
+def relateSuccessorNodes (i : Nat) : String :=
+  s!"Successor(n{i}, n{i - 1})\n"
+
+def declareDoneNode (i : Nat) : String :=
+  s!"DoneNode(n{i})\n"
+
+def createTransition (i j : Nat) (label : String) : String :=
+  let transition := s!"Let t_{i}_{j} := Transition(n{i}, n{j}, {isNeighbor i j})\n"
+  let transitionLabel := labelElement s!"t_{i}_{j}" label
+  transition ++ transitionLabel
+
+-- This function converts an NFA representation of a regex into a Penrose substance string.
+-- It generates nodes, transitions, and labels for the NFA.
+-- The nodes are created based on the NFA's structure, and transitions are defined based on
+-- the connections between nodes. Labels are applied to nodes and transitions for clarity.
+-- The function also handles special cases like done nodes, save nodes, character transitions,
+-- epsilon transitions, split nodes, and anchor nodes.
+def nfaToSubstance (regex : Regex) : String := Id.run do
+  let mut sub := r###"
+Let TRUE := True()
+Let FALSE := False()
+"###
+  for i in [0:regex.nfa.nodes.size] do
+    sub := sub ++ createNode i
+    if i > 0 then sub := sub ++ relateSuccessorNodes i
+
+  sub := sub ++ declareStartNode regex.nfa.start
+
+  for h : i in [0:regex.nfa.nodes.size] do
+    let node := regex.nfa.nodes[i]
+    match node with
+    | .done =>
+        sub := sub ++ labelNode i "done"
+        sub := sub ++ declareDoneNode i
+    | .save pos next =>
+        sub := sub ++ labelNode i s!"save {pos} {next}"
+        sub := sub ++ createTransition i next epsilon
+    | .char ch next =>
+        sub := sub ++ labelNode i s!"char '{ch}' {next}"
+        sub := sub ++ createTransition i next s!"{ch}"
+    | .epsilon next =>
+        sub := sub ++ labelNode i s!"epsilon {next}"
+        sub := sub ++ createTransition i next epsilon
+    | .split next₁ next₂ =>
+        sub := sub ++ labelNode i s!"split {next₁} {next₂}"
+        sub := sub ++ createTransition i next₁ epsilon
+        sub := sub ++ createTransition i next₂ epsilon
+    | .fail => ()
+    | .anchor a next =>
+        sub := sub ++ labelNode i s!"anchor {next}"
+        sub := sub ++ createTransition i next s!"{Anchor.toString a}"
+    | .sparse cs next =>
+        sub := sub ++ labelNode i s!"sparse {next}"
+        sub := sub ++ createTransition i next s!"{Classes.toString cs}"
+
+  return sub
+
+-- This function generates a Penrose diagram for the NFA representation of a regex.
+def mkNFADiagram (regex : Regex) : MetaM Html :=
+  return <PenroseDiagram
+      embeds={#[]}
+      dsl={include_str "NFAPenrose.domain"}
+      sty={include_str "NFAPenrose.style"}
+      sub={nfaToSubstance regex} />
+
+-- Use this for testing purposes. Sample regexes avauilable in  regex/tests/Test.lean
+def sampleRegex : Regex :=
+  --re! r##"a|"##
+  --re! r##"(?:|a)+"##
+  re! r##"[a-zA-Z0-9_]+@[a-zA-Z0-9]+\.[a-zA-Z]{2,}"##
+  -- re! r##"\w+"##
+  --re! r"\d{4}-\d{2}-\d{2}"
+  --re! r##"^\b"##
+  --re! r##"^\b$"##
+  --re! r##"(?:foo|bar|[A-Z])\b"##
+  --re! r##"(?:foo|bar|[A-Z])\B"##
+
+
+-- Uncomment the following lines to debug issues with the diagram
+-- def substance := nfaToSubstance sampleRegex
+-- #eval IO.println substance
+
+-- Place your cursor at the end of the following line to see the NFA diagram
+#html mkNFADiagram sampleRegex

--- a/correctness/RegexCorrectness/Display/NFADisplay.lean
+++ b/correctness/RegexCorrectness/Display/NFADisplay.lean
@@ -6,14 +6,15 @@ import Regex.Data.Classes
 import Regex.Syntax.Parser
 
 open Lean Meta ProofWidgets Jsx Regex.Syntax.Parser
-open scoped Jsx in
 
-def epsilon : String := "\\epsilon"
+namespace RegexCorrectness.Display.NFADisplay
 
-def isNeighbor (i j : Nat) : String :=
+private def epsilon : String := "\\epsilon"
+
+private def isNeighbor (i j : Nat) : String :=
   if i - j == 1 then "TRUE" else "FALSE"
 
-def escapeLabel (label : String) : String :=
+private def escapeLabel (label : String) : String :=
   label.replace "_" "\\_"
 
 def labelElement (elemLabel label : String) : String :=
@@ -26,22 +27,22 @@ def labelElement (elemLabel label : String) : String :=
   else
     s!"Label {elemLabel} $\\text\{{escapeLabel label}}$\n"
 
-def createNode (i : Nat) : String :=
+private def createNode (i : Nat) : String :=
   s!"Let n{i} := Node(\"{i}\")\n"
 
-def labelNode (i : Nat) (label : String) : String :=
+private def labelNode (i : Nat) (label : String) : String :=
   labelElement s!"n{i}" label
 
-def declareStartNode (i : Nat) : String :=
+private def declareStartNode (i : Nat) : String :=
   s!"StartNode(n{i})\n"
 
-def relateSuccessorNodes (i : Nat) : String :=
+private def relateSuccessorNodes (i : Nat) : String :=
   s!"Successor(n{i}, n{i - 1})\n"
 
-def declareDoneNode (i : Nat) : String :=
+private def declareDoneNode (i : Nat) : String :=
   s!"DoneNode(n{i})\n"
 
-def createTransition (i j : Nat) (label : String) : String :=
+private def createTransition (i j : Nat) (label : String) : String :=
   let transition := s!"Let t_{i}_{j} := Transition(n{i}, n{j}, {isNeighbor i j})\n"
   let transitionLabel := labelElement s!"t_{i}_{j}" label
   transition ++ transitionLabel
@@ -82,7 +83,8 @@ Let FALSE := False()
         sub := sub ++ labelNode i s!"split {next₁} {next₂}"
         sub := sub ++ createTransition i next₁ epsilon
         sub := sub ++ createTransition i next₂ epsilon
-    | .fail => ()
+    | .fail =>
+        sub := sub ++ labelNode i "fail"
     | .anchor a next =>
         sub := sub ++ labelNode i s!"anchor {next}"
         sub := sub ++ createTransition i next s!"{Anchor.toString a}"
@@ -100,17 +102,19 @@ def mkNFADiagram (regex : Regex) : MetaM Html :=
       sty={include_str "NFAPenrose.style"}
       sub={nfaToSubstance regex} />
 
+end RegexCorrectness.Display.NFADisplay
+
 -- Use this for testing purposes. Sample regexes avauilable in  regex/tests/Test.lean
 def sampleRegex : Regex :=
   --re! r##"a|"##
   --re! r##"(?:|a)+"##
-  re! r##"[a-zA-Z0-9_]+@[a-zA-Z0-9]+\.[a-zA-Z]{2,}"##
-  -- re! r##"\w+"##
+  --re! r##"[a-zA-Z0-9_]+@[a-zA-Z0-9]+\.[a-zA-Z]{2,}"##
+  --re! r##"\w+"##
   --re! r"\d{4}-\d{2}-\d{2}"
   --re! r##"^\b"##
   --re! r##"^\b$"##
   --re! r##"(?:foo|bar|[A-Z])\b"##
-  --re! r##"(?:foo|bar|[A-Z])\B"##
+  re! r##"(?:foo|bar|[A-Z])\B"##
 
 
 -- Uncomment the following lines to debug issues with the diagram
@@ -118,4 +122,5 @@ def sampleRegex : Regex :=
 -- #eval IO.println substance
 
 -- Place your cursor at the end of the following line to see the NFA diagram
+open RegexCorrectness.Display.NFADisplay
 #html mkNFADiagram sampleRegex

--- a/correctness/RegexCorrectness/Display/NFADisplay.lean
+++ b/correctness/RegexCorrectness/Display/NFADisplay.lean
@@ -15,7 +15,7 @@ private def isNeighbor (i j : Nat) : String :=
   if i - j == 1 then "TRUE" else "FALSE"
 
 private def escapeLabel (label : String) : String :=
-  label.replace "_" "\\_"
+  label.replace "\\" "\\\\" |>.replace "_" "\\_"
 
 def labelElement (elemLabel label : String) : String :=
   if label = "$" then

--- a/correctness/RegexCorrectness/Display/NFAPenrose.domain
+++ b/correctness/RegexCorrectness/Display/NFAPenrose.domain
@@ -1,0 +1,33 @@
+type Boolean
+
+type True <: Boolean
+constructor True()
+
+type False <: Boolean
+constructor False()
+
+type Node
+
+-- Node: the constructor for Node type
+-- offset: index of the node in the nodes array
+-- strOffset: string value of the offset
+constructor Node(String offset)
+
+type Transition
+-- Transition: constructor
+-- begin: offset of the starting node for the transition
+-- end: offset of the ending node for the transition
+-- isNeighbor: True if end - begin == 1, False otherwise; indicates if the offsets are neighboring
+constructor Transition(Node begin, Node end, Boolean isNeighbor)
+
+-- the offset of starting node
+predicate StartNode(Node)
+
+-- the offset of done node
+predicate DoneNode(Node)
+
+-- predicate relating two successive nodes in the nodes array
+-- this is used for drawing the nodes in the appropriate order
+-- thisNodeOffset: off set of current node
+-- successorNodeOffset: offset of the next node
+predicate Successor(Node thisNode, Node successorNode)

--- a/correctness/RegexCorrectness/Display/NFAPenrose.style
+++ b/correctness/RegexCorrectness/Display/NFAPenrose.style
@@ -74,7 +74,7 @@ where t := Transition(u, v, b);
   vec2 p0 = x0
   vec2 p2 = x2 - 30*w + 10*n
   vec2 mid = (p0+p2)/2
-  vec2 p1 = mid + distance * 0.1 * n
+  vec2 p1 = mid + distance * 0.15 * n
 
   shape t.shape = Path {
     d: interpolateQuadraticFromPoints("open", p0, p1, p2)

--- a/correctness/RegexCorrectness/Display/NFAPenrose.style
+++ b/correctness/RegexCorrectness/Display/NFAPenrose.style
@@ -1,0 +1,122 @@
+-- Style file for visualizing an NFA
+globals {
+  radius         = 25
+  topAlign       = 30
+  nodeSeparation = 250
+}
+
+colors {
+  white      = rgba(1., 1., 1., 1.)
+  lightGray  = rgba(.8, .8, .8, 1.)
+  mediumGray = rgba(.6, .6, .6, 1.)
+  darkGray   = rgba(.4, .4, .4, 1.)
+  paleGray   = rgba(0, 0, 0, 0.1)
+  black      = rgba(0, 0, 0, 1)
+}
+
+-- draw each node as a circle
+forall Node n
+{
+  -- draw the node as a shaded circle
+  n.shape = Circle {
+    r: globals.radius -- radius
+    fillColor: colors.lightGray
+    strokeColor: colors.mediumGray
+    strokeWidth: 1
+  }
+
+  n.x = n.shape.center[0]
+  n.y = n.shape.center[1]
+
+  -- draw the node label inside the node
+  n.labelText = Equation {
+     string: n.label
+     center: n.shape.center
+     fontSize: "10px"
+     fillColor: colors.darkGray
+  }
+}
+
+-- draw a circle around the done node
+forall Node node
+where DoneNode (node)
+{
+  shape doneMarker = Circle {
+    center : node.shape.center
+    r : 1.5 * node.shape.r
+    fillColor : colors.paleGray
+  }
+}
+
+forall Node u; Node v
+where Successor (u, v)
+{
+  -- ensure all node have their centers with same y coordinate
+  ensure equal(u.y, v.y)
+
+  --  ensure successive nodes are separated by 100
+  ensure equal(v.x - u.x, globals.nodeSeparation)
+}
+
+-- draw transitions for non neighboring nodes
+forall Node u; Node v; Transition t; False b
+where t := Transition(u, v, b);
+{
+  -- draw an arrow from u to v
+  vec2 x0 = u.shape.center
+  vec2 x2 = v.shape.center
+  scalar distance = norm(x2 - x0)
+  vec2 w = (x2-x0)/distance -- unit vector from u to v
+  vec2 n = rot90(w) -- unit normal
+  -- calculate p0, p1, p2 for quadratic interpolated curve
+  -- the coefficients are derived by trial and error, looking at the results
+  -- to see what looks like a good curve.
+  vec2 p0 = x0
+  vec2 p2 = x2 - 30*w + 10*n
+  vec2 mid = (p0+p2)/2
+  vec2 p1 = mid + distance * 0.1 * n
+
+  shape t.shape = Path {
+    d: interpolateQuadraticFromPoints("open", p0, p1, p2)
+    endArrowhead: "straight"
+  }
+
+  layer t.shape below u.shape
+
+  -- draw the label on the transition arrow
+  t.text = Equation {
+    string: t.label
+    center: (p1[0], (p1[1] + 7))
+    fontSize: "10px"
+    fillColor: colors.darkGray
+  }
+}
+
+-- draw transitions for neighboring nodes
+forall Node u; Node v; Transition t; True b
+where t := Transition(u, v, b);
+{
+  t.shape = Line {
+    start: (u.x + u.shape.r, u.y)
+    end: (v.x - v.shape.r, v.y)
+    endArrowhead: "straight"
+  }
+
+  -- draw the label on the transition arrow
+  t.text = Equation {
+    string: t.label
+    center: ((t.shape.start[0] + (t.shape.end[0] - t.shape.start[0])*.5) , (t.shape.start[1] + 7))
+    fontSize: "10px"
+    fillColor: colors.darkGray
+  }
+}
+
+-- draw arrow pointing to start node
+forall Node u
+where StartNode(u) {
+  startArrow = Line {
+    start: (u.x - (u.shape.r + 20), u.y)
+    end: (u.x - u.shape.r, u.y)
+    endArrowhead: "straight"
+  }
+}


### PR DESCRIPTION
- Sample usage:

```lean
def sampleRegex : Regex := re! r##"a|"##

-- Place your cursor at the end of the following line to see the NFA diagram
#html mkNFADiagram sampleRegex
```

- Sample regex 1:

```
re! r##"a|"##
```

- Generated diagram 1:

<img width="1328" height="147" alt="image" src="https://github.com/user-attachments/assets/80d7061c-ea02-4350-abc0-c3760e8dac7a" />

- Sample regex 2:

```
re! r##"[a-zA-Z0-9_]+@[a-zA-Z0-9]+\.[a-zA-Z]{2,}"##
```

- Generated diagram 2:

<img width="1454" height="144" alt="image" src="https://github.com/user-attachments/assets/304b7abb-8b56-44b1-8406-117de77f544f" />

- Sample regex 3:

```
re! r##"^\b$"##
```

- Generated diagram 3:

<img width="1306" height="130" alt="image" src="https://github.com/user-attachments/assets/791ccdd9-d42b-4d4f-bbcc-9316dd69d540" />
