### PR TITLE
Optimize memory allocations

### DIFF
--- a/regex/Regex/VM/Basic.lean
+++ b/regex/Regex/VM/Basic.lean
@@ -27,47 +27,28 @@ def writeUpdate (node : NFA.Node) : Bool :=
   | .done | .char _ _ | .sparse _ _ => true
   | _ => false
 
+@[inline]
+def pushNext (σ : Strategy) (nfa : NFA) (it : Iterator) (node : NFA.Node) (inBounds : node.inBounds nfa.nodes.size) (update : σ.Update) (stack : εStack σ nfa) : εStack σ nfa :=
+  match node with
+  | .epsilon state' => (update, ⟨state', inBounds⟩) :: stack
+  | .split state₁ state₂ => (update, ⟨state₁, inBounds.1⟩) :: (update, ⟨state₂, inBounds.2⟩) :: stack
+  | .save offset state' => (σ.write update offset it.pos, ⟨state', inBounds⟩) :: stack
+  | .anchor a state' =>
+    if a.test it then
+      (update, ⟨state', inBounds⟩) :: stack
+    else
+      stack
+  | .done => stack
+  | .fail => stack
+  | .char _ _ => stack
+  | .sparse _ _ => stack
+
 end εClosure
-
-structure εClosureExploreResult (σ : Strategy) (nfa : NFA) where
-  matched : Option σ.Update
-  states : SparseSet nfa.nodes.size
-  updates : Vector σ.Update nfa.nodes.size
-  stack : εStack σ nfa
-
-def εClosureExplore (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
-  (matched : Option σ.Update) (states : SparseSet nfa.nodes.size) (updates : Vector σ.Update nfa.nodes.size)
-  (update : σ.Update) (state : Fin nfa.nodes.size) (stack : εStack σ nfa) :
-  εClosureExploreResult σ nfa :=
-  if mem : state ∈ states then
-    ⟨matched, states, updates, stack⟩
-  else
-    let node := nfa[state]
-    let matched' := if node.isDone then matched <|> update else matched
-    let states' := states.insert state mem
-    let updates' := if εClosure.writeUpdate node then updates.set state update else updates
-    have : states'.measure < states.measure := SparseSet.lt_measure_insert' mem
-    match hn : node with
-    | .epsilon state' => εClosureExplore σ nfa wf it matched' states' updates' update ⟨state', wf.inBounds' state hn⟩ stack
-    | .split state₁ state₂ => εClosureExplore σ nfa wf it matched' states' updates' update ⟨state₁, (wf.inBounds' state hn).1⟩ ((update, ⟨state₂, (wf.inBounds' state hn).2⟩) :: stack)
-    | .save offset state' => εClosureExplore σ nfa wf it matched' states' updates' (σ.write update offset it.pos) ⟨state', wf.inBounds' state hn⟩ stack
-    | .anchor a state' =>
-      if a.test it then
-        εClosureExplore σ nfa wf it matched' states' updates' update ⟨state', wf.inBounds' state hn⟩ stack
-      else
-        ⟨matched', states', updates', stack⟩
-    | .done => ⟨matched', states', updates', stack⟩
-    | .fail => ⟨matched', states', updates', stack⟩
-    | .char _ _ => ⟨matched', states', updates', stack⟩
-    | .sparse _ _ => ⟨matched', states', updates', stack⟩
-termination_by states.measure
 
 structure εClosureResult (σ : Strategy) (nfa : NFA) where
   matched : Option σ.Update
   states : SparseSet nfa.nodes.size
   updates : Vector σ.Update nfa.nodes.size
-
-instance {σ : Strategy} {nfa : NFA} : Inhabited (εClosureResult σ nfa) := ⟨⟨.none, .empty, .replicate _ σ.empty⟩⟩
 
 /--
 Visit all ε-transitions from the states in the stack, updating `next.states` when the new state is
@@ -75,16 +56,23 @@ Visit all ε-transitions from the states in the stack, updating `next.states` wh
 match is found.
 -/
 -- Once we have the new compiler, we may want to test specialization by `@[specialize σ]`.
-partial def εClosure (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
+def εClosure (σ : Strategy) (nfa : NFA) (wf : nfa.WellFormed) (it : Iterator)
   (matched : Option σ.Update) (states : SparseSet nfa.nodes.size) (updates : Vector σ.Update nfa.nodes.size) (stack : εStack σ nfa) :
   εClosureResult σ nfa :=
   match stack with
   | [] => ⟨matched, states, updates⟩
   | (update, state) :: stack' =>
-    let ⟨matched', states', updates', stack''⟩ := εClosureExplore σ nfa wf it matched states updates update state stack'
-    -- TODO: prove that `(state ∈ states → states' = states ∧ stack' < stack) ∧ (state ∉ states → states'.measure < states.measure)`
-    -- Probably it's easier to handle termination if we assume `state ∉ states` in εClosureExplore.
-    εClosure σ nfa wf it matched' states' updates' stack''
+    if mem : state ∈ states then
+      εClosure σ nfa wf it matched states updates stack'
+    else
+      let node := nfa[state]
+      let matched' := if node.isDone then matched <|> update else matched
+      let states' := states.insert state mem
+      let updates' := if εClosure.writeUpdate node then updates.set state update else updates
+      let stack'' := εClosure.pushNext σ nfa it node (wf.inBounds state) update stack'
+      have : states'.measure < states.measure := SparseSet.lt_measure_insert' mem
+      εClosure σ nfa wf it matched' states' updates' stack''
+termination_by (states.measure, stack)
 
 /--
 If the given state can make a transition on the current character of `it`, make the transition and


### PR DESCRIPTION
We found that allocation and deallocation of Lean objects took significant (~50%) of the time when benchmarking the `main`. The branch tried to reduce the allocation by

1. Stopping bundling data in `SearchState`
2. Introducing `εClosureResult` (one allocation) instead of `Option σ.Update × SparseSet nfa.nodes.size × Vector σ.Update nfa.nodes.size` (two allocations)
3. Optimizing the pattern which `εClosure` pops the item from the stack right after pushing the very item
    * It turned out this **slowed down** the algorithm

We can observe that reduced allocation made the matching 3-20% faster.

| benchmark                                     | engine | 2025-09-25-v4.23.0-28454366.csv | 2025-09-25-v4.23.0-8e0cc785.csv |
|-----------------------------------------------|--------|---------------------------------|---------------------------------|
| curated/01-literal/sherlock-en                | lean   | 8.9 MB/s (1.09x)                 | **9.7 MB/s (1.00x)**            |
| curated/01-literal/sherlock-ru                | lean   | 28.2 MB/s (1.03x)                | **29.1 MB/s (1.00x)**           |
| curated/01-literal/sherlock-zh                | lean   | 28.2 MB/s (1.06x)                | **29.9 MB/s (1.00x)**           |
| curated/02-literal-alternate/sherlock-en      | lean   | 2.2 MB/s (1.17x)                 | **2.6 MB/s (1.00x)**            |
| curated/02-literal-alternate/sherlock-ru      | lean   | 3.9 MB/s (1.17x)                 | **4.6 MB/s (1.00x)**            |
| curated/02-literal-alternate/sherlock-zh      | lean   | 5.4 MB/s (1.18x)                 | **6.3 MB/s (1.00x)**            |
| curated/06-cloud-flare-redos/original         | lean   | 1690.8 KB/s (1.16x)              | **1969.3 KB/s (1.00x)**         |
| curated/06-cloud-flare-redos/simplified-short | lean   | 2.1 MB/s (1.19x)                 | **2.5 MB/s (1.00x)**            |
| curated/06-cloud-flare-redos/simplified-long  | lean   | 2.2 MB/s (1.19x)                 | **2.6 MB/s (1.00x)**            |
| curated/07-unicode-character-data/parse-line  | lean   | 2.2 MB/s (1.12x)                 | **2.4 MB/s (1.00x)**            |
| curated/07-unicode-character-data/compile     | lean   | **19.03us (1.00x)**              | 19.15us (1.01x)                 |
| curated/08-words/all-english                  | lean   | 3.0 MB/s (1.10x)                 | **3.3 MB/s (1.00x)**            |
| curated/08-words/long-english                 | lean   | 5.1 MB/s (1.09x)                 | **5.5 MB/s (1.00x)**            |
| curated/09-aws-keys/quick                     | lean   | 18.1 MB/s (1.09x)                | **19.8 MB/s (1.00x)**           |
| curated/09-aws-keys/compile-quick             | lean   | 8.13us (1.00x)                   | **8.09us (1.00x)**              |
| curated/10-bounded-repeat/letters-en          | lean   | 3.7 MB/s (1.07x)                 | **3.9 MB/s (1.00x)**            |
| curated/11-unstructured-to-json/extract       | lean   | 2.3 MB/s (1.14x)                 | **2.6 MB/s (1.00x)**            |
| curated/11-unstructured-to-json/compile       | lean   | **12.09us (1.00x)**              | 12.10us (1.00x)                 |
| curated/14-quadratic/1x                       | lean   | 116.0 KB/s (1.16x)               | **134.0 KB/s (1.00x)**          |
| curated/14-quadratic/2x                       | lean   | 57.8 KB/s (1.20x)                | **69.3 KB/s (1.00x)**           |
| curated/14-quadratic/10x                      | lean   | 12.3 KB/s (1.06x)                | **13.1 KB/s (1.00x)**           |
| curated/03-date/ascii                         | lean   | -                               | **58.9 KB/s (1.00x)**           |
| curated/03-date/unicode                       | lean   | -                               | **58.7 KB/s (1.00x)**           |
