### PR TITLE
Progress-checking tree

### DIFF
--- a/correctness/RegexCorrectness/Backtracker/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Tactic.DepRewrite
 
 open Regex.Data (BitMatrix BVPos)
 open String (Pos)
+open Regex.Backtracker.captureNextAux (pushNext)
 
 namespace Regex.Backtracker
 
@@ -155,7 +156,8 @@ theorem fun_cases' (σ : Strategy s) (nfa : NFA) (wf : nfa.WellFormed) (startPos
 
 end captureNextAux.pushNext
 
-theorem captureNextAux.induct' {s : String} (σ : Strategy s) (nfa : NFA) (wf : nfa.WellFormed) (startPos : Pos s)
+/-- Induction principle for `captureNextAux` (public name; avoids clashing with the private `captureNextAux.induct'`). -/
+theorem captureNextAuxRecOn {s : String} (σ : Strategy s) (nfa : NFA) (wf : nfa.WellFormed) (startPos : Pos s)
   (motive : BitMatrix nfa.size (startPos.remainingBytes + 1) → List (StackEntry σ nfa startPos) → Prop)
   (base : ∀ (visited : BitMatrix nfa.size (startPos.remainingBytes + 1)), motive visited [])
   (visited : ∀ (visited : BitMatrix nfa.size (startPos.remainingBytes + 1)) (update : σ.Update) (state : Fin nfa.size) (pos : BVPos startPos) (stack' : List (StackEntry σ nfa startPos)),

--- a/correctness/RegexCorrectness/Backtracker/Model/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Model/Basic.lean
@@ -1,0 +1,176 @@
+module
+
+public import Regex.NFA.Basic
+public import Regex.Strategy
+public import Mathlib.Data.Finset.Basic
+public import Mathlib.Data.Finset.Insert
+public import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Data.Finite.Prod
+import Mathlib.Tactic.DepRewrite
+
+open String (Pos)
+
+public section
+
+namespace Regex.Backtracker.Model
+
+private scoped instance {nfa : NFA} : Finite (Fin nfa.size) := sorry
+private scoped instance {s : String} : Finite (Pos s) := sorry
+private noncomputable scoped instance {s : String} {nfa : NFA} : Fintype (Fin nfa.size × Pos s) := Fintype.ofFinite _
+
+private noncomputable abbrev argUniv (s : String) (nfa : NFA) : Finset (Fin nfa.size × Pos s) := Finset.univ
+
+def captureNextAux {s : String} (σ : Strategy s) (nfa : NFA) (wf : nfa.WellFormed) (visited : Finset (Fin nfa.size × Pos s))
+  (update : σ.Update) (state : Fin nfa.size) (pos : Pos s) :
+  (Pos s × Option σ.Update × { visited' : Finset (Fin nfa.size × Pos s) // visited ⊆ visited' }) :=
+  if hmem : (state, pos) ∈ visited then
+    (pos, .none, ⟨visited, by simp⟩)
+  else
+    let visited' := insert (state, pos) visited
+    have lt₁ : visited.card < (argUniv s nfa).card :=
+      Finset.card_lt_card (Finset.ssubset_def.mp ⟨Finset.subset_univ visited, (by grind)⟩)
+    have : (argUniv s nfa).card - visited'.card < (argUniv s nfa).card - visited.card := by
+      grind only [= Finset.card_insert_of_notMem]
+    match hn : nfa[state] with
+    | .done => (pos, .some update, ⟨visited', by grind⟩)
+    | .fail => (pos, .none, ⟨visited, by simp⟩)
+    | .epsilon state' =>
+      let (pos, result, visited'') := captureNextAux σ nfa wf visited' update ⟨state', wf.inBounds' state state.isLt hn⟩ pos
+      (pos, result, ⟨visited'', by grind⟩)
+    | .split state₁ state₂ =>
+      have isLt : state₁ < nfa.size ∧ state₂ < nfa.size := wf.inBounds' state state.isLt hn
+      match captureNextAux σ nfa wf visited' update ⟨state₁, isLt.1⟩ pos with
+      | (pos, .some update', visited') => (pos, .some update', ⟨visited', by grind⟩)
+      | (_pos, .none, visited'') =>
+        have : (argUniv s nfa).card - visited''.val.card < (argUniv s nfa).card - visited.card := by
+          have : visited.card < visited''.val.card :=
+            calc visited.card
+              _ < visited'.card := by grind only
+              _ ≤ visited''.val.card := Finset.card_le_card visited''.property
+          grind
+        let (pos, result, visited''') := captureNextAux σ nfa wf visited'' update ⟨state₂, isLt.2⟩ pos
+        (pos, result, ⟨visited''', by grind⟩)
+    | .save offset state' =>
+      let (pos, result, visited'') := captureNextAux σ nfa wf visited' (σ.write update offset pos) ⟨state', wf.inBounds' state state.isLt hn⟩ pos
+      (pos, result, ⟨visited'', by grind⟩)
+    | .anchor a state' =>
+      if a.test pos then
+        let (pos, result, visited'') := captureNextAux σ nfa wf visited' update ⟨state', wf.inBounds' state state.isLt hn⟩ pos
+        (pos, result, ⟨visited'', by grind⟩)
+      else
+        (pos, .none, ⟨visited', by grind⟩)
+    | .char c state' =>
+      if h : ∃ ne : pos ≠ s.endPos, pos.get ne = c then
+        let (pos, result, visited'') := captureNextAux σ nfa wf visited' update ⟨state', wf.inBounds' state state.isLt hn⟩ (pos.next h.1)
+        (pos, result, ⟨visited'', by grind⟩)
+      else
+        (pos, .none, ⟨visited', by grind⟩)
+    | .sparse cs state' =>
+      if h : ∃ ne : pos ≠ s.endPos, pos.get ne ∈ cs then
+        let (pos, result, visited'') := captureNextAux σ nfa wf visited' update ⟨state', wf.inBounds' state state.isLt hn⟩ (pos.next h.1)
+        (pos, result, ⟨visited'', by grind⟩)
+      else
+        (pos, .none, ⟨visited', by grind⟩)
+termination_by (argUniv s nfa).card - visited.card
+
+section
+
+variable {s : String} {σ : Strategy s} {nfa : NFA} {wf : nfa.WellFormed} {visited : Finset (Fin nfa.size × Pos s)}
+  {update : σ.Update} {state : Fin nfa.size} {pos : Pos s} {offset state' state₁ state₂ : Nat}
+  {a : Regex.Data.Anchor} {c : Char} {cs : Regex.Data.Classes}
+
+@[grind =]
+theorem captureNextAux_visited (hmem : (state, pos) ∈ visited) :
+  captureNextAux σ nfa wf visited update state pos = (pos, .none, ⟨visited, by simp⟩) := by
+  simp [captureNextAux, hmem]
+
+@[grind =]
+theorem captureNextAux_done (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .done) :
+  captureNextAux σ nfa wf visited update state pos = (pos, .some update, ⟨insert (state, pos) visited, by simp⟩) := by
+  grind only [captureNextAux]
+
+@[grind =]
+theorem captureNextAux_fail (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .fail) :
+  captureNextAux σ nfa wf visited update state pos = (pos, .none, ⟨visited, by simp⟩) := by
+  grind only [captureNextAux]
+
+@[grind! .]
+theorem captureNextAux_epsilon (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .epsilon state') :
+  letI result := captureNextAux σ nfa wf (insert (state, pos) visited) update ⟨state', wf.inBounds' state state.isLt hn⟩ pos
+  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  grind only [captureNextAux]
+
+@[grind! .]
+theorem captureNextAux_split (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .split state₁ state₂) :
+  haveI isLt : state₁ < nfa.size ∧ state₂ < nfa.size := wf.inBounds' state state.isLt hn
+  letI result₁ := captureNextAux σ nfa wf (insert (state, pos) visited) update ⟨state₁, isLt.1⟩ pos
+  letI result₂ := captureNextAux σ nfa wf result₁.2.2 update ⟨state₂, isLt.2⟩ pos
+  captureNextAux σ nfa wf visited update state pos =
+    if result₁.2.1.isSome then
+      ⟨result₁.1, result₁.2.1, ⟨result₁.2.2, by grind⟩⟩
+    else
+      ⟨result₂.1, result₂.2.1, ⟨result₂.2.2, by grind⟩⟩ := by
+  conv =>
+    lhs
+    unfold captureNextAux
+  simp only [hmem, ↓reduceDIte]
+  rw! [hn]
+  grind [captureNextAux]
+
+@[grind! .]
+theorem captureNextAux_save (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .save offset state') :
+  haveI isLt : state' < nfa.size := wf.inBounds' state state.isLt hn
+  letI result := captureNextAux σ nfa wf (insert (state, pos) visited) (σ.write update offset pos) ⟨state', isLt⟩ pos
+  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  grind only [captureNextAux]
+
+@[grind! .]
+theorem captureNextAux_anchor_pos (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .anchor a state') (h : a.test pos) :
+  haveI isLt : state' < nfa.size := wf.inBounds' state state.isLt hn
+  letI result := captureNextAux σ nfa wf (insert (state, pos) visited) update ⟨state', isLt⟩ pos
+  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  grind only [captureNextAux]
+
+@[grind! .]
+theorem captureNextAux_anchor_neg (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .anchor a state') (h : ¬a.test pos) :
+  captureNextAux σ nfa wf visited update state pos = (pos, .none, ⟨insert (state, pos) visited, by simp⟩) := by
+  grind only [captureNextAux]
+
+@[grind! .]
+theorem captureNextAux_char_pos (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .char c state') (ne : pos ≠ s.endPos) (hc : pos.get ne = c) :
+  letI result := captureNextAux σ nfa wf (insert (state, pos) visited) update ⟨state', wf.inBounds' state state.isLt hn⟩ (pos.next ne)
+  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  conv =>
+    lhs
+    unfold captureNextAux
+  simp only [hmem, ↓reduceDIte]
+  rw! [hn]
+  simp [ne, hc]
+
+@[grind! .]
+theorem captureNextAux_char_neg (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .char c state') (h : pos = s.endPos ∨ ∃ ne : pos ≠ s.endPos, pos.get ne ≠ c) :
+  captureNextAux σ nfa wf visited update state pos = (pos, .none, ⟨insert (state, pos) visited, by simp⟩) := by
+  grind only [captureNextAux]
+
+@[grind! .]
+theorem captureNextAux_sparse_pos (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .sparse cs state') (ne : pos ≠ s.endPos) (hc : pos.get ne ∈ cs) :
+  letI result := captureNextAux σ nfa wf (insert (state, pos) visited) update ⟨state', wf.inBounds' state state.isLt hn⟩ (pos.next ne)
+  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  conv =>
+    lhs
+    unfold captureNextAux
+  simp only [hmem, ↓reduceDIte]
+  rw! [hn]
+  simp [ne, hc]
+
+@[grind! .]
+theorem captureNextAux_sparse_neg (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .sparse cs state') (h : pos = s.endPos ∨ ∃ ne : pos ≠ s.endPos, pos.get ne ∉ cs) :
+  captureNextAux σ nfa wf visited update state pos = (pos, .none, ⟨insert (state, pos) visited, by simp⟩) := by
+  grind only [captureNextAux]
+
+end
+
+end Regex.Backtracker.Model
+
+end

--- a/correctness/RegexCorrectness/Backtracker/Model/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Model/Basic.lean
@@ -36,7 +36,7 @@ def captureNextAux {s : String} (σ : Strategy s) (nfa : NFA) (wf : nfa.WellForm
       grind only [= Finset.card_insert_of_notMem]
     match hn : nfa[state] with
     | .done => (pos, .some update, ⟨visited', by grind⟩)
-    | .fail => (pos, .none, ⟨visited, by simp⟩)
+    | .fail => (pos, .none, ⟨visited', by grind⟩)
     | .epsilon state' =>
       let (pos, result, visited'') := captureNextAux σ nfa wf visited' update ⟨state', wf.inBounds' state state.isLt hn⟩ pos
       (pos, result, ⟨visited'', by grind⟩)
@@ -94,7 +94,7 @@ theorem captureNextAux_done (hmem : (state, pos) ∉ visited) (hn : nfa[state] =
 
 @[grind =]
 theorem captureNextAux_fail (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .fail) :
-  captureNextAux σ nfa wf visited update state pos = (pos, .none, ⟨visited, by simp⟩) := by
+  captureNextAux σ nfa wf visited update state pos = (pos, .none, ⟨insert (state, pos) visited, by simp⟩) := by
   grind only [captureNextAux]
 
 @[grind! .]

--- a/correctness/RegexCorrectness/Backtracker/Model/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Model/Basic.lean
@@ -100,7 +100,8 @@ theorem captureNextAux_fail (hmem : (state, pos) ∉ visited) (hn : nfa[state] =
 @[grind! .]
 theorem captureNextAux_epsilon (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .epsilon state') :
   letI result := captureNextAux σ nfa wf (insert (state, pos) visited) update ⟨state', wf.inBounds' state state.isLt hn⟩ pos
-  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  captureNextAux σ nfa wf visited update state pos =
+    ⟨result.1, result.2.1, ⟨result.2.2.val, by grind⟩⟩ := by
   grind only [captureNextAux]
 
 @[grind! .]
@@ -110,9 +111,9 @@ theorem captureNextAux_split (hmem : (state, pos) ∉ visited) (hn : nfa[state] 
   letI result₂ := captureNextAux σ nfa wf result₁.2.2 update ⟨state₂, isLt.2⟩ pos
   captureNextAux σ nfa wf visited update state pos =
     if result₁.2.1.isSome then
-      ⟨result₁.1, result₁.2.1, ⟨result₁.2.2, by grind⟩⟩
+      ⟨result₁.1, result₁.2.1, ⟨result₁.2.2.val, by grind⟩⟩
     else
-      ⟨result₂.1, result₂.2.1, ⟨result₂.2.2, by grind⟩⟩ := by
+      ⟨result₂.1, result₂.2.1, ⟨result₂.2.2.val, by grind⟩⟩ := by
   conv =>
     lhs
     unfold captureNextAux
@@ -124,14 +125,16 @@ theorem captureNextAux_split (hmem : (state, pos) ∉ visited) (hn : nfa[state] 
 theorem captureNextAux_save (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .save offset state') :
   haveI isLt : state' < nfa.size := wf.inBounds' state state.isLt hn
   letI result := captureNextAux σ nfa wf (insert (state, pos) visited) (σ.write update offset pos) ⟨state', isLt⟩ pos
-  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  captureNextAux σ nfa wf visited update state pos =
+    ⟨result.1, result.2.1, ⟨result.2.2.val, by grind⟩⟩ := by
   grind only [captureNextAux]
 
 @[grind! .]
 theorem captureNextAux_anchor_pos (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .anchor a state') (h : a.test pos) :
   haveI isLt : state' < nfa.size := wf.inBounds' state state.isLt hn
   letI result := captureNextAux σ nfa wf (insert (state, pos) visited) update ⟨state', isLt⟩ pos
-  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  captureNextAux σ nfa wf visited update state pos =
+    ⟨result.1, result.2.1, ⟨result.2.2.val, by grind⟩⟩ := by
   grind only [captureNextAux]
 
 @[grind! .]
@@ -142,7 +145,8 @@ theorem captureNextAux_anchor_neg (hmem : (state, pos) ∉ visited) (hn : nfa[st
 @[grind! .]
 theorem captureNextAux_char_pos (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .char c state') (ne : pos ≠ s.endPos) (hc : pos.get ne = c) :
   letI result := captureNextAux σ nfa wf (insert (state, pos) visited) update ⟨state', wf.inBounds' state state.isLt hn⟩ (pos.next ne)
-  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  captureNextAux σ nfa wf visited update state pos =
+    ⟨result.1, result.2.1, ⟨result.2.2.val, by grind⟩⟩ := by
   conv =>
     lhs
     unfold captureNextAux
@@ -158,7 +162,8 @@ theorem captureNextAux_char_neg (hmem : (state, pos) ∉ visited) (hn : nfa[stat
 @[grind! .]
 theorem captureNextAux_sparse_pos (hmem : (state, pos) ∉ visited) (hn : nfa[state] = .sparse cs state') (ne : pos ≠ s.endPos) (hc : pos.get ne ∈ cs) :
   letI result := captureNextAux σ nfa wf (insert (state, pos) visited) update ⟨state', wf.inBounds' state state.isLt hn⟩ (pos.next ne)
-  captureNextAux σ nfa wf visited update state pos = ⟨result.1, result.2.1, ⟨result.2.2, by grind⟩⟩ := by
+  captureNextAux σ nfa wf visited update state pos =
+    ⟨result.1, result.2.1, ⟨result.2.2.val, by grind⟩⟩ := by
   conv =>
     lhs
     unfold captureNextAux

--- a/correctness/RegexCorrectness/Backtracker/Model/Basic.lean
+++ b/correctness/RegexCorrectness/Backtracker/Model/Basic.lean
@@ -8,6 +8,7 @@ public import Mathlib.Data.Finset.Card
 import Mathlib.Data.Fintype.EquivFin
 import Mathlib.Data.Finite.Prod
 import Mathlib.Tactic.DepRewrite
+import RegexCorrectness.Data.String
 
 open String (Pos)
 
@@ -15,8 +16,9 @@ public section
 
 namespace Regex.Backtracker.Model
 
-private scoped instance {nfa : NFA} : Finite (Fin nfa.size) := sorry
-private scoped instance {s : String} : Finite (Pos s) := sorry
+private scoped instance {nfa : NFA} : Finite (Fin nfa.size) := Finite.of_fintype (Fin nfa.size)
+private scoped instance {s : String} : Fintype (Pos s) := ⟨⟨Pos.allPositions s, Pos.nodup_allPositions s⟩, Pos.mem_allPositions s⟩
+private scoped instance {s : String} : Finite (Pos s) := Finite.of_fintype (Pos s)
 private noncomputable scoped instance {s : String} {nfa : NFA} : Fintype (Fin nfa.size × Pos s) := Fintype.ofFinite _
 
 private noncomputable abbrev argUniv (s : String) (nfa : NFA) : Finset (Fin nfa.size × Pos s) := Finset.univ

--- a/correctness/RegexCorrectness/Backtracker/Model/Refinement.lean
+++ b/correctness/RegexCorrectness/Backtracker/Model/Refinement.lean
@@ -1,0 +1,227 @@
+module
+
+public import Regex.Backtracker.Basic
+import all Regex.Backtracker.Basic
+public import RegexCorrectness.Backtracker.Model.Basic
+import all RegexCorrectness.Backtracker.Model.Basic
+import all RegexCorrectness.Backtracker.Basic
+import RegexCorrectness.Data.BVPos
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Finset.Basic
+import Mathlib.Tactic
+
+open String (Pos)
+open Regex (NFA)
+open Regex.Data (BitMatrix BVPos Anchor)
+open Regex.Backtracker (StackEntry)
+open Regex.Backtracker.captureNextAux (pushNext)
+
+namespace Regex.Backtracker.Model
+
+noncomputable def mapMatrix {s : String} {nfa : NFA} {startPos : Pos s} (matrix : BitMatrix nfa.size (startPos.remainingBytes + 1)) :
+  Finset (Fin nfa.size × Pos s) :=
+  { p : Fin nfa.size × Pos s | ∃ le : startPos ≤ p.2, matrix.get p.1 (BVPos.index ⟨p.2, le⟩) }
+
+@[grind =, simp]
+theorem mem_mapMatrix_iff {s : String} {nfa : NFA} {startPos : Pos s}
+  (i : Fin nfa.size) (p : Pos s) (matrix : BitMatrix nfa.size (startPos.remainingBytes + 1)) :
+  (i, p) ∈ mapMatrix matrix ↔ ∃ le : startPos ≤ p, matrix.get i (BVPos.index ⟨p, le⟩) := by
+  grind [mapMatrix]
+
+@[grind =, simp]
+theorem mapMatrix_set {s : String} {nfa : NFA} {startPos : Pos s}
+  (i : Fin nfa.size) (bp : BVPos startPos) (matrix : BitMatrix nfa.size (startPos.remainingBytes + 1)) :
+  mapMatrix (matrix.set i bp.index) = insert ⟨i, bp.current⟩ (mapMatrix matrix) := by
+  ext ⟨j, pj⟩
+  rw [mem_mapMatrix_iff j pj _]
+  apply Iff.intro
+  . intro ⟨le, mem⟩
+    simp only [BitMatrix.get_set, Bool.decide_or, Bool.decide_and, Bool.decide_eq_true,
+      Bool.or_eq_true, Bool.and_eq_true, decide_eq_true_eq] at mem
+    match mem with
+    | .inl ⟨eq₁, eq₂⟩ => simp [eq₁, BVPos.ext_index eq₂]
+    | .inr mem => simp [le, mem]
+  . intro mem
+    simp only [Finset.mem_insert, Prod.mk.injEq, mem_mapMatrix_iff] at mem
+    match mem with
+    | .inl ⟨eq₁, eq₂⟩ =>
+      have le : startPos ≤ pj := eq₂ ▸ bp.le
+      have eq₂' : bp = ⟨pj, le⟩ := by simp [eq₂]
+      exact ⟨le, by simp [BitMatrix.get_set, eq₁, eq₂']⟩
+    | .inr ⟨le, mem⟩ => exact ⟨le, by simp [BitMatrix.get_set, mem]⟩
+
+@[grind =, simp]
+theorem mem_mapMatrix_iff_bvpos {s : String} {nfa : NFA} {startPos : Pos s}
+    (state : Fin nfa.size) (bp : BVPos startPos) (matrix : BitMatrix nfa.size (startPos.remainingBytes + 1)) :
+    (state, bp.current) ∈ mapMatrix matrix ↔ matrix.get state bp.index := by
+  rw [mem_mapMatrix_iff]
+  constructor
+  · intro ⟨le, h⟩
+    rw [BVPos.index_eq_of_le le bp.le] at h
+    simpa using h
+  · intro h
+    exact ⟨bp.le, by simpa [BVPos.index_eq_of_le bp.le bp.le] using h⟩
+
+theorem mapMatrix_subset_of_forall_get {s : String} {nfa : NFA} {startPos : Pos s}
+    {m m' : BitMatrix nfa.size (startPos.remainingBytes + 1)}
+    (h : ∀ (i : Fin nfa.size) (j : Fin (startPos.remainingBytes + 1)), m.get i j → m'.get i j) :
+    mapMatrix m ⊆ mapMatrix m' := by
+  intro p hp
+  rw [mem_mapMatrix_iff] at hp ⊢
+  obtain ⟨le, hp⟩ := hp
+  refine ⟨le, ?_⟩
+  exact h _ _ hp
+
+/--
+Interpret a stack as successive `captureNextAux` calls: the model explores the top entry fully,
+then continues with the rest of the stack on failure.
+-/
+noncomputable def modelRunStack {s : String} (σ : Strategy s) (nfa : NFA) (wf : nfa.WellFormed) (startPos : Pos s)
+  (visited : Finset (Fin nfa.size × Pos s)) (stack : List (StackEntry σ nfa startPos)) :
+  Option σ.Update × Finset (Fin nfa.size × Pos s) :=
+  match stack with
+  | [] => (.none, visited)
+  | ⟨update, state, pos⟩ :: stack' =>
+    let x := Model.captureNextAux σ nfa wf visited update state pos.current
+    match x with
+    | (_, .some u, ⟨v, _⟩) => (.some u, v)
+    | (_, .none, ⟨v, _⟩) => modelRunStack σ nfa wf startPos v stack'
+
+@[simp, grind =]
+theorem modelRunStack_nil {s : String} {σ : Strategy s} {nfa : NFA} {wf : nfa.WellFormed} {startPos : Pos s}
+  {visited : Finset (Fin nfa.size × Pos s)} :
+  modelRunStack σ nfa wf startPos visited [] = (.none, visited) := by
+  simp [modelRunStack]
+
+@[simp, grind =]
+theorem modelRunStack_singleton {s : String} {σ : Strategy s} {nfa : NFA} {wf : nfa.WellFormed} {startPos : Pos s}
+    {visited : Finset (Fin nfa.size × Pos s)} {update : σ.Update} {state : Fin nfa.size} {bp : BVPos startPos} :
+    modelRunStack σ nfa wf startPos visited [⟨update, state, bp⟩] =
+      (Model.captureNextAux σ nfa wf visited update state bp.current).2.map id (·.val) := by
+  grind [modelRunStack]
+
+theorem modelRunStack_cons_visited {s : String} {σ : Strategy s} {nfa : NFA} {wf : nfa.WellFormed} {startPos : Pos s}
+    {visited : Finset (Fin nfa.size × Pos s)} {update : σ.Update} {state : Fin nfa.size} {bp : BVPos startPos}
+    {stack' : List (StackEntry σ nfa startPos)}
+    (hmem : (state, bp.current) ∈ visited) :
+    modelRunStack σ nfa wf startPos visited (⟨update, state, bp⟩ :: stack') =
+      modelRunStack σ nfa wf startPos visited stack' := by
+  simp [modelRunStack, Model.captureNextAux_visited hmem]
+
+theorem modelRunStack_cons_done {s : String} {σ : Strategy s} {nfa : NFA} {wf : nfa.WellFormed} {startPos : Pos s}
+    {visited : Finset (Fin nfa.size × Pos s)} {update : σ.Update} {state : Fin nfa.size} {bp : BVPos startPos}
+    {stack' : List (StackEntry σ nfa startPos)}
+    (hmem : (state, bp.current) ∉ visited) (hn : nfa[state] = .done) :
+    modelRunStack σ nfa wf startPos visited (⟨update, state, bp⟩ :: stack') =
+      (.some update, insert (state, bp.current) visited) := by
+  simp [modelRunStack, Model.captureNextAux_done hmem hn]
+
+theorem modelRunStack_cons_pushNext {s : String} {σ : Strategy s} {nfa : NFA} {wf : nfa.WellFormed} {startPos : Pos s}
+    {visited : Finset (Fin nfa.size × Pos s)} {update : σ.Update} {state : Fin nfa.size} {bp : BVPos startPos}
+    {stack' : List (StackEntry σ nfa startPos)}
+    (hmem : (state, bp.current) ∉ visited) (hn : nfa[state] ≠ .done) :
+    modelRunStack σ nfa wf startPos visited (⟨update, state, bp⟩ :: stack') =
+      modelRunStack σ nfa wf startPos (insert (state, bp.current) visited)
+        (pushNext σ nfa wf startPos stack' update state bp) := by
+  cases stack', update, state, bp using captureNextAux.pushNext.fun_cases' σ nfa wf startPos with
+  | done => contradiction
+  | fail stack' update state bp hn' =>
+    rw [captureNextAux.pushNext.fail hn']
+    simp [modelRunStack, Model.captureNextAux_fail hmem hn']
+  | epsilon stack' update state bp state' hn' =>
+    rw [captureNextAux.pushNext.epsilon hn']
+    grind [modelRunStack, Model.captureNextAux_epsilon hmem hn']
+  | split stack' update state bp state₁ state₂ hn' =>
+    rw [captureNextAux.pushNext.split hn']
+    conv =>
+      lhs
+      simp [modelRunStack]
+    rw [Model.captureNextAux_split hmem hn']
+    split_ifs with hsome
+    · simp [modelRunStack, Option.isSome_iff_exists] at hsome ⊢
+      obtain ⟨u, hu⟩ := hsome
+      grind
+    · simp only [Bool.not_eq_true] at hsome
+      grind [modelRunStack, Model.captureNextAux_split hmem hn']
+  | save stack' update state bp offset state' hn' =>
+    rw [captureNextAux.pushNext.save hn']
+    grind [modelRunStack, Model.captureNextAux_save hmem hn']
+  | anchor_pos stack' update state bp a state' hn' ht =>
+    rw [captureNextAux.pushNext.anchor_pos hn' ht]
+    grind [modelRunStack, Model.captureNextAux_anchor_pos hmem hn' ht]
+  | anchor_neg stack' update state bp a state' hn' ht =>
+    rw [captureNextAux.pushNext.anchor_neg hn' ht]
+    simp [modelRunStack, Model.captureNextAux_anchor_neg hmem hn' ht]
+  | char_pos stack' update state bp c state' hn' hne hc =>
+    rw [captureNextAux.pushNext.char_pos hn' hne hc]
+    have ne : bp.current ≠ s.endPos := by
+      simpa [BVPos.ne_end_iff_current_ne_end] using hne
+    have hc' : bp.current.get ne = c := by
+      simpa [Regex.Data.BVPos.get_eq_get] using hc
+    grind [modelRunStack, Model.captureNextAux_char_pos hmem hn' ne hc']
+  | char_neg stack' update state bp c state' hn' h =>
+    rw [captureNextAux.pushNext.char_neg hn' h]
+    have h' : bp.current = s.endPos ∨ ∃ ne : bp.current ≠ s.endPos, bp.current.get ne ≠ c := by
+      rcases h with heq | ⟨ne_bv, hc⟩
+      · have : bp.current = s.endPos := by
+          simpa [String.endBVPos, Regex.Data.BVPos.ext_iff] using congrArg Regex.Data.BVPos.current heq
+        exact .inl this
+      · exact .inr ⟨BVPos.ne_end_iff_current_ne_end.mp ne_bv, by simpa [Regex.Data.BVPos.get_eq_get] using hc⟩
+    simp [modelRunStack, Model.captureNextAux_char_neg hmem hn' h']
+  | sparse_pos stack' update state bp cs state' hn' hne hc =>
+    rw [captureNextAux.pushNext.sparse_pos hn' hne hc]
+    have ne : bp.current ≠ s.endPos := by
+      simpa [BVPos.ne_end_iff_current_ne_end] using hne
+    have hc' : bp.current.get ne ∈ cs := by
+      simpa [Regex.Data.BVPos.get_eq_get] using hc
+    grind [modelRunStack, Model.captureNextAux_sparse_pos hmem hn' ne hc']
+  | sparse_neg stack' update state bp cs state' hn' h =>
+    rw [captureNextAux.pushNext.sparse_neg hn' h]
+    have h' : bp.current = s.endPos ∨ ∃ ne : bp.current ≠ s.endPos, bp.current.get ne ∉ cs := by
+      rcases h with heq | ⟨ne_bv, hc⟩
+      · have : bp.current = s.endPos := by
+          simpa [String.endBVPos, Regex.Data.BVPos.ext_iff] using congrArg Regex.Data.BVPos.current heq
+        exact .inl this
+      · exact .inr ⟨BVPos.ne_end_iff_current_ne_end.mp ne_bv, by simpa [Regex.Data.BVPos.get_eq_get] using hc⟩
+    simp [modelRunStack, Model.captureNextAux_sparse_neg hmem hn' h']
+
+end Regex.Backtracker.Model
+
+namespace Regex.Backtracker
+
+open Regex.Backtracker.Model (mapMatrix mapMatrix_set mem_mapMatrix_iff_bvpos modelRunStack modelRunStack_nil
+  modelRunStack_singleton modelRunStack_cons_visited modelRunStack_cons_done
+  modelRunStack_cons_pushNext)
+
+theorem captureNextAux_refinesModelStack {s : String} {σ : Strategy s} {nfa : NFA} {wf : nfa.WellFormed}
+    {startPos : Pos s} (visited : BitMatrix nfa.size (startPos.remainingBytes + 1))
+    (stack : List (StackEntry σ nfa startPos)) :
+    modelRunStack σ nfa wf startPos (mapMatrix visited) stack =
+      (captureNextAux σ nfa wf startPos visited stack).map id mapMatrix := by
+  induction visited, stack using captureNextAuxRecOn σ nfa wf startPos with
+  | base visited =>
+    simp [captureNextAux_base, modelRunStack_nil]
+  | visited visited update state bp stack' mem ih =>
+    have hmem : (state, bp.current) ∈ mapMatrix visited := mem_mapMatrix_iff_bvpos state bp visited |>.mpr mem
+    simpa [captureNextAux_visited mem, modelRunStack_cons_visited hmem] using ih
+  | done visited update state bp stack' mem hn =>
+    have hmem : (state, bp.current) ∉ mapMatrix visited := by
+      intro h
+      exact mem (mem_mapMatrix_iff_bvpos state bp visited |>.mp h)
+    simp [captureNextAux_done mem hn, mapMatrix_set, modelRunStack_cons_done hmem hn]
+  | next visited update state bp stack' mem hn ih =>
+    have hmem : (state, bp.current) ∉ mapMatrix visited := by
+      intro h
+      exact mem (mem_mapMatrix_iff_bvpos state bp visited |>.mp h)
+    simpa [captureNextAux_next mem hn, mapMatrix_set, modelRunStack_cons_pushNext hmem hn] using ih
+
+theorem captureNextAux_refinesModel {s : String} {σ : Strategy s} {nfa : NFA} {wf : nfa.WellFormed}
+    {startPos : Pos s} (visited : BitMatrix nfa.size (startPos.remainingBytes + 1))
+    (update : σ.Update) (state : Fin nfa.size) (bp : BVPos startPos) :
+    (captureNextAux σ nfa wf startPos visited [⟨update, state, bp⟩]).map id mapMatrix =
+      (Model.captureNextAux σ nfa wf (mapMatrix visited) update state bp.current).2.map id (·.val) := by
+  have hmain := @captureNextAux_refinesModelStack s σ nfa wf startPos visited [⟨update, state, bp⟩]
+  rw [modelRunStack_singleton] at hmain
+  exact hmain.symm
+
+end Regex.Backtracker

--- a/correctness/RegexCorrectness/Backtracker/Model/Semantics.lean
+++ b/correctness/RegexCorrectness/Backtracker/Model/Semantics.lean
@@ -1,0 +1,70 @@
+module
+
+public import RegexCorrectness.Backtracker.Model.Basic
+import all RegexCorrectness.Backtracker.Model.Basic
+public import RegexCorrectness.NFA.Semantics.Tree.Basic
+import all RegexCorrectness.NFA.Semantics.Tree.Basic
+
+open String (Pos)
+open Regex (NFA)
+open scoped Regex.Backtracker.Model
+
+public section
+
+namespace Regex.Backtracker.Model
+
+#check captureNextAux.induct
+
+noncomputable def mapVis {s : String} {nfa : NFA} (vis : Finset (Nat × Pos s)) : Finset (Fin nfa.size × Pos s) :=
+  { p : Fin nfa.size × Pos s | (p.1.val, p.2) ∈ vis }
+
+@[grind =, simp]
+theorem mapVis_insert {s : String} {nfa : NFA} (i : Nat) (p : Pos s) (lt : i < nfa.size) (vis : Finset (Nat × Pos s)) :
+  mapVis (insert (i, p) vis) = insert ⟨⟨i, lt⟩, p⟩ (mapVis vis) := by
+  grind [mapVis]
+
+@[grind =, simp]
+theorem mem_mapVis_iff {s : String} {nfa : NFA} (i : Nat) (p : Pos s) (lt : i < nfa.size) (vis : Finset (Nat × Pos s)) :
+  (⟨i, lt⟩, p) ∈ mapVis vis ↔ (i, p) ∈ vis := by
+  grind [mapVis]
+
+theorem captureNextAux_some_iff_firstMatch_some {s : String} {nfa : NFA} {wf : nfa.WellFormed}
+  {i : Nat} {p : Pos s} {us : List (Nat × Pos s)} {vis : Finset (Nat × Pos s)}
+  (t : NFA.Tree s nfa i p us vis) (p' us') :
+  t.firstMatch = .some (p', us') ↔
+  (captureNextAux (HistoryStrategy s) nfa wf (mapVis vis) us ⟨i, t.lt⟩ p).1 = p' ∧
+  (captureNextAux (HistoryStrategy s) nfa wf (mapVis vis) us ⟨i, t.lt⟩ p).2.1 = .some us' := by
+  fun_induction NFA.Tree.firstMatch generalizing p' us'
+  next => grind
+  next => grind
+  next i p us vis lt hm hn => grind
+  next i p us vis j lt hm hn t ih =>
+    rw [captureNextAux_epsilon (by grind) hn, ih p' us', mapVis_insert i p lt vis]
+  next i p us vis j₁ j₂ lt hm hn t₁ t₂ ih₁ ih₂ =>
+    match eq : t₁.firstMatch with
+    | .none =>
+      dsimp
+      rw [ih₂ p' us', mapVis_insert i p lt vis]
+      sorry -- This doesn't work
+    | .some (p'', us'') =>
+      have ih₁ := (ih₁ p'' us'').mp eq
+      rw [mapVis_insert i p lt vis] at ih₁
+      rw [captureNextAux_split (by grind) hn]
+      simp [ih₁]
+  next i p us vis j offset lt hm hn t ih =>
+    rw [captureNextAux_save (by grind) hn, ih p' us', mapVis_insert i p lt vis]
+    simp
+  next i p us vis j a lt hm hn ha t ih =>
+    rw [captureNextAux_anchor_pos (by grind) hn ha, ih p' us', mapVis_insert i p lt vis]
+  next => grind
+  next i p us vis j lt hm ne t hn ih =>
+    rw [captureNextAux_char_pos (by grind) hn ne rfl, ih p' us', mapVis_insert i p lt vis]
+  next => grind
+  next i p us vis j cs lt hm hn ne hc t ih =>
+    rw [captureNextAux_sparse_pos (by grind) hn ne hc, ih p' us', mapVis_insert i p lt vis]
+  next => grind
+
+
+end Regex.Backtracker.Model
+
+end

--- a/correctness/RegexCorrectness/Backtracker/Model/Semantics.lean
+++ b/correctness/RegexCorrectness/Backtracker/Model/Semantics.lean
@@ -7,13 +7,10 @@ import all RegexCorrectness.NFA.Semantics.Tree.Basic
 
 open String (Pos)
 open Regex (NFA)
-open scoped Regex.Backtracker.Model
 
 public section
 
 namespace Regex.Backtracker.Model
-
-#check captureNextAux.induct
 
 noncomputable def mapVis {s : String} {nfa : NFA} (vis : Finset (Nat × Pos s)) : Finset (Fin nfa.size × Pos s) :=
   { p : Fin nfa.size × Pos s | (p.1.val, p.2) ∈ vis }
@@ -28,42 +25,138 @@ theorem mem_mapVis_iff {s : String} {nfa : NFA} (i : Nat) (p : Pos s) (lt : i < 
   (⟨i, lt⟩, p) ∈ mapVis vis ↔ (i, p) ∈ vis := by
   grind [mapVis]
 
-theorem captureNextAux_some_iff_firstMatch_some {s : String} {nfa : NFA} {wf : nfa.WellFormed}
-  {i : Nat} {p : Pos s} {us : List (Nat × Pos s)} {vis : Finset (Nat × Pos s)}
-  (t : NFA.Tree s nfa i p us vis) (p' us') :
-  t.firstMatch = .some (p', us') ↔
-  (captureNextAux (HistoryStrategy s) nfa wf (mapVis vis) us ⟨i, t.lt⟩ p).1 = p' ∧
-  (captureNextAux (HistoryStrategy s) nfa wf (mapVis vis) us ⟨i, t.lt⟩ p).2.1 = .some us' := by
-  fun_induction NFA.Tree.firstMatch generalizing p' us'
-  next => grind
-  next => grind
-  next i p us vis lt hm hn => grind
-  next i p us vis j lt hm hn t ih =>
-    rw [captureNextAux_epsilon (by grind) hn, ih p' us', mapVis_insert i p lt vis]
-  next i p us vis j₁ j₂ lt hm hn t₁ t₂ ih₁ ih₂ =>
-    match eq : t₁.firstMatch with
-    | .none =>
-      dsimp
-      rw [ih₂ p' us', mapVis_insert i p lt vis]
-      sorry -- This doesn't work
-    | .some (p'', us'') =>
-      have ih₁ := (ih₁ p'' us'').mp eq
-      rw [mapVis_insert i p lt vis] at ih₁
-      rw [captureNextAux_split (by grind) hn]
-      simp [ih₁]
-  next i p us vis j offset lt hm hn t ih =>
-    rw [captureNextAux_save (by grind) hn, ih p' us', mapVis_insert i p lt vis]
-    simp
-  next i p us vis j a lt hm hn ha t ih =>
-    rw [captureNextAux_anchor_pos (by grind) hn ha, ih p' us', mapVis_insert i p lt vis]
-  next => grind
-  next i p us vis j lt hm ne t hn ih =>
-    rw [captureNextAux_char_pos (by grind) hn ne rfl, ih p' us', mapVis_insert i p lt vis]
-  next => grind
-  next i p us vis j cs lt hm hn ne hc t ih =>
-    rw [captureNextAux_sparse_pos (by grind) hn ne hc, ih p' us', mapVis_insert i p lt vis]
-  next => grind
+theorem captureNextAux_visOut_of_none {s : String} {nfa : NFA} {wf : nfa.WellFormed}
+  {i : Nat} {p : Pos s} {us : List (Nat × Pos s)} {visIn visOut : Finset (Nat × Pos s)} {t : NFA.Tree}
+  (h : t.IsValid nfa i p us visIn visOut)
+  (hc : (captureNextAux (HistoryStrategy s) nfa wf (mapVis visIn) us ⟨i, t.lt h⟩ p).2.1 = .none) :
+  (captureNextAux (HistoryStrategy s) nfa wf (mapVis visIn) us ⟨i, t.lt h⟩ p).2.2.val = mapVis visOut := by
+  induction h with
+  | visited => grind only [= captureNextAux_visited, = mem_mapVis_iff]
+  | fail => grind only [= mapVis_insert, = captureNextAux_fail, = Fin.getElem_fin, = mem_mapVis_iff]
+  | done => grind only [= mapVis_insert, = captureNextAux_done, = Fin.getElem_fin, = mem_mapVis_iff]
+  | @epsilon i j p us visIn visOut lt hm hn t h ih =>
+    rw [mapVis_insert i p lt visIn] at ih
+    revert hc
+    rw [captureNextAux_epsilon (by grind) hn]
+    exact ih
+  | @split i j₁ j₂ p us visIn visMid visOut lt hm hn t₁ t₂ h₁ h₂ ih₁ ih₂ =>
+    rw [mapVis_insert i p lt visIn] at ih₁
+    rw [captureNextAux_split (by grind) hn] at ⊢ hc
+    split
+    next h => grind only [= Option.isSome_none]
+    next h =>
+      simp only [HistoryStrategy.update_def, h, Bool.false_eq_true, ↓reduceIte] at hc
+      simp only [HistoryStrategy.update_def, Bool.not_eq_true, Option.isSome_eq_false_iff,
+        Option.isNone_iff_eq_none] at h
+      have ih₁ := ih₁ h
+      simp only [HistoryStrategy.update_def]
+      rw [ih₁] at ⊢ hc
+      exact ih₂ hc
+  | @save i j p us visIn visOut offset lt hm hn t h ih =>
+    rw [mapVis_insert i p lt visIn] at ih
+    rw [captureNextAux_save (by grind) hn] at ⊢ hc
+    simp [ih hc]
+  | @anchor i j p us visIn visOut a lt hm hn ha t h ih =>
+    rw [mapVis_insert i p lt visIn] at ih
+    rw [captureNextAux_anchor_pos (by grind) hn ha] at ⊢ hc
+    simp [ih hc]
+  | anchorFail => grind only [= mapVis_insert, !captureNextAux_anchor_neg, = Fin.getElem_fin, = mem_mapVis_iff]
+  | @char i j p us visIn visOut c lt hm hn ne hc' t h ih =>
+    rw [mapVis_insert i p lt visIn] at ih
+    rw [captureNextAux_char_pos (by grind) hn ne hc'] at ⊢ hc
+    simp [ih hc]
+  | charFail => grind only [= mapVis_insert, !captureNextAux_char_neg, = Fin.getElem_fin, = mem_mapVis_iff]
+  | @sparse i j p us visIn visOut cs lt hm hn ne hc' t h ih =>
+    rw [mapVis_insert i p lt visIn] at ih
+    rw [captureNextAux_sparse_pos (by grind) hn ne hc'] at ⊢ hc
+    simp [ih hc]
+  | sparseFail => grind only [= mapVis_insert, !captureNextAux_sparse_neg, = Fin.getElem_fin, = mem_mapVis_iff]
 
+theorem firstMatch_some_iff_captureNext_some {s : String} {nfa : NFA} {wf : nfa.WellFormed}
+  {i : Nat} {p : Pos s} {us : List (Nat × Pos s)} {visIn visOut : Finset (Nat × Pos s)} {t : NFA.Tree}
+  (h : NFA.Tree.IsValid nfa i p us visIn t visOut) (p' us') :
+  NFA.Tree.firstMatch p us t = Option.some (p', us') ↔
+  (captureNextAux (HistoryStrategy s) nfa wf (mapVis visIn) us ⟨i, NFA.Tree.lt h⟩ p).1 = p' ∧
+  (captureNextAux (HistoryStrategy s) nfa wf (mapVis visIn) us ⟨i, NFA.Tree.lt h⟩ p).2.1 = Option.some us' := by
+  fun_induction NFA.Tree.firstMatch p us t generalizing i p' us' visIn visOut with
+  | case1 =>
+    cases h with
+    | visited => grind only [= captureNextAux_visited, = mem_mapVis_iff]
+  | case2 =>
+    cases h with
+    | fail => grind only [= captureNextAux_fail, = Fin.getElem_fin, = mem_mapVis_iff]
+  | case3 =>
+    cases h with
+    | done => grind only [= captureNextAux_done, = Fin.getElem_fin, = mem_mapVis_iff]
+  | case4 p us t ih =>
+    cases h with
+    | epsilon =>
+      rename_i j lt hn hm h
+      rw [captureNextAux_epsilon (by grind) hn, ih h p' us', mapVis_insert i p lt visIn]
+  | case5 p us t₁ t₂ ih₁ ih₂ =>
+    cases h with
+    | split =>
+      rename_i j₁ j₂ visMid lt hn hm h₁ h₂
+      match eq : t₁.firstMatch p us with
+      | .some (p'', us'') =>
+        have ih₁ := (ih₁ h₁ p'' us'').mp eq
+        rw [mapVis_insert i p lt visIn] at ih₁
+        rw [captureNextAux_split (by grind) hn, ih₁.1, ih₁.2]
+        simp
+      | .none =>
+        dsimp
+        rw [captureNextAux_split (by grind) hn, ih₂ h₂ p' us']
+        have isLt : j₁ < nfa.size ∧ j₂ < nfa.size := wf.inBounds' i lt hn
+        have isNone : (captureNextAux (HistoryStrategy s) nfa wf (mapVis (insert (i, p) visIn)) us ⟨j₁, isLt.1⟩ p).2.1 = .none := by
+          match eq' : captureNextAux (HistoryStrategy s) nfa wf (mapVis (insert (i, p) visIn)) us ⟨j₁, isLt.1⟩ p with
+          | (_, .none, _) => rfl
+          | (p'', .some us'', _) => grind only [ih₁ h₁ p'' us'']
+        have hmid := captureNextAux_visOut_of_none h₁ isNone
+        rw [mapVis_insert i p lt visIn] at isNone hmid
+        simp only [HistoryStrategy.update_def, isNone, Option.isSome_none, Bool.false_eq_true, ↓reduceIte]
+        rw [hmid]
+  | case6 p us offset t ih =>
+    cases h with
+    | save =>
+      rename_i j lt hm hn h
+      rw [captureNextAux_save (by grind) hn, ih h p' us', mapVis_insert i p lt visIn]
+      simp
+  | case7 p u t ih =>
+    cases h with
+    | anchor =>
+      rename_i j a lt hn ha hm h
+      rw [captureNextAux_anchor_pos (by grind) hn ha, ih h p' us', mapVis_insert i p lt visIn]
+  | case8 =>
+    cases h with
+    | anchorFail => grind only [!captureNextAux_anchor_neg, = Fin.getElem_fin, = mem_mapVis_iff]
+  | case9 p u t ne ih =>
+    cases h with
+    | char =>
+      rename_i j c lt hn _ hc hm h
+      rw [captureNextAux_char_pos (by grind) hn ne hc, ih h p' us', mapVis_insert i p lt visIn]
+  | case10 =>
+    cases h with
+    | char => grind only
+  | case11 =>
+    cases h with
+    | charFail =>
+      rename_i j c lt hn hc hm hv
+      rw [captureNextAux_char_neg (by grind) hn hc]
+      grind only
+  | case12 p u t ne ih =>
+    cases h with
+    | sparse =>
+      rename_i j cs lt hn _ hc hm h
+      rw [captureNextAux_sparse_pos (by grind) hn ne hc, ih h p' us', mapVis_insert i p lt visIn]
+  | case13 =>
+    cases h with
+    | sparse => grind only
+  | case14 =>
+    cases h with
+    | sparseFail =>
+      rename_i j cs lt hn hc hm hv
+      rw [captureNextAux_sparse_neg (by grind) hn hc]
+      grind only
 
 end Regex.Backtracker.Model
 

--- a/correctness/RegexCorrectness/Backtracker/Refinement.lean
+++ b/correctness/RegexCorrectness/Backtracker/Refinement.lean
@@ -64,7 +64,7 @@ theorem captureNextAux.pushNext.refines {s nfa wf startPos bufferSize stackH sta
 
 theorem captureNextAux.refines {s} (nfa wf startPos bufferSize visited) {stackH stackB} (refStack : materializeStack stackH = stackB) :
   materializeResultAux (captureNextAux (HistoryStrategy s) nfa wf startPos visited stackH) = captureNextAux (BufferStrategy s bufferSize) nfa wf startPos visited stackB := by
-  induction visited, stackH using captureNextAux.induct' (HistoryStrategy s) nfa wf startPos generalizing stackB with
+  induction visited, stackH using captureNextAuxRecOn (HistoryStrategy s) nfa wf startPos generalizing stackB with
   | base visited =>
     simp at refStack
     simp [refStack, captureNextAux_base, materializeResultAux]

--- a/correctness/RegexCorrectness/Data/BVPos.lean
+++ b/correctness/RegexCorrectness/Data/BVPos.lean
@@ -12,6 +12,12 @@ namespace Regex.Data.BVPos
 
 variable {s : String} {startPos : Pos s}
 
+@[simp]
+theorem index_eq_of_le {p : Pos s} (le le' : startPos ≤ p) :
+    BVPos.index (⟨p, le⟩ : BVPos startPos) = BVPos.index (⟨p, le'⟩ : BVPos startPos) := by
+  ext
+  simp [BVPos.index]
+
 @[ext]
 theorem ext_index {p₁ p₂ : BVPos startPos} (h₂ : p₁.index = p₂.index) : p₁ = p₂ := by
   simp only [index, Pos.Raw.byteDistance, Fin.mk.injEq] at h₂
@@ -19,6 +25,11 @@ theorem ext_index {p₁ p₂ : BVPos startPos} (h₂ : p₁.index = p₂.index) 
   have : startPos.offset.byteIdx ≤ p₁.current.offset.byteIdx := p₁.le
   have : startPos.offset.byteIdx ≤ p₂.current.offset.byteIdx := p₂.le
   grind
+
+@[simp]
+theorem get_eq_get (pos : BVPos startPos) (h : pos ≠ s.endBVPos startPos) :
+    pos.get h = pos.current.get (Regex.Data.BVPos.ne_end_iff_current_ne_end.mp h) := by
+  grind [Regex.Data.BVPos.get]
 
 def Splits (p : BVPos startPos) (l r : String) : Prop :=
   p.current.Splits l r

--- a/correctness/RegexCorrectness/Data/Expr/Nullable.lean
+++ b/correctness/RegexCorrectness/Data/Expr/Nullable.lean
@@ -1,0 +1,38 @@
+module
+
+public import RegexCorrectness.Data.Expr.Semantics.Captures
+
+open String (Pos)
+
+public section
+
+namespace Regex.Data.Expr
+
+@[expose, grind =]
+def Nullable : Expr → Prop
+  | .empty | .epsilon | .anchor _ => True
+  | .char _ => False
+  | .classes _ => False
+  | .group _ e => e.Nullable
+  | .concat e₁ e₂ => e₁.Nullable ∧ e₂.Nullable
+  | .alternate e₁ e₂ => e₁.Nullable ∨ e₂.Nullable
+  | .star _ _ => True
+
+theorem Captures.lt_of_not_nullable {s} {p p' : Pos s} {groups e}
+  (h : ¬Nullable e) (c : Expr.Captures p p' groups e) :
+  p < p' := by
+  induction c
+  case concat c₁ c₂ _ _ => grind [c₁.le, c₂.le]
+  all_goals grind [Pos.lt_next]
+
+@[expose, grind =]
+def NullableStar : Expr → Prop
+  | .empty | .epsilon | .anchor _ | .char _ | .classes _ => False
+  | .group _ e => e.NullableStar
+  | .concat e₁ e₂ => e₁.NullableStar ∨ e₂.NullableStar
+  | .alternate e₁ e₂ => e₁.NullableStar ∨ e₂.NullableStar
+  | .star _ e => e.Nullable ∨ e.NullableStar
+
+end Regex.Data.Expr
+
+end

--- a/correctness/RegexCorrectness/Data/Expr/Semantics/Tree/Basic.lean
+++ b/correctness/RegexCorrectness/Data/Expr/Semantics/Tree/Basic.lean
@@ -1,0 +1,127 @@
+module
+
+public import Regex.Data.Expr
+public import RegexCorrectness.Data.Expr.Semantics.Captures
+public import RegexCorrectness.Data.Expr.Semantics.Separation
+public import RegexCorrectness.Data.Expr.Semantics.GroupMap
+
+open String (Pos)
+
+public section
+
+namespace Regex.Data.Expr.Semantics
+
+/--
+`Tree` records the full search traces of a regex match.
+
+Leaves represent success or failure, and internal nodes represent the nondeterministic operations
+a regex matching algorithm can perform, such as branching, reading one character, checking an anchor,
+and opening or closing a capture group.
+
+Reference: Barriere, Deng, and Pit-Claudel, "Formal Verification for JavaScript Regular
+Expressions: a Proven Semantics and its Applications (Extended Version)",
+https://arxiv.org/abs/2507.13091
+
+They call this "backtracking tree" in their paper.
+-/
+inductive Tree where
+  | complete
+  | fail
+  | choice (t₁ t₂ : Tree)
+  | read (next : Tree)
+  | anchorPass (next : Tree)
+  | openGroup (tag : Nat) (next : Tree)
+  | closeGroup (tag : Nat) (next : Tree)
+  | progress (next : Tree)
+deriving Inhabited
+
+namespace Tree
+
+variable {s : String}
+
+inductive Action (s : String) where
+  | expr (e : Expr)
+  | closeGroup (tag : Nat)
+  | check (p : Pos s)
+
+inductive IsValid {s : String} : List (Action s) → Pos s → GroupMap s → Tree → Prop where
+  | complete {p : Pos s} {gs : GroupMap s} :
+    IsValid [] p gs .complete
+  | epsilon {as : List (Action s)} {p : Pos s} {gs : GroupMap s} {t : Tree} (h : IsValid as p gs t) :
+    IsValid (.expr .epsilon :: as) p gs t
+  | anchor {a : Anchor} {as : List (Action s)} {p : Pos s} {gs : GroupMap s} {t : Tree}
+    (ha : a.test p) (h : IsValid as p gs t) :
+    IsValid (.expr (.anchor a) :: as) p gs (.anchorPass t)
+  | anchorFail {a : Anchor} {as : List (Action s)} {p : Pos s} {gs : GroupMap s} (ha : ¬a.test p) :
+    IsValid (.expr (.anchor a) :: as) p gs .fail
+  | char {c : Char} {as : List (Action s)} {p : Pos s} {gs : GroupMap s} {t : Tree}
+    (hp : p ≠ s.endPos) (hc : p.get hp = c) (h : IsValid as (p.next hp) gs t) :
+    IsValid (.expr (.char c) :: as) p gs (.read t)
+  | charFail {c : Char} {as : List (Action s)} {p : Pos s} {gs : GroupMap s}
+    (hp : p = s.endPos ∨ ∃ hp' : p ≠ s.endPos, p.get hp' ≠ c) :
+    IsValid (.expr (.char c) :: as) p gs .fail
+  | sparse {cs : Classes} {as : List (Action s)} {p : Pos s} {gs : GroupMap s} {t : Tree}
+    (hp : p ≠ s.endPos) (hc : p.get hp ∈ cs) (h : IsValid as (p.next hp) gs t) :
+    IsValid (.expr (.classes cs) :: as) p gs (.read t)
+  | sparseFail {cs : Classes} {as : List (Action s)} {p : Pos s} {gs : GroupMap s}
+    (hp : p = s.endPos ∨ ∃ hp' : p ≠ s.endPos, p.get hp' ∉ cs) :
+    IsValid (.expr (.classes cs) :: as) p gs .fail
+  | openGroup {tag : Nat} {e : Expr} {as : List (Action s)} {p : Pos s} {gs : GroupMap s} {t : Tree}
+    (h : IsValid (.expr e :: .closeGroup tag :: as) p (gs.openGroup tag p) t) :
+    IsValid (.expr (.group tag e) :: as) p gs (.openGroup tag t)
+  | closeGroup {tag : Nat} {as : List (Action s)} {p : Pos s} {gs : GroupMap s} {t : Tree}
+    (h : IsValid as p (gs.closeGroup tag p) t) :
+    IsValid (.closeGroup tag :: as) p gs (.closeGroup tag t)
+  | alternate {e₁ e₂ : Expr} {as : List (Action s)} {p : Pos s} {gs : GroupMap s} {t₁ t₂ : Tree}
+    (h₁ : IsValid (.expr e₁ :: as) p gs t₁) (h₂ : IsValid (.expr e₂ :: as) p gs t₂) :
+    IsValid (.expr (.alternate e₁ e₂) :: as) p gs (.choice t₁ t₂)
+  | concat {e₁ e₂ : Expr} {as : List (Action s)} {p : Pos s} {gs : GroupMap s} {t : Tree}
+    (h : IsValid (.expr e₁ :: .expr e₂ :: as) p gs t) :
+    IsValid (.expr (.concat e₁ e₂) :: as) p gs t
+  -- e* = e(<check> e* | ε) | ε = e<check>e* | e | ε
+  | star {greedy : Bool} {e : Expr} {as : List (Action s)} {p : Pos s} {gs : GroupMap s}
+    {tLoop tOnce tExit : Tree}
+    (h₁ : IsValid (.expr e :: .check p :: .expr (.star greedy e) :: as) p gs tLoop)
+    (h₂ : IsValid (.expr e :: as) p gs tOnce)
+    (h₃ : IsValid as p gs tExit) :
+    IsValid (.expr (.star greedy e) :: as) p gs
+      (if greedy then .choice tLoop tExit else .choice tExit tLoop)
+  | progress {as : List (Action s)} {p p' : Pos s} {gs : GroupMap s} {t : Tree}
+    (hp : p < p') (h : IsValid as p' gs t) :
+    IsValid (.check p :: as) p' gs (.progress t)
+
+theorem deterministic_isValid {s : String} {as : List (Action s)} {p : Pos s} {gs : GroupMap s} {t₁ t₂ : Tree}
+  (h₁ : IsValid as p gs t₁) (h₂ : IsValid as p gs t₂) :
+  t₁ = t₂ := by
+  induction h₁ generalizing t₂ <;> grind [IsValid]
+
+def firstMatch (t : Tree) : Option Unit :=
+  match t with
+  | .complete => .some ()
+  | .fail => .none
+  | .choice t₁ t₂ => firstMatch t₁ <|> firstMatch t₂
+  | .read t => t.firstMatch
+  | .anchorPass t => t.firstMatch
+  | .openGroup _ t => t.firstMatch
+  | .closeGroup _ t => t.firstMatch
+  | .progress t => t.firstMatch
+
+def extractCapturesAux {s : String} (p : Pos s) (gs : GroupMap s) (t : Tree) : List (Pos s × GroupMap s) :=
+  match t with
+  | .complete => [(p, gs)]
+  | .fail => []
+  | .choice t₁ t₂ => t₁.extractCapturesAux p gs ++ t₂.extractCapturesAux p gs
+  | .read t => if hp : p ≠ s.endPos then t.extractCapturesAux (p.next hp) gs else []
+  | .anchorPass t => t.extractCapturesAux p gs
+  | .openGroup tag t => t.extractCapturesAux p (gs.openGroup tag p)
+  | .closeGroup tag t => t.extractCapturesAux p (gs.closeGroup tag p)
+  | .progress t => t.extractCapturesAux p gs
+
+def extractCaptures {s : String} (startAt : Pos s) (t : Tree) : List (Pos s × GroupMap s) :=
+  t.extractCapturesAux startAt .empty
+
+end Tree
+
+end Regex.Data.Expr.Semantics
+
+end

--- a/correctness/RegexCorrectness/Data/Expr/Semantics/Tree/Basic.lean
+++ b/correctness/RegexCorrectness/Data/Expr/Semantics/Tree/Basic.lean
@@ -85,7 +85,7 @@ inductive IsValid {s : String} : List (Action s) → Pos s → GroupMap s → Tr
     (h₂ : IsValid (.expr e :: as) p gs tOnce)
     (h₃ : IsValid as p gs tExit) :
     IsValid (.expr (.star greedy e) :: as) p gs
-      (if greedy then .choice tLoop tExit else .choice tExit tLoop)
+      (if greedy then .choice (.choice tLoop tOnce) tExit else .choice tExit (.choice tOnce tLoop))
   | progress {as : List (Action s)} {p p' : Pos s} {gs : GroupMap s} {t : Tree}
     (hp : p < p') (h : IsValid as p' gs t) :
     IsValid (.check p :: as) p' gs (.progress t)

--- a/correctness/RegexCorrectness/Data/Expr/Semantics/Tree/Equivalence.lean
+++ b/correctness/RegexCorrectness/Data/Expr/Semantics/Tree/Equivalence.lean
@@ -1,0 +1,326 @@
+module
+
+public import RegexCorrectness.Data.Expr.Semantics.Tree.Basic
+import all RegexCorrectness.Data.Expr.Semantics.Tree.Basic
+public import RegexCorrectness.Data.Expr.Nullable
+
+open String (Pos)
+
+namespace Regex.Data.Expr.Semantics.Tree
+
+variable {s : String}
+
+def WfActions : List (Action s) → Prop
+  | [] => True
+  | .expr e :: as => e.Disjoint ∧ ¬e.NullableStar ∧ WfActions as
+  | .closeGroup _ :: as => WfActions as
+  | .check _ :: as => WfActions as
+
+@[simp] theorem wfActions_expr {e : Expr} {as : List (Action s)} :
+  WfActions (.expr e :: as) ↔ e.Disjoint ∧ ¬e.NullableStar ∧ WfActions as := by
+  rfl
+
+@[simp] theorem wfActions_closeGroup {tag : Nat} {as : List (Action s)} :
+  WfActions (.closeGroup tag :: as) ↔ WfActions as := by
+  rfl
+
+@[simp] theorem wfActions_check {p : Pos s} {as : List (Action s)} :
+  WfActions (.check p :: as) ↔ WfActions as := by
+  rfl
+
+@[simp] theorem wfActions_single_expr {e : Expr} :
+  WfActions (s := s) [.expr e] ↔ e.Disjoint ∧ ¬e.NullableStar := by
+  simp [WfActions]
+
+@[simp] theorem wfActions_group_expr_closeGroup {tag : Nat} {e : Expr} {as : List (Action s)} :
+  WfActions (.expr (.group tag e) :: as) ↔
+    tag ∉ e.tags ∧ ¬e.NullableStar ∧ WfActions (.expr e :: .closeGroup tag :: as) := by
+  simp [Disjoint, NullableStar, and_assoc, and_left_comm, and_comm]
+
+@[simp] theorem wfActions_alternate_branches {e₁ e₂ : Expr} {as : List (Action s)} :
+  WfActions (.expr (.alternate e₁ e₂) :: as) ↔
+    WfActions (.expr e₁ :: as) ∧ WfActions (.expr e₂ :: as) := by
+  simp [Disjoint, NullableStar, and_assoc, and_left_comm, and_comm]
+
+@[simp] theorem wfActions_concat_exprs {e₁ e₂ : Expr} {as : List (Action s)} :
+  WfActions (.expr (.concat e₁ e₂) :: as) ↔
+    WfActions (.expr e₁ :: .expr e₂ :: as) := by
+  grind [Disjoint, wfActions_expr]
+
+@[simp] theorem wfActions_star_unfold {greedy : Bool} {e : Expr} {as : List (Action s)} :
+  WfActions (.expr (.star greedy e) :: as) ↔
+    WfActions (.expr e :: .expr (.star greedy e) :: as) := by
+  grind [Disjoint, wfActions_expr]
+
+inductive Runs {s : String} : List (Action s) → Pos s → GroupMap s → Pos s → GroupMap s → Prop where
+  | nil {p : Pos s} {gs : GroupMap s} :
+    Runs [] p gs p gs
+  | expr {e : Expr} {as : List (Action s)} {p p' q : Pos s} {gs gs' : GroupMap s} {groups : CaptureGroups s}
+    (cap : e.Captures p p' groups) (rest : Runs as p' (gs.addCaptures groups) q gs') :
+    Runs (.expr e :: as) p gs q gs'
+  | closeGroup {tag : Nat} {as : List (Action s)} {p q : Pos s} {gs gs' : GroupMap s}
+    (rest : Runs as p (gs.closeGroup tag p) q gs') :
+    Runs (.closeGroup tag :: as) p gs q gs'
+  | check {as : List (Action s)} {pc p q : Pos s} {gs gs' : GroupMap s}
+    (h : pc < p) (rest : Runs as p gs q gs') :
+    Runs (.check pc :: as) p gs q gs'
+
+namespace Runs
+
+theorem head_expr {e : Expr} {as : List (Action s)} {p q : Pos s} {gs gs' : GroupMap s}
+  (h : Runs (.expr e :: as) p gs q gs') :
+  ∃ p' groups, e.Captures p p' groups ∧ Runs as p' (gs.addCaptures groups) q gs' := by
+  cases h with
+  | expr cap rest => exact ⟨_, _, cap, rest⟩
+
+theorem head_closeGroup {tag : Nat} {as : List (Action s)} {p q : Pos s} {gs gs' : GroupMap s}
+  (h : Runs (.closeGroup tag :: as) p gs q gs') :
+  Runs as p (gs.closeGroup tag p) q gs' := by
+  cases h with
+  | closeGroup rest => exact rest
+
+theorem head_check {pc : Pos s} {as : List (Action s)} {p p' : Pos s} {gs gs' : GroupMap s}
+  (h : Runs (.check pc :: as) p gs p' gs') :
+  pc < p ∧ Runs as p gs p' gs' := by
+  cases h with
+  | check hpc hrest => exact ⟨hpc, hrest⟩
+
+theorem head_expr_expr {e₁ e₂ : Expr} {as : List (Action s)} {p q : Pos s} {gs gs' : GroupMap s}
+  (h : Runs (.expr e₁ :: .expr e₂ :: as) p gs q gs') :
+  ∃ p' p'' groups₁ groups₂,
+    e₁.Captures p p' groups₁ ∧
+    e₂.Captures p' p'' groups₂ ∧
+    Runs as p'' ((gs.addCaptures groups₁).addCaptures groups₂) q gs' := by
+  obtain ⟨p', groups₁, cap₁, hrest₁⟩ := Runs.head_expr h
+  obtain ⟨p'', groups₂, cap₂, hrest₂⟩ := Runs.head_expr hrest₁
+  exact ⟨p', p'', groups₁, groups₂, cap₁, cap₂, hrest₂⟩
+
+end Runs
+
+theorem mem_extractCapturesAux_of_runs {as : List (Action s)}
+  {p₁ p₂ : Pos s} {gs gs' : GroupMap s} {t : Tree}
+  (v : t.IsValid as p₁ gs) (wf : WfActions as) (r : Runs as p₁ gs p₂ gs') :
+  (p₂, gs') ∈ t.extractCapturesAux p₁ gs := by
+  induction v generalizing p₂ gs' with
+  | complete =>
+    cases r
+    simp [extractCapturesAux]
+  | epsilon h ih =>
+    cases r with
+    | expr cap rest =>
+      cases cap with
+      | epsilon =>
+        exact ih (wfActions_expr.mp wf).2.2 rest
+  | anchor ha h ih =>
+    cases r with
+    | expr cap rest =>
+      cases cap with
+      | anchor htest =>
+        exact ih (wfActions_expr.mp wf).2.2 rest
+  | anchorFail ha =>
+    cases r with
+    | expr cap rest =>
+      cases cap with
+      | anchor htest => grind
+  | char hp hc h ih =>
+    cases r with
+    | expr cap rest =>
+      cases cap with
+      | char hp' hc' =>
+        simpa [extractCapturesAux, hp] using ih (wfActions_expr.mp wf).2.2 rest
+  | @charFail c as p gs hp =>
+    cases r with
+    | expr cap rest =>
+      cases cap with
+      | char hp' hc' => grind
+  | sparse hp hc h ih =>
+    cases r with
+    | expr cap rest =>
+      cases cap with
+      | sparse hp' hc' =>
+        simpa [extractCapturesAux, hp] using ih (wfActions_expr.mp wf).2.2 rest
+  | @sparseFail cs as p gs hp =>
+    cases r with
+    | expr cap rest =>
+      cases cap with
+      | sparse hp' hc' => grind
+  | @openGroup tag e as p gs t h ih =>
+    cases r with
+    | expr cap rest =>
+      cases cap with
+      | group capInner =>
+        rename_i pmid groups
+        have ⟨htag, _, hprem⟩ := wfActions_group_expr_closeGroup.mp wf
+        have hclose :
+            ((gs.openGroup tag p).addCaptures groups).closeGroup tag pmid =
+              gs.addCaptures (.group tag p pmid groups) := by
+          apply GroupMap.closeGroup_addCaptures_openGroup_eq_addCaptures_group
+          intro first last mem
+          exact htag (capInner.mem_tags_of_mem_groups _ _ _ mem)
+        have hrest' : Runs as pmid (((gs.openGroup tag p).addCaptures groups).closeGroup tag pmid) p₂ gs' := by
+          simpa [hclose] using rest
+        have hinner : Runs (.expr e :: .closeGroup tag :: as) p (gs.openGroup tag p) p₂ gs' :=
+          .expr capInner (.closeGroup hrest')
+        simpa [extractCapturesAux] using ih hprem hinner
+  | closeGroup h ih =>
+    cases r with
+    | closeGroup r =>
+      simpa [extractCapturesAux] using ih (wfActions_closeGroup.mp wf) r
+  | @alternate e₁ e₂ as p gs t₁ t₂ h₁ h₂ ih₁ ih₂ =>
+    cases r with
+    | expr cap rest =>
+      have ⟨hleft, hright⟩ := wfActions_alternate_branches.mp wf
+      cases cap with
+      | alternateLeft capLeft =>
+        exact List.mem_append.mpr <| Or.inl <| ih₁ hleft (.expr capLeft rest)
+      | alternateRight capRight =>
+        exact List.mem_append.mpr <| Or.inr <| ih₂ hright (.expr capRight rest)
+  | @concat e₁ e₂ as p gs t h ih =>
+    cases r with
+    | expr cap rest =>
+      cases cap with
+      | @concat p p' p'' groups₁ groups₂ e₁ e₂ cap₁ cap₂ =>
+        have hprem := wfActions_concat_exprs.mp wf
+        have hrest' : Runs (.expr e₂ :: as) p' (gs.addCaptures groups₁) p₂ gs' :=
+          .expr cap₂ (by simpa [GroupMap.addCaptures] using rest)
+        exact ih hprem (.expr cap₁ hrest')
+  | @star greedy e as p gs tLoop tOnce tExit h₁ h₂ h₃ ih₁ ih₂ ih₃ =>
+    cases r with
+    | @expr _ _ _ q _ _ _ groups cap rest =>
+      have hprem := wfActions_star_unfold.mp wf
+      have ⟨hns, htail⟩ := (wfActions_expr.mp wf).2
+      cases cap with
+      | starEpsilon =>
+        cases greedy
+        · exact List.mem_append.mpr <| Or.inl <| ih₃ htail rest
+        · exact List.mem_append.mpr <| Or.inr <| ih₃ htail rest
+      | @starConcat p p' p'' groups₁ groups₂ _ _ cap₁ cap₂ =>
+        have hrest' : Runs (.expr (.star greedy e) :: as) p' (gs.addCaptures groups₁) p₂ gs' :=
+          .expr cap₂ (by simpa [GroupMap.addCaptures] using rest)
+        have mem : (p₂, gs') ∈ extractCapturesAux p gs tLoop := by
+          apply ih₁ ?_ ?_
+          . simpa [wfActions_expr, wfActions_check] using hprem
+          . simp only [NullableStar, not_or] at hns
+            exact .expr cap₁ (.check (cap₁.lt_of_not_nullable hns.1) (.expr cap₂ rest))
+        cases greedy
+        · exact List.mem_append.mpr <| .inr (List.mem_append.mpr <| .inr mem)
+        · exact List.mem_append.mpr <| .inl (List.mem_append.mpr <| .inl mem)
+  | @progress as p p' gs t hp h ih =>
+    cases r with
+    | check h rest =>
+      simpa [extractCapturesAux] using ih (wfActions_check.mp wf) rest
+
+theorem runs_of_mem_extractCapturesAux {as : List (Action s)}
+  {p₁ p₂ : Pos s} {gs gs' : GroupMap s} {t : Tree}
+  (v : t.IsValid as p₁ gs) (wf : WfActions as) (hmem : (p₂, gs') ∈ t.extractCapturesAux p₁ gs) :
+  Runs as p₁ gs p₂ gs' := by
+  induction v generalizing p₂ gs' with
+  | complete =>
+    simp [extractCapturesAux] at hmem
+    rcases hmem with ⟨rfl, rfl⟩
+    exact .nil
+  | epsilon hvalid ih =>
+    exact .expr .epsilon (ih (wfActions_expr.mp wf).2.2 hmem)
+  | anchor ha hvalid ih =>
+    exact .expr (.anchor ha) (ih (wfActions_expr.mp wf).2.2 hmem)
+  | anchorFail ha =>
+    simp [extractCapturesAux] at hmem
+  | char hp hc hvalid ih =>
+    simp [extractCapturesAux, hp] at hmem
+    exact .expr (.char hp hc) (ih (wfActions_expr.mp wf).2.2 hmem)
+  | charFail hp =>
+    simp [extractCapturesAux] at hmem
+  | sparse hp hc hvalid ih =>
+    simp [extractCapturesAux, hp] at hmem
+    exact .expr (.sparse hp hc) (ih (wfActions_expr.mp wf).2.2 hmem)
+  | sparseFail hp =>
+    simp [extractCapturesAux] at hmem
+  | @openGroup tag e as p gs t hvalid ih =>
+    have ⟨htag, _, hprem⟩ := wfActions_group_expr_closeGroup.mp wf
+    have hinner := ih hprem (by simpa using hmem)
+    obtain ⟨pEnd, groups, capInner, hrest₀⟩ := Runs.head_expr hinner
+    have hrest := Runs.head_closeGroup hrest₀
+    have hclose :
+        ((gs.openGroup tag p).addCaptures groups).closeGroup tag pEnd =
+          gs.addCaptures (.group tag p pEnd groups) := by
+      apply GroupMap.closeGroup_addCaptures_openGroup_eq_addCaptures_group
+      intro first last mem
+      exact htag (capInner.mem_tags_of_mem_groups _ _ _ mem)
+    exact .expr (.group capInner) (by simpa [hclose] using hrest)
+  | closeGroup hvalid ih =>
+    exact .closeGroup (ih (wfActions_closeGroup.mp wf) (by simpa using hmem))
+  | @alternate e₁ e₂ as p gs t₁ t₂ h₁ h₂ ih₁ ih₂ =>
+    simp [extractCapturesAux] at hmem
+    rcases hmem with hmem | hmem
+    · have hhead : (Expr.alternate e₁ e₂).Disjoint := (wfActions_expr.mp wf).1
+      have ⟨hleft, _⟩ := wfActions_alternate_branches.mp wf
+      obtain ⟨p', groups, capLeft, hrest⟩ := Runs.head_expr (ih₁ hleft hmem)
+      exact .expr (.alternateLeft capLeft) hrest
+    · have hhead : (Expr.alternate e₁ e₂).Disjoint := (wfActions_expr.mp wf).1
+      have ⟨_, hright⟩ := wfActions_alternate_branches.mp wf
+      obtain ⟨p', groups, capRight, hrest⟩ := Runs.head_expr (ih₂ hright hmem)
+      exact .expr (.alternateRight capRight) hrest
+  | @concat e₁ e₂ as p gs t hvalid ih =>
+    have hprem := wfActions_concat_exprs.mp wf
+    have hinner := ih hprem hmem
+    obtain ⟨p', p'', groups₁, groups₂, cap₁, cap₂, hrest₂⟩ := Runs.head_expr_expr hinner
+    exact .expr (.concat cap₁ cap₂) (by simpa using hrest₂)
+  | @star greedy e as p gs tLoop tOnce tExit h₁ h₂ h₃ ih₁ ih₂ ih₃ =>
+    have htail := (wfActions_expr.mp wf)
+    have hprem := wfActions_star_unfold.mp wf
+    have hExit (hmem : (p₂, gs') ∈ tExit.extractCapturesAux p gs) :
+      Runs (.expr (.star greedy e) :: as) p gs p₂ gs' := by
+      exact .expr .starEpsilon (ih₃ htail.2.2 (by simpa [extractCapturesAux] using hmem))
+    have hOnce (hmem : (p₂, gs') ∈ tOnce.extractCapturesAux p gs) :
+      Runs (.expr (.star greedy e) :: as) p gs p₂ gs' := by
+      obtain ⟨p₁, groups₁, cap₁, hrest₂⟩ := Runs.head_expr (ih₂ (by simp_all) hmem)
+      exact .expr (.starConcat cap₁ .starEpsilon) (by simpa using hrest₂)
+    have hLoop (hmem : (p₂, gs') ∈ tLoop.extractCapturesAux p gs) :
+      Runs (.expr (.star greedy e) :: as) p gs p₂ gs' := by
+      have hinner := ih₁ hprem hmem
+      obtain ⟨p₁, groups₁, cap₁, hinner'⟩ := Runs.head_expr hinner
+      obtain ⟨_, hinner''⟩ := Runs.head_check hinner'
+      obtain ⟨p₂, groups₂, cap₂, hrest₂⟩ := Runs.head_expr hinner''
+      exact .expr (.starConcat cap₁ cap₂) (by simpa using hrest₂)
+    grind [extractCapturesAux]
+  | @progress as p p' gs t hp h ih =>
+    have hrest := ih (wfActions_check.mp wf) hmem
+    exact .check hp hrest
+
+theorem mem_extractCapturesAux_of_captures {p₁ p₂ p₃ : Pos s}
+  {groups : CaptureGroups s} {e : Expr} {as : List (Action s)}
+  {gs gs' : GroupMap s} {t : Tree}
+  (v : t.IsValid (.expr e :: as) p₁ gs) (wf : WfActions (.expr e :: as)) (c : e.Captures p₁ p₂ groups)
+  (r : Runs as p₂ (gs.addCaptures groups) p₃ gs') :
+  (p₃, gs') ∈ t.extractCapturesAux p₁ gs :=
+  mem_extractCapturesAux_of_runs v wf (.expr c r)
+
+theorem captures_of_mem_extractCapturesAux {p₁ p₃ : Pos s}
+  {gs gs' : GroupMap s} {e : Expr} {as : List (Action s)} {t : Tree}
+  (v : t.IsValid (.expr e :: as) p₁ gs)
+  (hmem : (p₃, gs') ∈ t.extractCapturesAux p₁ gs)
+  (hdisj : WfActions (.expr e :: as)) :
+  ∃ p₂ groups, e.Captures p₁ p₂ groups ∧ Runs as p₂ (gs.addCaptures groups) p₃ gs' :=
+  Runs.head_expr (runs_of_mem_extractCapturesAux v hdisj hmem)
+
+public theorem mem_extractCaptures_of_captures {p p' : Pos s} {groups : CaptureGroups s} {e : Expr}
+  {t : Tree}
+  (v : t.IsValid [.expr e] p .empty)
+  (disj : e.Disjoint) (hns : ¬e.NullableStar) (c : e.Captures p p' groups) :
+  (p', GroupMap.addCaptures GroupMap.empty groups) ∈ t.extractCaptures p :=
+  mem_extractCapturesAux_of_captures v ⟨disj, hns, trivial⟩ c Runs.nil
+
+public theorem captures_of_mem_extractCaptures {p p' : Pos s} {gs : GroupMap s} {e : Expr}
+  {t : Tree}
+  (v : t.IsValid [.expr e] p .empty) (hmem : (p', gs) ∈ t.extractCaptures p)
+  (disj : e.Disjoint) (hns : ¬e.NullableStar) :
+  ∃ groups, e.Captures p p' groups ∧ gs = GroupMap.addCaptures GroupMap.empty groups := by
+  have hdisj : WfActions (s := s) [.expr e] := by
+    exact ⟨disj, hns, trivial⟩
+  obtain ⟨p₂, groups, cap, r⟩ :=
+    captures_of_mem_extractCapturesAux v (by simpa [extractCaptures] using hmem) hdisj
+  cases r with
+  | nil =>
+    exact ⟨groups, cap, rfl⟩
+
+end Regex.Data.Expr.Semantics.Tree

--- a/correctness/RegexCorrectness/NFA/Semantics/Tree/Basic.lean
+++ b/correctness/RegexCorrectness/NFA/Semantics/Tree/Basic.lean
@@ -47,6 +47,7 @@ inductive IsValid {s : String} (nfa : NFA) :
       (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .epsilon j) {next : Tree}
       (h : IsValid nfa j p us (insert (i, p) visIn) next visOut) :
       IsValid nfa i p us visIn (.epsilon next) visOut
+  -- NOTE: `visOut` refers to the visited set after both branches fail
   | split {i j₁ j₂ p us visIn visMid visOut}
       (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .split j₁ j₂) {t₁ t₂ : Tree}
       (h₁ : IsValid nfa j₁ p us (insert (i, p) visIn) t₁ visMid)

--- a/correctness/RegexCorrectness/NFA/Semantics/Tree/Basic.lean
+++ b/correctness/RegexCorrectness/NFA/Semantics/Tree/Basic.lean
@@ -1,179 +1,128 @@
 module
 
 public import Regex.NFA.Basic
-public import RegexCorrectness.Data.Expr.Semantics.GroupMap
 public import Mathlib.Data.Finset.Basic
 public import Mathlib.Data.Finset.Insert
 
 open String (Pos)
-open Regex.Data.Expr (GroupMap)
+open Regex (NFA)
 
 public section
 
 namespace Regex.NFA
--- This does not work since `split` needs to use the `visited` set after the left branch is processed for the right branch. (really?)
-inductive Tree (s : String) (nfa : NFA) : Nat → Pos s → List (Nat × Pos s) → Finset (Nat × Pos s) → Type where
-  | visited {i p us visited} (lt : i < nfa.size) (hm : (i, p) ∈ visited) : Tree s nfa i p us visited
-  | fail {i p us visited} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .fail) :
-    Tree s nfa i p us visited
-  | done {i p us visited} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .done) :
-    Tree s nfa i p us visited
-  | epsilon {i j p us visited} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .epsilon j)
-    (h : Tree s nfa j p us (insert (i, p) visited)) :
-    Tree s nfa i p us visited
-  | split {i j₁ j₂ p us visited} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .split j₁ j₂)
-    (h₁ : Tree s nfa j₁ p us (insert (i, p) visited)) (h₂ : Tree s nfa j₂ p us (insert (i, p) visited)) :
-    Tree s nfa i p us visited
-  | save {i j p us visited offset} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .save offset j)
-    (h : Tree s nfa j p (us ++ [(offset, p)]) (insert (i, p) visited)) :
-    Tree s nfa i p us visited
-  | anchor {i j p us visited a} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .anchor a j)
-    (ha : a.test p) (h : Tree s nfa j p us (insert (i, p) visited)) :
-    Tree s nfa i p us visited
-  | anchorFail {i j p us visited a} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .anchor a j)
-    (ha : ¬a.test p) :
-    Tree s nfa i p us visited
-  | char {i j p us visited c} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .char c j)
-    (ne : p ≠ s.endPos) (hc : p.get ne = c) (h : Tree s nfa j (p.next ne) us (insert (i, p) visited)) :
-    Tree s nfa i p us visited
-  | charFail {i j p us visited c} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .char c j)
-    (hc : p = s.endPos ∨ ∃ ne : p ≠ s.endPos, p.get ne ≠ c) :
-    Tree s nfa i p us visited
-  | sparse {i j p us visited cs} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .sparse cs j)
-    (ne : p ≠ s.endPos) (hc : p.get ne ∈ cs) (h : Tree s nfa j (p.next ne) us (insert (i, p) visited)) :
-    Tree s nfa i p us visited
-  | sparseFail {i j p us visited cs} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .sparse cs j)
-    (hc : p = s.endPos ∨ ∃ ne : p ≠ s.endPos, p.get ne ∉ cs) :
-    Tree s nfa i p us visited
+
+/--
+Shape of an NFA backtracking trace (no indices: states, positions, captures, visited sets
+live in `IsValid`).
+-/
+inductive Tree where
+  | visited
+  | fail
+  | done
+  | epsilon (next : Tree)
+  | split (t₁ t₂ : Tree)
+  | save (offset : Nat) (next : Tree)
+  | anchorPass (next : Tree)
+  | anchorFail
+  | char (next : Tree)
+  | charFail
+  | sparse (next : Tree)
+  | sparseFail
+deriving DecidableEq, Inhabited
 
 namespace Tree
 
+inductive IsValid {s : String} (nfa : NFA) :
+    Nat → Pos s → List (Nat × Pos s) → Finset (Nat × Pos s) → Tree → Finset (Nat × Pos s) → Prop where
+  | visited {i p us visIn visOut}
+      (lt : i < nfa.size) (hm : (i, p) ∈ visIn) (hvis : visOut = visIn) :
+      IsValid nfa i p us visIn .visited visOut
+  | fail {i p us visIn visOut}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .fail) (hvis : visOut = insert (i, p) visIn) :
+      IsValid nfa i p us visIn .fail visOut
+  | done {i p us visIn visOut}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .done) (hvis : visOut = insert (i, p) visIn) :
+      IsValid nfa i p us visIn .done visOut
+  | epsilon {i j p us visIn visOut}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .epsilon j) {next : Tree}
+      (h : IsValid nfa j p us (insert (i, p) visIn) next visOut) :
+      IsValid nfa i p us visIn (.epsilon next) visOut
+  | split {i j₁ j₂ p us visIn visMid visOut}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .split j₁ j₂) {t₁ t₂ : Tree}
+      (h₁ : IsValid nfa j₁ p us (insert (i, p) visIn) t₁ visMid)
+      (h₂ : IsValid nfa j₂ p us visMid t₂ visOut) :
+      IsValid nfa i p us visIn (.split t₁ t₂) visOut
+  | save {i j p us visIn visOut offset}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .save offset j) {next : Tree}
+      (h : IsValid nfa j p (us ++ [(offset, p)]) (insert (i, p) visIn) next visOut) :
+      IsValid nfa i p us visIn (.save offset next) visOut
+  | anchor {i j p us visIn visOut a}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .anchor a j) (ha : a.test p) {next : Tree}
+      (h : IsValid nfa j p us (insert (i, p) visIn) next visOut) :
+      IsValid nfa i p us visIn (.anchorPass next) visOut
+  | anchorFail {i j p us visIn visOut a}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .anchor a j) (ha : ¬a.test p)
+      (hvis : visOut = insert (i, p) visIn) :
+      IsValid nfa i p us visIn .anchorFail visOut
+  | char {i j p us visIn visOut c}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .char c j) (ne : p ≠ s.endPos) (hc : p.get ne = c)
+      {next : Tree}
+      (h : IsValid nfa j (p.next ne) us (insert (i, p) visIn) next visOut) :
+      IsValid nfa i p us visIn (.char next) visOut
+  | charFail {i j p us visIn visOut c}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .char c j)
+      (hc : p = s.endPos ∨ ∃ ne : p ≠ s.endPos, p.get ne ≠ c) (hvis : visOut = insert (i, p) visIn) :
+      IsValid nfa i p us visIn .charFail visOut
+  | sparse {i j p us visIn visOut cs}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .sparse cs j) (ne : p ≠ s.endPos)
+      (hc : p.get ne ∈ cs) {next : Tree}
+      (h : IsValid nfa j (p.next ne) us (insert (i, p) visIn) next visOut) :
+      IsValid nfa i p us visIn (.sparse next) visOut
+  | sparseFail {i j p us visIn visOut cs}
+      (lt : i < nfa.size) (hm : (i, p) ∉ visIn) (hn : nfa[i] = .sparse cs j)
+      (hc : p = s.endPos ∨ ∃ ne : p ≠ s.endPos, p.get ne ∉ cs) (hvis : visOut = insert (i, p) visIn) :
+      IsValid nfa i p us visIn .sparseFail visOut
+
+theorem deterministic_isValid {s : String} {nfa : NFA} {i : Nat} {p : Pos s} {us : List (Nat × Pos s)}
+    {visIn : Finset (Nat × Pos s)} {t₁ t₂ : Tree} {visOut₁ visOut₂ : Finset (Nat × Pos s)}
+    (h₁ : IsValid nfa i p us visIn t₁ visOut₁) (h₂ : IsValid nfa i p us visIn t₂ visOut₂) :
+    t₁ = t₂ ∧ visOut₁ = visOut₂ := by
+  induction h₁ generalizing t₂ visOut₂ <;> cases h₂ <;> grind [IsValid]
+
+theorem tree_eq_of_isValid {s : String} {nfa : NFA} {i : Nat} {p : Pos s} {us : List (Nat × Pos s)}
+    {visIn : Finset (Nat × Pos s)} {t₁ t₂ : Tree} {visOut₁ visOut₂ : Finset (Nat × Pos s)}
+    (h₁ : IsValid nfa i p us visIn t₁ visOut₁) (h₂ : IsValid nfa i p us visIn t₂ visOut₂) :
+    t₁ = t₂ :=
+  (deterministic_isValid h₁ h₂).1
+
+theorem visOut_eq_of_isValid {s : String} {nfa : NFA} {i : Nat} {p : Pos s} {us : List (Nat × Pos s)}
+    {visIn : Finset (Nat × Pos s)} {t₁ t₂ : Tree} {visOut₁ visOut₂ : Finset (Nat × Pos s)}
+    (h₁ : IsValid nfa i p us visIn t₁ visOut₁) (h₂ : IsValid nfa i p us visIn t₂ visOut₂) :
+    visOut₁ = visOut₂ :=
+  (deterministic_isValid h₁ h₂).2
+
+theorem lt {s : String} {nfa : NFA} {i : Nat} {p : Pos s} {us : List (Nat × Pos s)}
+    {visIn visOut : Finset (Nat × Pos s)} {t : Tree} (h : IsValid nfa i p us visIn t visOut) :
+    i < nfa.size := by
+  cases h <;> assumption
+
 @[expose, grind =]
-def firstMatch {s nfa i p us visited} (t : Tree s nfa i p us visited) : Option (Pos s × List (Nat × Pos s)) :=
+def firstMatch {s : String} (p : Pos s) (us : List (Nat × Pos s)) (t : Tree) : Option (Pos s × List (Nat × Pos s)) :=
   match t with
-  | .visited _ _ => .none
-  | .fail _ _ _ => .none
-  | .done _ _ _ => .some (p, us)
-  | .epsilon _ _ _ h => h.firstMatch
-  | .split _ _ _ h₁ h₂ => h₁.firstMatch <|> h₂.firstMatch
-  | .save _ _ _ h => h.firstMatch
-  | .anchor _ _ _ _ h => h.firstMatch
-  | .anchorFail _ _ _ _ => .none
-  | .char _ _ _ _ _ h => h.firstMatch
-  | .charFail _ _ _ _ => .none
-  | .sparse _ _ _ _ _ h => h.firstMatch
-  | .sparseFail _ _ _ _ => .none
-
-private def cast {s nfa i i' p p' us us' visited visited'}
-  (eqi : i = i') (eqp : p = p') (equs : us = us') (eqv : visited = visited')
-  (t : Tree s nfa i p us visited) :
-  Tree s nfa i' p' us' visited' :=
-  match t with
-  | .visited lt hm =>
-    .visited (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
-  | .fail lt hm hn =>
-    .fail (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm) (by simpa [eqi] using hn)
-  | .done lt hm hn =>
-    .done (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm) (by simpa [eqi] using hn)
-  | .epsilon lt hm hn t =>
-    .epsilon (eqi ▸ lt)
-              (eqi ▸ eqp ▸ eqv ▸ hm)
-              (by simpa [eqi] using hn)
-              (t.cast rfl eqp equs (by simp [eqi, eqp, eqv]))
-  | .split lt hm hn t₁ t₂ =>
-    .split (eqi ▸ lt)
-            (eqi ▸ eqp ▸ eqv ▸ hm)
-            (by simpa [eqi] using hn)
-            (t₁.cast rfl eqp equs (by simp [eqi, eqp, eqv]))
-            (t₂.cast rfl eqp equs (by simp [eqi, eqp, eqv]))
-  | .save lt hm hn t =>
-    .save (eqi ▸ lt)
-          (eqi ▸ eqp ▸ eqv ▸ hm)
-          (by simpa [eqi] using hn)
-          (t.cast rfl eqp (by simp [eqp, equs]) (by simp [eqi, eqp, eqv]))
-  | .anchor lt hm hn ha t =>
-    .anchor (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm) (by simpa [eqi] using hn)
-            (by simpa [eqp] using ha)
-            (t.cast rfl eqp equs (by simp [eqi, eqp, eqv]))
-  | .anchorFail lt hm hn ha =>
-    .anchorFail (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
-                (by simpa [eqi] using hn)
-                (by simpa [eqp] using ha)
-  | .char lt hm hn ne hc t =>
-    .char (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
-          (by simpa [eqi] using hn)
-          (by simpa [eqp] using ne)
-          (by simpa [eqp] using hc)
-          (t.cast rfl (by simp [eqp]) equs (by simp [eqi, eqp, eqv]))
-  | .charFail lt hm hn hc =>
-    .charFail (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
-              (by simpa [eqi] using hn)
-              (by simpa [eqp] using hc)
-  | .sparse lt hm hn ne hc t =>
-    .sparse (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
-            (by simpa [eqi] using hn)
-            (by simpa [eqp] using ne)
-            (by simpa [eqp] using hc)
-            (t.cast rfl (by simp [eqp]) equs (by simp [eqi, eqp, eqv]))
-  | .sparseFail lt hm hn hc =>
-    .sparseFail (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
-                (by simpa [eqi] using hn)
-                (by simpa [eqp] using hc)
-
-private theorem deterministicAux {s nfa i i' p p' us us' visited visited'}
-  (eqi : i = i') (eqp : p = p') (equs : us = us') (eqv : visited = visited')
-  (t : Tree s nfa i p us visited) (t' : Tree s nfa i' p' us' visited') :
-  t.cast eqi eqp equs eqv = t' := by
-  induction t generalizing i' p' us' visited' t' with
-  | @visited i p us visited lt hm => grind only [Tree, Tree.cast]
-  | @fail i p us visited lt hm hn => grind only [Tree, Tree.cast]
-  | @done i p us visited lt hm hn => grind only [Tree, Tree.cast]
-  | @epsilon i j p us visited lt hm hn t ih =>
-    cases t' with
-    | @epsilon i' j' p' us' visited' lt' hm' hn' t' =>
-      grind only [Tree.cast, ih (by grind) eqp equs (by grind) t']
-    | _ => grind only
-  | @split i j₁ j₂ p us visited lt hm hn t₁ t₂ ih₁ ih₂ =>
-    cases t' with
-    | @split i' j₁' j₂' p' us' visited' lt' hm' hn' t₁' t₂' =>
-      grind only [Tree.cast, ih₁ (by grind) eqp equs (by grind) t₁', ih₂ (by grind) eqp equs (by grind) t₂']
-    | _ => grind only
-  | @save i j p us visited offset lt hm hn t ih =>
-    cases t' with
-    | @save i' j' p' us' visited' offset' lt' hm' hn' t' =>
-      grind only [Tree.cast, ih (by grind) eqp (by grind) (by grind) t']
-    | _ => grind only
-  | @anchor i j p us visited a lt hm hn ha t ih =>
-    cases t' with
-    | @anchor i' j' p' us' visited' a' lt' hm' hn' ha' t' =>
-      grind only [Tree.cast, ih (by grind) eqp (by grind) (by grind) t']
-    | _ => grind only
-  | anchorFail => grind only [Tree, Tree.cast]
-  | @char i j p us visited c lt hm hn ne hc t ih =>
-    cases t' with
-    | @char i' j' p' us' visited' c' lt' hm' hn' ne' hc' t' =>
-      grind only [Tree.cast, ih (by grind) (by grind) equs (by grind) t']
-    | _ => grind only
-  | charFail  => grind only [Tree, Tree.cast]
-  | @sparse i j p us visited cs lt hm hn ne hc t ih =>
-    cases t' with
-    | @sparse i' j' p' us' visited' cs' lt' hm' hn' ne' hc' t' =>
-      grind only [Tree.cast, ih (by grind) (by grind) equs (by grind) t']
-    | _ => grind only
-  | sparseFail => grind only [Tree, Tree.cast]
-
-private theorem cast_rfl {s nfa i p us visited} (t : Tree s nfa i p us visited) :
-  t.cast rfl rfl rfl rfl = t := by
-  induction t <;> grind [Tree.cast]
-
-theorem deterministic {s nfa i p us visited} (t₁ t₂ : Tree s nfa i p us visited) :
-  t₁ = t₂ :=
-  cast_rfl t₁ ▸ deterministicAux rfl rfl rfl rfl t₁ t₂
-
-instance {s nfa i p us visited} : Subsingleton (Tree s nfa i p us visited) := ⟨deterministic⟩
-
-theorem lt {s nfa i p us visited} (t : Tree s nfa i p us visited) : i < nfa.size := by
-  induction t <;> assumption
+  | .visited => .none
+  | .fail => .none
+  | .done => .some (p, us)
+  | .epsilon next => firstMatch p us next
+  | .split t₁ t₂ => firstMatch p us t₁ <|> firstMatch p us t₂
+  | .save offset next => firstMatch p (us ++ [(offset, p)]) next
+  | .anchorPass next => firstMatch p us next
+  | .anchorFail => .none
+  | .char next =>
+    if h : p ≠ s.endPos then firstMatch (p.next h) us next else .none
+  | .charFail => .none
+  | .sparse next =>
+    if h : p ≠ s.endPos then firstMatch (p.next h) us next else .none
+  | .sparseFail => .none
 
 end Tree
 

--- a/correctness/RegexCorrectness/NFA/Semantics/Tree/Basic.lean
+++ b/correctness/RegexCorrectness/NFA/Semantics/Tree/Basic.lean
@@ -1,0 +1,182 @@
+module
+
+public import Regex.NFA.Basic
+public import RegexCorrectness.Data.Expr.Semantics.GroupMap
+public import Mathlib.Data.Finset.Basic
+public import Mathlib.Data.Finset.Insert
+
+open String (Pos)
+open Regex.Data.Expr (GroupMap)
+
+public section
+
+namespace Regex.NFA
+-- This does not work since `split` needs to use the `visited` set after the left branch is processed for the right branch. (really?)
+inductive Tree (s : String) (nfa : NFA) : Nat → Pos s → List (Nat × Pos s) → Finset (Nat × Pos s) → Type where
+  | visited {i p us visited} (lt : i < nfa.size) (hm : (i, p) ∈ visited) : Tree s nfa i p us visited
+  | fail {i p us visited} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .fail) :
+    Tree s nfa i p us visited
+  | done {i p us visited} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .done) :
+    Tree s nfa i p us visited
+  | epsilon {i j p us visited} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .epsilon j)
+    (h : Tree s nfa j p us (insert (i, p) visited)) :
+    Tree s nfa i p us visited
+  | split {i j₁ j₂ p us visited} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .split j₁ j₂)
+    (h₁ : Tree s nfa j₁ p us (insert (i, p) visited)) (h₂ : Tree s nfa j₂ p us (insert (i, p) visited)) :
+    Tree s nfa i p us visited
+  | save {i j p us visited offset} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .save offset j)
+    (h : Tree s nfa j p (us ++ [(offset, p)]) (insert (i, p) visited)) :
+    Tree s nfa i p us visited
+  | anchor {i j p us visited a} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .anchor a j)
+    (ha : a.test p) (h : Tree s nfa j p us (insert (i, p) visited)) :
+    Tree s nfa i p us visited
+  | anchorFail {i j p us visited a} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .anchor a j)
+    (ha : ¬a.test p) :
+    Tree s nfa i p us visited
+  | char {i j p us visited c} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .char c j)
+    (ne : p ≠ s.endPos) (hc : p.get ne = c) (h : Tree s nfa j (p.next ne) us (insert (i, p) visited)) :
+    Tree s nfa i p us visited
+  | charFail {i j p us visited c} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .char c j)
+    (hc : p = s.endPos ∨ ∃ ne : p ≠ s.endPos, p.get ne ≠ c) :
+    Tree s nfa i p us visited
+  | sparse {i j p us visited cs} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .sparse cs j)
+    (ne : p ≠ s.endPos) (hc : p.get ne ∈ cs) (h : Tree s nfa j (p.next ne) us (insert (i, p) visited)) :
+    Tree s nfa i p us visited
+  | sparseFail {i j p us visited cs} (lt : i < nfa.size) (hm : (i, p) ∉ visited) (hn : nfa[i] = .sparse cs j)
+    (hc : p = s.endPos ∨ ∃ ne : p ≠ s.endPos, p.get ne ∉ cs) :
+    Tree s nfa i p us visited
+
+namespace Tree
+
+@[expose, grind =]
+def firstMatch {s nfa i p us visited} (t : Tree s nfa i p us visited) : Option (Pos s × List (Nat × Pos s)) :=
+  match t with
+  | .visited _ _ => .none
+  | .fail _ _ _ => .none
+  | .done _ _ _ => .some (p, us)
+  | .epsilon _ _ _ h => h.firstMatch
+  | .split _ _ _ h₁ h₂ => h₁.firstMatch <|> h₂.firstMatch
+  | .save _ _ _ h => h.firstMatch
+  | .anchor _ _ _ _ h => h.firstMatch
+  | .anchorFail _ _ _ _ => .none
+  | .char _ _ _ _ _ h => h.firstMatch
+  | .charFail _ _ _ _ => .none
+  | .sparse _ _ _ _ _ h => h.firstMatch
+  | .sparseFail _ _ _ _ => .none
+
+private def cast {s nfa i i' p p' us us' visited visited'}
+  (eqi : i = i') (eqp : p = p') (equs : us = us') (eqv : visited = visited')
+  (t : Tree s nfa i p us visited) :
+  Tree s nfa i' p' us' visited' :=
+  match t with
+  | .visited lt hm =>
+    .visited (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
+  | .fail lt hm hn =>
+    .fail (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm) (by simpa [eqi] using hn)
+  | .done lt hm hn =>
+    .done (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm) (by simpa [eqi] using hn)
+  | .epsilon lt hm hn t =>
+    .epsilon (eqi ▸ lt)
+              (eqi ▸ eqp ▸ eqv ▸ hm)
+              (by simpa [eqi] using hn)
+              (t.cast rfl eqp equs (by simp [eqi, eqp, eqv]))
+  | .split lt hm hn t₁ t₂ =>
+    .split (eqi ▸ lt)
+            (eqi ▸ eqp ▸ eqv ▸ hm)
+            (by simpa [eqi] using hn)
+            (t₁.cast rfl eqp equs (by simp [eqi, eqp, eqv]))
+            (t₂.cast rfl eqp equs (by simp [eqi, eqp, eqv]))
+  | .save lt hm hn t =>
+    .save (eqi ▸ lt)
+          (eqi ▸ eqp ▸ eqv ▸ hm)
+          (by simpa [eqi] using hn)
+          (t.cast rfl eqp (by simp [eqp, equs]) (by simp [eqi, eqp, eqv]))
+  | .anchor lt hm hn ha t =>
+    .anchor (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm) (by simpa [eqi] using hn)
+            (by simpa [eqp] using ha)
+            (t.cast rfl eqp equs (by simp [eqi, eqp, eqv]))
+  | .anchorFail lt hm hn ha =>
+    .anchorFail (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
+                (by simpa [eqi] using hn)
+                (by simpa [eqp] using ha)
+  | .char lt hm hn ne hc t =>
+    .char (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
+          (by simpa [eqi] using hn)
+          (by simpa [eqp] using ne)
+          (by simpa [eqp] using hc)
+          (t.cast rfl (by simp [eqp]) equs (by simp [eqi, eqp, eqv]))
+  | .charFail lt hm hn hc =>
+    .charFail (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
+              (by simpa [eqi] using hn)
+              (by simpa [eqp] using hc)
+  | .sparse lt hm hn ne hc t =>
+    .sparse (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
+            (by simpa [eqi] using hn)
+            (by simpa [eqp] using ne)
+            (by simpa [eqp] using hc)
+            (t.cast rfl (by simp [eqp]) equs (by simp [eqi, eqp, eqv]))
+  | .sparseFail lt hm hn hc =>
+    .sparseFail (eqi ▸ lt) (eqi ▸ eqp ▸ eqv ▸ hm)
+                (by simpa [eqi] using hn)
+                (by simpa [eqp] using hc)
+
+private theorem deterministicAux {s nfa i i' p p' us us' visited visited'}
+  (eqi : i = i') (eqp : p = p') (equs : us = us') (eqv : visited = visited')
+  (t : Tree s nfa i p us visited) (t' : Tree s nfa i' p' us' visited') :
+  t.cast eqi eqp equs eqv = t' := by
+  induction t generalizing i' p' us' visited' t' with
+  | @visited i p us visited lt hm => grind only [Tree, Tree.cast]
+  | @fail i p us visited lt hm hn => grind only [Tree, Tree.cast]
+  | @done i p us visited lt hm hn => grind only [Tree, Tree.cast]
+  | @epsilon i j p us visited lt hm hn t ih =>
+    cases t' with
+    | @epsilon i' j' p' us' visited' lt' hm' hn' t' =>
+      grind only [Tree.cast, ih (by grind) eqp equs (by grind) t']
+    | _ => grind only
+  | @split i j₁ j₂ p us visited lt hm hn t₁ t₂ ih₁ ih₂ =>
+    cases t' with
+    | @split i' j₁' j₂' p' us' visited' lt' hm' hn' t₁' t₂' =>
+      grind only [Tree.cast, ih₁ (by grind) eqp equs (by grind) t₁', ih₂ (by grind) eqp equs (by grind) t₂']
+    | _ => grind only
+  | @save i j p us visited offset lt hm hn t ih =>
+    cases t' with
+    | @save i' j' p' us' visited' offset' lt' hm' hn' t' =>
+      grind only [Tree.cast, ih (by grind) eqp (by grind) (by grind) t']
+    | _ => grind only
+  | @anchor i j p us visited a lt hm hn ha t ih =>
+    cases t' with
+    | @anchor i' j' p' us' visited' a' lt' hm' hn' ha' t' =>
+      grind only [Tree.cast, ih (by grind) eqp (by grind) (by grind) t']
+    | _ => grind only
+  | anchorFail => grind only [Tree, Tree.cast]
+  | @char i j p us visited c lt hm hn ne hc t ih =>
+    cases t' with
+    | @char i' j' p' us' visited' c' lt' hm' hn' ne' hc' t' =>
+      grind only [Tree.cast, ih (by grind) (by grind) equs (by grind) t']
+    | _ => grind only
+  | charFail  => grind only [Tree, Tree.cast]
+  | @sparse i j p us visited cs lt hm hn ne hc t ih =>
+    cases t' with
+    | @sparse i' j' p' us' visited' cs' lt' hm' hn' ne' hc' t' =>
+      grind only [Tree.cast, ih (by grind) (by grind) equs (by grind) t']
+    | _ => grind only
+  | sparseFail => grind only [Tree, Tree.cast]
+
+private theorem cast_rfl {s nfa i p us visited} (t : Tree s nfa i p us visited) :
+  t.cast rfl rfl rfl rfl = t := by
+  induction t <;> grind [Tree.cast]
+
+theorem deterministic {s nfa i p us visited} (t₁ t₂ : Tree s nfa i p us visited) :
+  t₁ = t₂ :=
+  cast_rfl t₁ ▸ deterministicAux rfl rfl rfl rfl t₁ t₂
+
+instance {s nfa i p us visited} : Subsingleton (Tree s nfa i p us visited) := ⟨deterministic⟩
+
+theorem lt {s nfa i p us visited} (t : Tree s nfa i p us visited) : i < nfa.size := by
+  induction t <;> assumption
+
+end Tree
+
+end Regex.NFA
+
+end

--- a/regex/Regex/Data/String.lean
+++ b/regex/Regex/Data/String.lean
@@ -141,6 +141,38 @@ theorem lt_next_iff_lt_or_eq {s} {pos pos' : Pos s} (h' : pos' ≠ s.endPos) :
   pos < pos'.next h' ↔ pos < pos' ∨ pos = pos' :=
   lt_next_iff.trans le_iff_lt_or_eq
 
+-- Useful for proving that `Pos s` is Fintype.
+private def allPositionsAux (s : String) (pos : Pos s) : List (Pos s) :=
+  if h : pos = s.endPos then
+    [pos]
+  else
+    pos :: allPositionsAux s (pos.next h)
+termination_by pos
+
+def allPositions (s : String) : List (Pos s) := allPositionsAux s s.startPos
+
+theorem lt_iff_next_le {s : String} {pos pos' : Pos s} (ne : pos ≠ s.endPos) : pos < pos' ↔ pos.next ne ≤ pos' := by
+  induction pos' using Pos.posRevInduction with
+  | endPos => grind only [le_endPos, lt_of_le_of_ne]
+  | next pos' h ih => grind only [le_next_iff, lt_next_iff, next_inj, next_le_of_lt,
+    next.congr_simp, le_iff_lt_or_eq, lt_of_le_of_ne]
+
+private theorem mem_allPositionsAux_iff_le {s : String} {pos pos' : Pos s} : pos' ∈ allPositionsAux s pos ↔ pos ≤ pos' := by
+  fun_induction allPositionsAux
+  next => grind only [le_iff_lt_or_eq, = List.mem_cons, ne_endPos_of_lt, ← List.not_mem_nil]
+  next pos ne ih => grind only [le_iff_lt_or_eq, le_trans, = List.mem_cons, lt_iff_next_le]
+
+theorem mem_allPositions (s : String) (pos : Pos s) : pos ∈ allPositions s :=
+  mem_allPositionsAux_iff_le.mpr (Pos.startPos_le pos)
+
+private theorem allPositionsAux_nodup {s : String} {pos : Pos s} : (allPositionsAux s pos).Nodup := by
+  fun_induction allPositionsAux
+  next => grind
+  next pos ne ih => grind [Pos.lt_next, mem_allPositionsAux_iff_le]
+
+theorem nodup_allPositions (s : String) : (allPositions s).Nodup :=
+  allPositionsAux_nodup
+
 end String.Pos
 
 namespace String


### PR DESCRIPTION
This PR adds an alternative tree-based semantics for a regex with a progress checking to prevent infinite loops when the regex has `e*` where `e` is nullable.

Specifically, the semantics treats `e*` as `e<check_p>e* | e | ε`, where `<check_p>` asserts that the position (after matching first `e`) must be greater than the starting position of `e*`. This semantics is in line with https://github.com/pandaman64/lean-regex/pull/162.